### PR TITLE
test(test): cover component matcher failure output

### DIFF
--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -66,6 +66,15 @@ class ComponentMatchersTest :
                     "Expected component color <${NamedTextColor.BLUE}>, but was <${NamedTextColor.RED}>."
             }
 
+            "reports missing root color with expected and actual colors" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("Warning") shouldHaveColor NamedTextColor.RED
+                    }
+
+                failure.message shouldContain "Expected component color <${NamedTextColor.RED}>, but was <null>."
+            }
+
             "matches complete Adventure styles" {
                 val style = Style.style(NamedTextColor.GOLD, TextDecoration.BOLD)
 

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -68,7 +68,7 @@ class ComponentMatchersTest :
                     }
                 val expectedMessage =
                     "Expected component color <${NamedTextColor.BLUE}>, " +
-                        "but was <${NamedTextColor.RED}>."
+                            "but was <${NamedTextColor.RED}>."
 
                 failure.message shouldContain expectedMessage
             }

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -35,8 +35,35 @@ class ComponentMatchersTest :
                 failure.message shouldContain "Expected component text to contain <Bye>, but was <Hello>."
             }
 
+            "reports nested text mismatch with the complete extracted content" {
+                val component =
+                    Component
+                        .text()
+                        .content("Hello ")
+                        .append(Component.text("world"))
+                        .append(Component.text("!"))
+                        .build()
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        component shouldContainText "missing"
+                    }
+
+                failure.message shouldContain "Expected component text to contain <missing>, but was <Hello world!>."
+            }
+
             "matches root component colors" {
                 Component.text("Warning", NamedTextColor.RED) shouldHaveColor NamedTextColor.RED
+            }
+
+            "reports color mismatch with expected and actual colors" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("Warning", NamedTextColor.RED) shouldHaveColor NamedTextColor.BLUE
+                    }
+
+                failure.message shouldContain
+                    "Expected component color <${NamedTextColor.BLUE}>, but was <${NamedTextColor.RED}>."
             }
 
             "matches complete Adventure styles" {

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -31,8 +31,9 @@ class ComponentMatchersTest :
                     shouldThrow<AssertionError> {
                         Component.text("Hello") shouldContainText "Bye"
                     }
+                val expectedMessage = "Expected component text to contain <Bye>, but was <Hello>."
 
-                failure.message shouldContain "Expected component text to contain <Bye>, but was <Hello>."
+                failure.message shouldContain expectedMessage
             }
 
             "reports nested text mismatch with the complete extracted content" {
@@ -48,8 +49,10 @@ class ComponentMatchersTest :
                     shouldThrow<AssertionError> {
                         component shouldContainText "missing"
                     }
+                val expectedMessage =
+                    "Expected component text to contain <missing>, but was <Hello world!>."
 
-                failure.message shouldContain "Expected component text to contain <missing>, but was <Hello world!>."
+                failure.message shouldContain expectedMessage
             }
 
             "matches root component colors" {
@@ -57,13 +60,17 @@ class ComponentMatchersTest :
             }
 
             "reports color mismatch with expected and actual colors" {
+                val component = Component.text("Warning", NamedTextColor.RED)
+
                 val failure =
                     shouldThrow<AssertionError> {
-                        Component.text("Warning", NamedTextColor.RED) shouldHaveColor NamedTextColor.BLUE
+                        component shouldHaveColor NamedTextColor.BLUE
                     }
+                val expectedMessage =
+                    "Expected component color <${NamedTextColor.BLUE}>, " +
+                        "but was <${NamedTextColor.RED}>."
 
-                failure.message shouldContain
-                    "Expected component color <${NamedTextColor.BLUE}>, but was <${NamedTextColor.RED}>."
+                failure.message shouldContain expectedMessage
             }
 
             "reports missing root color with expected and actual colors" {
@@ -71,8 +78,10 @@ class ComponentMatchersTest :
                     shouldThrow<AssertionError> {
                         Component.text("Warning") shouldHaveColor NamedTextColor.RED
                     }
+                val expectedMessage =
+                    "Expected component color <${NamedTextColor.RED}>, but was <null>."
 
-                failure.message shouldContain "Expected component color <${NamedTextColor.RED}>, but was <null>."
+                failure.message shouldContain expectedMessage
             }
 
             "matches complete Adventure styles" {
@@ -98,8 +107,9 @@ class ComponentMatchersTest :
                     shouldThrow<IllegalStateException> {
                         Component.text("Hello").childAt(0)
                     }
+                val expectedMessage = "Expected child at index <0>, but component has <0> children."
 
-                failure.message shouldContain "Expected child at index <0>, but component has <0> children."
+                failure.message shouldContain expectedMessage
             }
         },
     )


### PR DESCRIPTION
## Summary

- Adds missing failure-message coverage for `shouldHaveColor` so expected and actual colors are locked down.
- Adds nested `shouldContainText` failure coverage to verify the matcher reports the complete extracted component text.
- Completes the verification gap for the already-landed `kotventure-test` matcher slice.

## Related issues

Closes #9

## Type of change

- [ ] feat - new capability
- [ ] fix - bug fix
- [ ] refactor - internal, no behaviour change
- [ ] docs
- [x] test
- [ ] chore / build / ci

## Testing

- `./gradlew :test:test`
- `./gradlew ktlintFormat`
- `./gradlew build`
- `./gradlew ktlintCheck spotlessCheck`

## Checklist

- [x] Title and commit subjects follow `verb(area): something`
- [x] Linked the related issue
- [x] Tests added/updated (dogfood the `test` matchers where applicable)
- [x] `./gradlew ktlintCheck spotlessCheck` clean; `explicitApi()` satisfied with KDoc on public API
- [x] Updated `docs/` and `CHANGELOG.md` if user-facing (existing README/CHANGELOG already document the matcher module; this PR is test coverage only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test that verifies missing-text failures report the fully extracted nested content in their failure messages.
  * Clarified several failure-message assertions by computing expected messages locally, improving test maintainability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->