### PR TITLE
chore(build): add test module to lazy layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 - Dependabot grouping of minor/patch updates; Gradle parallel + build cache.
 - Java 25 project baseline with Gradle Wrapper 9.5.1.
 - `core` module with the first direct `component {}` text builder slice.
+- `test` module with the first public Kotest component matchers for dogfooding DSL output.
 - Explicit `AdventureDsl` registry slots for MiniMessage tag providers, themes, animation drivers, and platform
   adapters.
 - Regression tests covering the new component builder, registry behavior, and absence of SPI wiring in production

--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ See [`docs/DESIGN.md`](docs/DESIGN.md) for the full design and the [Roadmap](doc
 
 ## ✅ Implemented So Far
 
-The first `core` slice exposes a plain component builder and explicit startup registry:
+The current build enables the first two lazy modules:
+
+- `kotventure-core` — the plain component builder and explicit startup registry
+- `kotventure-test` — Kotest component matchers consumed test-scoped by library modules
+
+The first `core` slice exposes a plain component builder:
 
 ```kotlin
 val message = component {
@@ -69,6 +74,9 @@ val message = component {
 
 `AdventureDsl` stores typed extension registrations for MiniMessage tag providers, theme providers, animation drivers,
 and the active platform adapter. Registration is explicit at startup; there is no classpath scanning.
+
+`kotventure-test` starts the testing toolkit with structural component matchers such as `shouldContainText`,
+`shouldHaveColor`, and `shouldHaveChildCount`.
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ group = 'io.github.lmliam.kotventure'
 version = '0.0.1-SNAPSHOT'
 
 subprojects {
+    apply plugin: 'java-library'
     apply plugin: 'org.jetbrains.kotlin.jvm'
     apply plugin: 'io.kotest'
     apply plugin: 'com.diffplug.spotless'

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -175,6 +175,8 @@ conveniences:
 ## 10. Build, publishing & versioning
 
 - **Build:** Gradle multi‑module, Kotlin 2.2, JVM toolchain 25, ktlint + Spotless, Kotest.
+- **Java compatibility:** Kotventure builds with the Java 25 toolchain. Adventure 5.x sets a Java 21+ consumer floor, so
+  modules should keep public APIs wrapper/composition based rather than extending Adventure component/style interfaces.
 - **Publishing:** **JitPack** during pre‑alpha/alpha (zero infra, builds from git tags) → **Maven Central** (
   `io.github.lmliam` namespace, GPG‑signed) at beta/`1.0`.
 - **BOM** module so consumers align versions across the many artifacts.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -176,7 +176,7 @@ conveniences:
 
 - **Build:** Gradle multi‑module, Kotlin 2.2, JVM toolchain 25, ktlint + Spotless, Kotest.
 - **Java compatibility:** Kotventure builds with the Java 25 toolchain. Adventure 5.x sets a Java 21+ consumer floor, so
-  modules should keep public APIs wrapper/composition based rather than extending Adventure component/style interfaces.
+  modules should keep public APIs wrapper/composition-based rather than extending Adventure component/style interfaces.
 - **Publishing:** **JitPack** during pre‑alpha/alpha (zero infra, builds from git tags) → **Maven Central** (
   `io.github.lmliam` namespace, GPG‑signed) at beta/`1.0`.
 - **BOM** module so consumers align versions across the many artifacts.

--- a/docs/PRE-ALPHA-PLAN.md
+++ b/docs/PRE-ALPHA-PLAN.md
@@ -32,6 +32,7 @@
 ## 📦 Deliverables
 
 - `kotventure-core-0.0.x-PRE-ALPHA.jar`
+- `kotventure-test-0.0.x-PRE-ALPHA.jar`
 - `kotventure-0.0.x-PRE-ALPHA.jar`
 - Minimal `README.md` with example:
   ```kotlin

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,16 +6,14 @@ configurations {
     testImplementation.extendsFrom annotationProcessor
 }
 
-def dep = [
+ext.kotventureDependencies = [
         "adventure-api"         : "net.kyori:adventure-api:${versions.'adventure-api'}",
         "kotest-assertions-core": "io.kotest:kotest-assertions-core:${versions.kotest}",
         "kotest-runner-junit5"  : "io.kotest:kotest-runner-junit5:${versions.kotest}"
 ]
 
 dependencies {
-    implementation dep."adventure-api"
-
-    testImplementation dep."kotest-assertions-core"
-    testImplementation dep."kotest-runner-junit5"
+    testImplementation kotventureDependencies."kotest-assertions-core"
+    testImplementation kotventureDependencies."kotest-runner-junit5"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
@@ -1,5 +1,10 @@
 package io.github.lmliam.kotventure.core.text
 
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveStyle
 import io.kotest.core.spec.style.StringSpec
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.Style

--- a/modules/test/build.gradle
+++ b/modules/test/build.gradle
@@ -1,10 +1,9 @@
-description = 'Core DSL primitives and explicit extension registry.'
+description = 'Kotest matchers and testing utilities for Kotventure components.'
 
 // Shared root subproject conventions apply Kotlin/JVM, JDK 25, explicitApi(),
 // dependencies, lint, and test configuration for every module.
 
 dependencies {
-    api kotventureDependencies."adventure-api"
-
-    testImplementation project(':test')
+    api project(':core')
+    api kotventureDependencies."kotest-assertions-core"
 }

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -1,4 +1,4 @@
-package io.github.lmliam.kotventure.core.text
+package io.github.lmliam.kotventure.test.text
 
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
@@ -8,27 +8,42 @@ import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 
-internal infix fun Component.shouldContainText(expected: String): Component =
+/**
+ * Asserts that this text component has exactly [expected] as its plain text content.
+ */
+public infix fun Component.shouldContainText(expected: String): Component =
     apply {
         this should haveTextContent(expected)
     }
 
-internal infix fun Component.shouldHaveColor(expected: TextColor): Component =
+/**
+ * Asserts that this component has [expected] as its root color.
+ */
+public infix fun Component.shouldHaveColor(expected: TextColor): Component =
     apply {
         this should haveColor(expected)
     }
 
-internal infix fun Component.shouldHaveStyle(expected: Style): Component =
+/**
+ * Asserts that this component has exactly [expected] as its root Adventure style.
+ */
+public infix fun Component.shouldHaveStyle(expected: Style): Component =
     apply {
         this should haveStyle(expected)
     }
 
-internal infix fun Component.shouldHaveChildCount(expected: Int): Component =
+/**
+ * Asserts that this component has exactly [expected] direct child components.
+ */
+public infix fun Component.shouldHaveChildCount(expected: Int): Component =
     apply {
         this should haveChildCount(expected)
     }
 
-internal fun Component.childAt(index: Int): Component {
+/**
+ * Returns this component's child at [index], or fails with a readable test error.
+ */
+public fun Component.childAt(index: Int): Component {
     val children = children()
     check(index in children.indices) {
         "Expected child at index <$index>, but component has <${children.size}> children."

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -9,7 +9,7 @@ import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 
 /**
- * Asserts that this text component has exactly [expected] as its plain text content.
+ * Asserts that this component tree contains [expected] in its text content.
  */
 public infix fun Component.shouldContainText(expected: String): Component =
     apply {
@@ -53,13 +53,25 @@ public fun Component.childAt(index: Int): Component {
 
 private fun haveTextContent(expected: String): Matcher<Component> =
     Matcher { value ->
-        val actual = (value as? TextComponent)?.content()
+        val actual = value.textContent()
         MatcherResult(
-            actual == expected,
-            { "Expected text content <$expected>, but was <$actual>." },
-            { "Expected text content not to be <$expected>." },
+            expected in actual,
+            { "Expected component text to contain <$expected>, but was <$actual>." },
+            { "Expected component text not to contain <$expected>." },
         )
     }
+
+private fun Component.textContent(): String =
+    buildString {
+        appendText(this@textContent)
+    }
+
+private fun StringBuilder.appendText(component: Component) {
+    if (component is TextComponent) {
+        append(component.content())
+    }
+    component.children().forEach { child -> appendText(child) }
+}
 
 private fun haveColor(expected: TextColor): Matcher<Component> =
     Matcher { value ->

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -1,0 +1,58 @@
+package io.github.lmliam.kotventure.test.text
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.Style
+import net.kyori.adventure.text.format.TextDecoration
+
+class ComponentMatchersTest :
+    StringSpec(
+        {
+            "matches text content on Adventure text components" {
+                Component.text("Hello") shouldContainText "Hello"
+            }
+
+            "reports text mismatch with expected and actual content" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("Hello") shouldContainText "Bye"
+                    }
+
+                failure.message shouldContain "Expected text content <Bye>, but was <Hello>."
+            }
+
+            "matches root component colors" {
+                Component.text("Warning", NamedTextColor.RED) shouldHaveColor NamedTextColor.RED
+            }
+
+            "matches complete Adventure styles" {
+                val style = Style.style(NamedTextColor.GOLD, TextDecoration.BOLD)
+
+                Component.text("Title").style(style) shouldHaveStyle style
+            }
+
+            "matches child count and retrieves children by index" {
+                val component =
+                    Component
+                        .text()
+                        .content("Hello ")
+                        .append(Component.text("world"))
+                        .build()
+
+                component shouldHaveChildCount 1
+                component.childAt(0) shouldContainText "world"
+            }
+
+            "reports missing child indexes clearly" {
+                val failure =
+                    shouldThrow<IllegalStateException> {
+                        Component.text("Hello").childAt(0)
+                    }
+
+                failure.message shouldContain "Expected child at index <0>, but component has <0> children."
+            }
+        },
+    )

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -15,13 +15,24 @@ class ComponentMatchersTest :
                 Component.text("Hello") shouldContainText "Hello"
             }
 
+            "matches text content nested in child components" {
+                val component =
+                    Component
+                        .text()
+                        .content("Hello ")
+                        .append(Component.text("world"))
+                        .build()
+
+                component shouldContainText "world"
+            }
+
             "reports text mismatch with expected and actual content" {
                 val failure =
                     shouldThrow<AssertionError> {
                         Component.text("Hello") shouldContainText "Bye"
                     }
 
-                failure.message shouldContain "Expected text content <Bye>, but was <Hello>."
+                failure.message shouldContain "Expected component text to contain <Bye>, but was <Hello>."
             }
 
             "matches root component colors" {

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,8 +12,8 @@ plugins {
 rootProject.name = 'Kotventure'
 
 // Modules are introduced lazily, one phase at a time (see docs/DESIGN.md §4 and issue #7).
-// Each module lives under modules/<name>; re-enable entries as the modules land, e.g.:
-//   include 'core'
-//   project(':core').projectDir = file('modules/core')
+// Each module lives under modules/<name>; enable only modules that have landed.
 include 'core'
+include 'test'
 project(':core').projectDir = file('modules/core')
+project(':test').projectDir = file('modules/test')


### PR DESCRIPTION
## Summary

Establish the second lazy module in the Phase 0 layout by enabling `test`, publishing the first component matcher helpers from `io.github.lmliam.kotventure.test.text`, and wiring `core` tests to consume that module test-scoped.

## Related Issues

Closes #7

## Scope

- [x] Build tooling
- [ ] GitHub Actions workflow
- [ ] Dependency bump
- [x] Repo config (labels, CODEOWNERS, etc.)

## Notes for Reviewers

- `java-library` is now part of the shared subproject convention so `core` can expose Adventure through `api` and `test` can expose matcher dependencies intentionally.
- `settings.gradle` enables only `core` and `test`; no future modules are scaffolded.

## Checklist

- [x] Linked related issue
- [x] Verified build/test pass after change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a test module providing public component matchers for assertions (text content, color, style, child count); text-match now checks substring containment.

* **Documentation**
  * Updated README, changelog, design notes, and pre-alpha plan to document the two-module layout, Java compatibility, and test artifact.

* **Tests**
  * Added comprehensive tests validating matchers and error messages.

* **Chores**
  * Enabled the test module in the build and adjusted dependency/subproject configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->