### PR TITLE
feat(core): add text decoration dsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 - Text component decoration support through `decorate(...)`, `bold()`, `italic()`, `underlined()`, `strikethrough()`,
   and `obfuscated()`.
 - `test` module with the first public Kotest component matchers for dogfooding DSL output.
-- `shouldHaveDecoration` matcher for root component decoration assertions.
+- `shouldHaveDecoration` and `shouldNotHaveDecoration` matchers for root component decoration assertions.
 - Explicit `AdventureDsl` registry slots for MiniMessage tag providers, themes, animation drivers, and platform
   adapters.
 - Regression tests covering the new component builder, registry behavior, and absence of SPI wiring in production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 - Dependabot grouping of minor/patch updates; Gradle parallel + build cache.
 - Java 25 project baseline with Gradle Wrapper 9.5.1.
 - `core` module with the first direct `component {}` text builder slice.
+- Text component decoration support through `decorate(...)`, `bold()`, `italic()`, `underlined()`, `strikethrough()`,
+  and `obfuscated()`.
 - `test` module with the first public Kotest component matchers for dogfooding DSL output.
+- `shouldHaveDecoration` matcher for root component decoration assertions.
 - Explicit `AdventureDsl` registry slots for MiniMessage tag providers, themes, animation drivers, and platform
   adapters.
 - Regression tests covering the new component builder, registry behavior, and absence of SPI wiring in production

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ val message = component {
 and the active platform adapter. Registration is explicit at startup; there is no classpath scanning.
 
 `kotventure-test` starts the testing toolkit with structural component matchers such as `shouldContainText`,
-`shouldHaveColor`, `shouldHaveDecoration`, and `shouldHaveChildCount`.
+`shouldHaveColor`, `shouldHaveDecoration`, `shouldNotHaveDecoration`, and `shouldHaveChildCount`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,13 @@ The first `core` slice exposes a plain component builder:
 
 ```kotlin
 val message = component {
-    content("Hello ")
-    color(NamedTextColor.AQUA)
+    text("Hello ") {
+        color(NamedTextColor.AQUA)
+        bold()
+    }
     text {
         content("world")
+        decorate(TextDecoration.UNDERLINED)
     }
 }
 ```
@@ -75,7 +78,7 @@ val message = component {
 and the active platform adapter. Registration is explicit at startup; there is no classpath scanning.
 
 `kotventure-test` starts the testing toolkit with structural component matchers such as `shouldContainText`,
-`shouldHaveColor`, and `shouldHaveChildCount`.
+`shouldHaveColor`, `shouldHaveDecoration`, and `shouldHaveChildCount`.
 
 ---
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,6 +13,7 @@ configurations {
 ext.kotventureDependencies = [
         "adventure-api"         : catalog.findLibrary('adventure-api').get(),
         "adventure-bom"         : catalog.findLibrary('adventure-bom').get(),
+        "kctfork-core"          : catalog.findLibrary('kctfork-core').get(),
         "kotest-assertions-core": catalog.findLibrary('kotest-assertions-core').get(),
         "kotest-runner-junit5"  : catalog.findLibrary('kotest-runner-junit5').get()
 ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 adventureApi = "5.1.1"
 gradleKtlintPlugin = "14.2.0"
+kctfork = "0.12.1"
 kotest = "6.0.1"
 kotestPlugin = "6.1.11"
 kotlin = "2.4.0"
@@ -11,6 +12,7 @@ spotlessKtlint = "1.5.0"
 adventure-api = { module = "net.kyori:adventure-api", version.ref = "adventureApi" }
 adventure-bom = { module = "net.kyori:adventure-bom", version.ref = "adventureApi" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+kctfork-core = { module = "dev.zacsweers.kctfork:core", version.ref = "kctfork" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 

--- a/modules/core/build.gradle
+++ b/modules/core/build.gradle
@@ -7,4 +7,5 @@ dependencies {
     api kotventureDependencies."adventure-api"
 
     testImplementation project(':test')
+    testImplementation kotventureDependencies."kctfork-core"
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/dsl/KotventureDslMarker.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/dsl/KotventureDslMarker.kt
@@ -4,4 +4,4 @@ package io.github.lmliam.kotventure.core.dsl
  * Marks Kotventure DSL scopes so nested blocks cannot accidentally call outer receivers.
  */
 @DslMarker
-internal annotation class KotventureDslMarker
+public annotation class KotventureDslMarker

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextComponentBuilder.kt
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
 
 internal class TextComponentBuilder : TextScope {
     private val builder: TextComponent.Builder = Component.text()
@@ -18,6 +19,40 @@ internal class TextComponentBuilder : TextScope {
 
     override fun style(style: Style) {
         builder.style(style)
+    }
+
+    override fun decorate(decoration: TextDecoration) {
+        builder.decoration(decoration, true)
+    }
+
+    override fun bold() {
+        decorate(TextDecoration.BOLD)
+    }
+
+    override fun italic() {
+        decorate(TextDecoration.ITALIC)
+    }
+
+    override fun underlined() {
+        decorate(TextDecoration.UNDERLINED)
+    }
+
+    override fun strikethrough() {
+        decorate(TextDecoration.STRIKETHROUGH)
+    }
+
+    override fun obfuscated() {
+        decorate(TextDecoration.OBFUSCATED)
+    }
+
+    override fun text(
+        value: String,
+        init: TextScope.() -> Unit,
+    ) {
+        text {
+            content(value)
+            init()
+        }
     }
 
     override fun text(init: TextScope.() -> Unit) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextScope.kt
@@ -3,6 +3,7 @@ package io.github.lmliam.kotventure.core.text
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
 
 /**
  * Scope for configuring a text component and its nested child components.
@@ -23,6 +24,44 @@ public interface TextScope {
      * Applies a complete Adventure style to the component being configured.
      */
     public fun style(style: Style)
+
+    /**
+     * Enables [decoration] on the component being configured.
+     */
+    public fun decorate(decoration: TextDecoration)
+
+    /**
+     * Enables bold text on the component being configured.
+     */
+    public fun bold()
+
+    /**
+     * Enables italic text on the component being configured.
+     */
+    public fun italic()
+
+    /**
+     * Enables underlined text on the component being configured.
+     */
+    public fun underlined()
+
+    /**
+     * Enables strikethrough text on the component being configured.
+     */
+    public fun strikethrough()
+
+    /**
+     * Enables obfuscated text on the component being configured.
+     */
+    public fun obfuscated()
+
+    /**
+     * Appends a nested text child with [value] as its initial content and configured by [init].
+     */
+    public fun text(
+        value: String,
+        init: TextScope.() -> Unit = {},
+    )
 
     /**
      * Appends a nested text child configured by [init].

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
@@ -84,6 +84,16 @@ class ComponentDslTest :
                 component shouldHaveStyle style
             }
 
+            "applies a decoration to the root text component" {
+                val component =
+                    component {
+                        content("Marked root")
+                        decorate(TextDecoration.BOLD)
+                    }
+
+                component shouldHaveDecoration TextDecoration.BOLD
+            }
+
             "applies a decoration through the generic decoration hook" {
                 val component =
                     component {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
@@ -9,6 +9,7 @@ import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
 import io.github.lmliam.kotventure.test.text.shouldHaveStyle
+import io.github.lmliam.kotventure.test.text.shouldNotHaveDecoration
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -135,6 +136,7 @@ class ComponentDslTest :
 
                 component shouldHaveChildCount 2
                 component.childAt(0) shouldContainText "plain"
+                component.childAt(0) shouldNotHaveDecoration TextDecoration.BOLD
                 component.childAt(1) shouldContainText "loud"
                 component.childAt(1) shouldHaveDecoration TextDecoration.BOLD
             }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
@@ -1,15 +1,23 @@
 package io.github.lmliam.kotventure.core.text
 
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
 import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
 import io.github.lmliam.kotventure.test.text.shouldHaveStyle
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextDecoration
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
+@OptIn(ExperimentalCompilerApi::class)
 class ComponentDslTest :
     StringSpec(
         {
@@ -51,6 +59,19 @@ class ComponentDslTest :
                 component.childAt(1) shouldContainText "!"
             }
 
+            "appends text children with initial content" {
+                val component =
+                    component {
+                        text("Hello") {
+                            color(NamedTextColor.AQUA)
+                        }
+                    }
+
+                component shouldHaveChildCount 1
+                component.childAt(0) shouldContainText "Hello"
+                component.childAt(0) shouldHaveColor NamedTextColor.AQUA
+            }
+
             "applies a complete Adventure style" {
                 val style = Style.style(NamedTextColor.GOLD, TextDecoration.BOLD)
 
@@ -61,6 +82,120 @@ class ComponentDslTest :
                     }
 
                 component shouldHaveStyle style
+            }
+
+            "applies a decoration through the generic decoration hook" {
+                val component =
+                    component {
+                        text("Marked") {
+                            decorate(TextDecoration.UNDERLINED)
+                        }
+                    }
+
+                component.childAt(0) shouldHaveDecoration TextDecoration.UNDERLINED
+            }
+
+            "applies each named decoration toggle" {
+                val component =
+                    component {
+                        text("Decorated") {
+                            bold()
+                            italic()
+                            underlined()
+                            strikethrough()
+                            obfuscated()
+                        }
+                    }
+
+                component.childAt(0) shouldHaveDecoration TextDecoration.BOLD
+                component.childAt(0) shouldHaveDecoration TextDecoration.ITALIC
+                component.childAt(0) shouldHaveDecoration TextDecoration.UNDERLINED
+                component.childAt(0) shouldHaveDecoration TextDecoration.STRIKETHROUGH
+                component.childAt(0) shouldHaveDecoration TextDecoration.OBFUSCATED
+            }
+
+            "applies decorations independently to nested children" {
+                val component =
+                    component {
+                        text("plain")
+                        text("loud") {
+                            bold()
+                        }
+                    }
+
+                component shouldHaveChildCount 2
+                component.childAt(0) shouldContainText "plain"
+                component.childAt(1) shouldContainText "loud"
+                component.childAt(1) shouldHaveDecoration TextDecoration.BOLD
+            }
+
+            "prevents implicit outer scope access in Kotventure-marked DSL blocks" {
+                val source =
+                    """
+                    import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+                    import io.github.lmliam.kotventure.core.text.component
+
+                    @KotventureDslMarker
+                    class OuterScope {
+                        fun outerOnly() {
+                        }
+                    }
+
+                    fun outer(init: OuterScope.() -> Unit) {
+                        OuterScope().init()
+                    }
+
+                    fun shouldNotCompile() {
+                        outer {
+                            component {
+                                outerOnly()
+                            }
+                        }
+                    }
+                    """.trimIndent()
+
+                val compilation =
+                    KotlinCompilation().apply {
+                        inheritClassPath = true
+                        sources = listOf(SourceFile.kotlin("DslMarkerScopeTest.kt", source))
+                    }
+
+                val result = compilation.compile()
+
+                result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                result.messages shouldContain "implicit receiver"
+            }
+
+            "builds a component tree when nested scopes stay explicit" {
+                var outerWasCalled = false
+
+                @KotventureDslMarker
+                class OuterScope {
+                    fun outerOnly() {
+                        outerWasCalled = true
+                    }
+                }
+
+                fun outer(init: OuterScope.() -> Unit) {
+                    OuterScope().init()
+                }
+
+                lateinit var component: net.kyori.adventure.text.Component
+
+                outer outer@{
+                    component =
+                        component {
+                            text("child") {
+                                bold()
+                            }
+                            this@outer.outerOnly()
+                        }
+                }
+
+                outerWasCalled shouldBe true
+                component shouldHaveChildCount 1
+                component.childAt(0) shouldContainText "child"
+                component.childAt(0) shouldHaveDecoration TextDecoration.BOLD
             }
         },
     )

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -123,7 +123,7 @@ private fun haveDecorationState(
             actual == state,
             {
                 "Expected component decoration <$expected> to be <${state.name}>, " +
-                    "but was <${actual.name}>."
+                        "but was <${actual.name}>."
             },
             { "Expected component decoration <$expected> not to be <${state.name}>." },
         )

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -3,7 +3,6 @@ package io.github.lmliam.kotventure.test.text
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
-import io.kotest.matchers.shouldNot
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.format.Style
@@ -44,11 +43,11 @@ public infix fun Component.shouldHaveDecoration(expected: TextDecoration): Compo
     }
 
 /**
- * Asserts that this component does not have [expected] enabled on its root style.
+ * Asserts that this component has no explicit [expected] state on its root style.
  */
 public infix fun Component.shouldNotHaveDecoration(expected: TextDecoration): Component =
     apply {
-        this shouldNot haveDecoration(expected)
+        this should haveDecorationState(expected, State.NOT_SET)
     }
 
 /**
@@ -112,16 +111,21 @@ private fun haveStyle(expected: Style): Matcher<Component> =
         )
     }
 
-private fun haveDecoration(expected: TextDecoration): Matcher<Component> =
+private fun haveDecoration(expected: TextDecoration): Matcher<Component> = haveDecorationState(expected, State.TRUE)
+
+private fun haveDecorationState(
+    expected: TextDecoration,
+    state: State,
+): Matcher<Component> =
     Matcher { value ->
         val actual = value.style().decoration(expected)
         MatcherResult(
-            actual == State.TRUE,
+            actual == state,
             {
-                "Expected component decoration <$expected> to be <${State.TRUE.name}>, " +
-                        "but was <${actual.name}>."
+                "Expected component decoration <$expected> to be <${state.name}>, " +
+                    "but was <${actual.name}>."
             },
-            { "Expected component decoration <$expected> not to be <${State.TRUE.name}>." },
+            { "Expected component decoration <$expected> not to be <${state.name}>." },
         )
     }
 

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -7,6 +7,8 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.format.TextDecoration.State
 
 /**
  * Asserts that this component tree contains [expected] in its text content.
@@ -30,6 +32,14 @@ public infix fun Component.shouldHaveColor(expected: TextColor): Component =
 public infix fun Component.shouldHaveStyle(expected: Style): Component =
     apply {
         this should haveStyle(expected)
+    }
+
+/**
+ * Asserts that this component has [expected] enabled on its root style.
+ */
+public infix fun Component.shouldHaveDecoration(expected: TextDecoration): Component =
+    apply {
+        this should haveDecoration(expected)
     }
 
 /**
@@ -90,6 +100,19 @@ private fun haveStyle(expected: Style): Matcher<Component> =
             actual == expected,
             { "Expected component style <$expected>, but was <$actual>." },
             { "Expected component style not to be <$expected>." },
+        )
+    }
+
+private fun haveDecoration(expected: TextDecoration): Matcher<Component> =
+    Matcher { value ->
+        val actual = value.style().decoration(expected)
+        MatcherResult(
+            actual == State.TRUE,
+            {
+                "Expected component decoration <$expected> to be <${State.TRUE.name}>, " +
+                    "but was <${actual.name}>."
+            },
+            { "Expected component decoration <$expected> not to be <${State.TRUE.name}>." },
         )
     }
 

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -3,6 +3,7 @@ package io.github.lmliam.kotventure.test.text
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.format.Style
@@ -40,6 +41,14 @@ public infix fun Component.shouldHaveStyle(expected: Style): Component =
 public infix fun Component.shouldHaveDecoration(expected: TextDecoration): Component =
     apply {
         this should haveDecoration(expected)
+    }
+
+/**
+ * Asserts that this component does not have [expected] enabled on its root style.
+ */
+public infix fun Component.shouldNotHaveDecoration(expected: TextDecoration): Component =
+    apply {
+        this shouldNot haveDecoration(expected)
     }
 
 /**
@@ -110,7 +119,7 @@ private fun haveDecoration(expected: TextDecoration): Matcher<Component> =
             actual == State.TRUE,
             {
                 "Expected component decoration <$expected> to be <${State.TRUE.name}>, " +
-                    "but was <${actual.name}>."
+                        "but was <${actual.name}>."
             },
             { "Expected component decoration <$expected> not to be <${State.TRUE.name}>." },
         )

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -120,7 +120,22 @@ class ComponentMatchersTest :
                             .decoration(TextDecoration.BOLD, true) shouldNotHaveDecoration TextDecoration.BOLD
                     }
                 val expectedMessage =
-                    "Expected component decoration <${TextDecoration.BOLD}> not to be <TRUE>."
+                    "Expected component decoration <${TextDecoration.BOLD}> to be <NOT_SET>, " +
+                        "but was <TRUE>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "does not treat explicitly disabled decorations as missing" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component
+                            .text("Title")
+                            .decoration(TextDecoration.BOLD, false) shouldNotHaveDecoration TextDecoration.BOLD
+                    }
+                val expectedMessage =
+                    "Expected component decoration <${TextDecoration.BOLD}> to be <NOT_SET>, " +
+                        "but was <FALSE>."
 
                 failure.message shouldContain expectedMessage
             }

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -96,6 +96,10 @@ class ComponentMatchersTest :
                     .decoration(TextDecoration.BOLD, true) shouldHaveDecoration TextDecoration.BOLD
             }
 
+            "matches missing root decorations" {
+                Component.text("Title") shouldNotHaveDecoration TextDecoration.BOLD
+            }
+
             "reports decoration mismatch with expected and actual state" {
                 val failure =
                     shouldThrow<AssertionError> {
@@ -104,6 +108,19 @@ class ComponentMatchersTest :
                 val expectedMessage =
                     "Expected component decoration <${TextDecoration.BOLD}> to be <TRUE>, " +
                             "but was <NOT_SET>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports unexpected root decorations" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component
+                            .text("Title")
+                            .decoration(TextDecoration.BOLD, true) shouldNotHaveDecoration TextDecoration.BOLD
+                    }
+                val expectedMessage =
+                    "Expected component decoration <${TextDecoration.BOLD}> not to be <TRUE>."
 
                 failure.message shouldContain expectedMessage
             }

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -121,7 +121,7 @@ class ComponentMatchersTest :
                     }
                 val expectedMessage =
                     "Expected component decoration <${TextDecoration.BOLD}> to be <NOT_SET>, " +
-                        "but was <TRUE>."
+                            "but was <TRUE>."
 
                 failure.message shouldContain expectedMessage
             }
@@ -135,7 +135,7 @@ class ComponentMatchersTest :
                     }
                 val expectedMessage =
                     "Expected component decoration <${TextDecoration.BOLD}> to be <NOT_SET>, " +
-                        "but was <FALSE>."
+                            "but was <FALSE>."
 
                 failure.message shouldContain expectedMessage
             }

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -90,6 +90,24 @@ class ComponentMatchersTest :
                 Component.text("Title").style(style) shouldHaveStyle style
             }
 
+            "matches root decorations" {
+                Component
+                    .text("Title")
+                    .decoration(TextDecoration.BOLD, true) shouldHaveDecoration TextDecoration.BOLD
+            }
+
+            "reports decoration mismatch with expected and actual state" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("Title") shouldHaveDecoration TextDecoration.BOLD
+                    }
+                val expectedMessage =
+                    "Expected component decoration <${TextDecoration.BOLD}> to be <TRUE>, " +
+                            "but was <NOT_SET>."
+
+                failure.message shouldContain expectedMessage
+            }
+
             "matches child count and retrieves children by index" {
                 val component =
                     Component


### PR DESCRIPTION
## Summary

Adds the first decoration-capable text component slice for `kotventure-core` and the matching test assertion in `kotventure-test`.

## Related Issues

Closes #8

## DSL Impact

`TextScope` now supports `text("...") { ... }`, generic `decorate(TextDecoration.X)`, and named toggles: `bold()`, `italic()`, `underlined()`, `strikethrough()`, and `obfuscated()`. The DSL marker is public so downstream compile-time checks can verify Kotventure-marked scopes.

## Rationale

This completes the first shippable text component builder surface with real Adventure `TextComponent.Builder` decorations, ordered nested children, and matcher dogfooding for component assertions.

## Testing

- Red step: `./gradlew :core:test :test:test` failed on missing `text(String)`, decoration DSL methods, and `shouldHaveDecoration` before implementation.
- Green/local gates: `./gradlew ktlintFormat build ktlintCheck spotlessCheck`.
- Added `ComponentDslTest` coverage for `text("...")`, decoration toggles, nested child ordering, and compile-fail `@DslMarker` behavior through kctfork.
- Added `ComponentMatchersTest` coverage for `shouldHaveDecoration` pass/fail output.

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run through the component DSL test coverage and full Gradle build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text decoration support added (bold, italic, underlined, strikethrough, obfuscated) and nested text DSL allowing initial content with nested styling.
  * Added `shouldHaveDecoration` matcher for asserting component decorations.

* **Documentation**
  * Updated examples to show the more fluent, nested component DSL and decoration usage.

* **Tests**
  * Added DSL scoping validation and coverage for decoration application and the new matcher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->