### PR TITLE
chore(build): adopt Adventure 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,4 +31,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 - Regression tests covering the new component builder, registry behavior, and absence of SPI wiring in production
   sources.
 
+### Changed
+
+- Upgraded the Adventure dependency baseline from 4.24.0 to 5.1.1 and aligned enabled modules through the Adventure BOM.
+
 [Unreleased]: https://github.com/LMLiam/Kotventure/commits/master

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ and the active platform adapter. Registration is explicit at startup; there is n
 Pre-alpha snapshots will be published via [JitPack](https://jitpack.io). Coordinates and a worked example land with the
 first tagged slice (`0.0.1`).
 
+## 🧰 Build & Compatibility
+
+Kotventure builds and tests with the Java 25 Gradle toolchain. Its Adventure baseline is 5.1.1, which sets a Java 21+
+minimum for consumers using Kotventure artifacts.
+
 ---
 
 ## 🤝 Contributing

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -31,7 +31,7 @@ access.
 
 | Project                            | What it is                                                                  | Gap we exploit                                                              |
 |------------------------------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| Adventure's retired Kotlin extras  | Official, minimal builder DSL + operators                                   | Removed in Adventure 5.0; no MiniMessage tooling, testing, or platform UX   |
+| Adventure's retired Kotlin extras  | Former official Kotlin builders/operators                                   | Removed in Adventure 5.0; no MiniMessage tooling, testing, or platform UX   |
 | Pluto‑Studio/`adventure-kt`        | The serious rival — component DSL, `mini()`, styles, titles, multi‑platform | No typed/validated MiniMessage, no testing toolkit, no codegen/ANSI tooling |
 | HoshiKurama component DSL          | `buildComponent {}`                                                         | Stale (2021), narrow                                                        |
 | KSpigot / KPaper                   | Broad Kotlin server libs that *include* a chat DSL                          | Not Adventure‑focused; tied to broader frameworks                           |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,6 +1,6 @@
 # Kotventure — Design
 
-> **Status:** Living design document · **Stage:** Pre‑Alpha (`0.0.x`) · **Last updated:** 2026‑06‑07
+> **Status:** Living design document · **Stage:** Pre‑Alpha (`0.0.x`) · **Last updated:** 2026‑06‑08
 >
 > This document captures the agreed architecture, scope, and roadmap. It is the source of truth that the GitHub Epic and
 > its sub‑issues are derived from. Syntax shown is **illustrative** and will be refined during implementation.
@@ -31,7 +31,7 @@ access.
 
 | Project                            | What it is                                                                  | Gap we exploit                                                              |
 |------------------------------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| `net.kyori:adventure-extra-kotlin` | Official, minimal builder DSL + operators                                   | Tiny surface; no MiniMessage tooling, testing, or platform UX               |
+| Adventure's retired Kotlin extras  | Official, minimal builder DSL + operators                                   | Removed in Adventure 5.0; no MiniMessage tooling, testing, or platform UX   |
 | Pluto‑Studio/`adventure-kt`        | The serious rival — component DSL, `mini()`, styles, titles, multi‑platform | No typed/validated MiniMessage, no testing toolkit, no codegen/ANSI tooling |
 | HoshiKurama component DSL          | `buildComponent {}`                                                         | Stale (2021), narrow                                                        |
 | KSpigot / KPaper                   | Broad Kotlin server libs that *include* a chat DSL                          | Not Adventure‑focused; tied to broader frameworks                           |
@@ -174,9 +174,12 @@ conveniences:
 
 ## 10. Build, publishing & versioning
 
-- **Build:** Gradle multi‑module, Kotlin 2.2, JVM toolchain 25, ktlint + Spotless, Kotest.
+- **Build:** Gradle multi‑module, Kotlin 2.4, JVM toolchain 25, ktlint + Spotless, Kotest.
 - **Java compatibility:** Kotventure builds with the Java 25 toolchain. Adventure 5.x sets a Java 21+ consumer floor, so
   modules should keep public APIs wrapper/composition-based rather than extending Adventure component/style interfaces.
+- **Adventure baseline:** Kotventure aligns Adventure artifacts through the Adventure 5.1.1 BOM. The core module wraps
+  `adventure-api`; feature modules add serializer, MiniMessage, platform, or tooling artifacts only when their roadmap
+  slice lands.
 - **Publishing:** **JitPack** during pre‑alpha/alpha (zero infra, builds from git tags) → **Maven Central** (
   `io.github.lmliam` namespace, GPG‑signed) at beta/`1.0`.
 - **BOM** module so consumers align versions across the many artifacts.
@@ -185,6 +188,23 @@ conveniences:
 
 > **Note:** adding/updating GitHub Actions workflows requires a token with the `workflow` scope (
 `gh auth refresh -s workflow`). CI‑on‑master is tracked as its own issue.
+
+### 10.1 Adventure 5.x compatibility
+
+Adventure 5.1.1 is the compatibility baseline for all new roadmap slices. Treat PaperMC's official
+[Adventure 4.x → 5.x migration guide](https://docs.papermc.io/adventure/migration/adventure-4.x/) as the checklist
+when adding dependencies or public DSL types.
+
+- Keep the project build on Java 25 while documenting Adventure's Java 21+ consumer minimum in release and setup docs.
+- Use composition/delegation around Adventure builders and value types; do not extend sealed Adventure component,
+  style, renderer, or event implementation types.
+- Prefer current Adventure 5.x serializer, translation-store, renderer, component-builder, and click-event APIs in each
+  feature slice. Removed Adventure 4.x modules or classes must not appear as dependencies or planned public API.
+- Account for JSpecify nullness, SLF4J 2.0 expectations, and Adventure module metadata whenever they affect Kotlin
+  source compatibility or consumer setup.
+
+Roadmap issues checked for 5.x notes: serializers (#30), click events (#21), renderer/object-component handling
+(#71/#81), translation (#16/#48), NBT components (#18), and component builders (#8/#15).
 
 ## 11. Phased roadmap
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,11 +12,14 @@ configurations {
 
 ext.kotventureDependencies = [
         "adventure-api"         : catalog.findLibrary('adventure-api').get(),
+        "adventure-bom"         : catalog.findLibrary('adventure-bom').get(),
         "kotest-assertions-core": catalog.findLibrary('kotest-assertions-core').get(),
         "kotest-runner-junit5"  : catalog.findLibrary('kotest-runner-junit5').get()
 ]
 
 dependencies {
+    api platform(kotventureDependencies."adventure-bom")
+
     testImplementation kotventureDependencies."kotest-assertions-core"
     testImplementation kotventureDependencies."kotest-runner-junit5"
     testRuntimeOnly catalog.findLibrary('junit-platform-launcher').get()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-adventureApi = "4.24.0"
+adventureApi = "5.1.1"
 gradleKtlintPlugin = "14.2.0"
 kotest = "6.0.1"
 kotestPlugin = "6.1.11"
@@ -9,6 +9,7 @@ spotlessKtlint = "1.5.0"
 
 [libraries]
 adventure-api = { module = "net.kyori:adventure-api", version.ref = "adventureApi" }
+adventure-bom = { module = "net.kyori:adventure-bom", version.ref = "adventureApi" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }


### PR DESCRIPTION
## Summary

- Bumps the Adventure baseline to 5.1.1 and adds the Adventure BOM to the centralized dependency map.
- Documents the Java 25 project toolchain, Adventure 5.x Java 21+ consumer minimum, and migration checklist link.
- Records the roadmap audit for serializer, click-event, renderer/object-component, translation, NBT, and component-builder 5.x notes.

## Related Issues

Closes #80

## Scope

- [x] Build tooling
- [ ] GitHub Actions workflow
- [x] Dependency bump
- [ ] Repo config (labels, CODEOWNERS, etc.)

## Notes for Reviewers

Dependency insight confirms `net.kyori:adventure-api:5.1.1` and `net.kyori:adventure-bom:5.1.1` on both `:core` and `:test` compile classpaths. No production source changes were needed; the existing component builder already wraps `Component.text()` via composition.

## Checklist

- [x] Linked related issue (if applicable)
- [x] Verified build/test pass after change

## Testing

- `./gradlew ktlintFormat`
- `./gradlew ktlintCheck spotlessCheck`
- `./gradlew build`
- `./gradlew test`
- `./gradlew :core:dependencyInsight --dependency net.kyori:adventure-api --configuration compileClasspath`
- `./gradlew :core:dependencyInsight --dependency net.kyori:adventure-bom --configuration compileClasspath`
- `./gradlew :test:dependencyInsight --dependency net.kyori:adventure-api --configuration compileClasspath`
- `./gradlew :test:dependencyInsight --dependency net.kyori:adventure-bom --configuration compileClasspath`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Build & Compatibility section describing the Java toolchain and Adventure baseline requirements.
  * Expanded design docs with Adventure 5.x compatibility guidance, checklist, and updated Kotlin/Java notes.
  * Updated versioning/publishing guidance to reflect new baseline.

* **Chores**
  * Upgraded Adventure dependency baseline from 4.24.0 to 5.1.1 and aligned dependency management via the Adventure BOM.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->