### PR TITLE
feat(core): add serializer extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 - `core` module with the first direct `component {}` text builder slice.
 - Text component decoration support through `decorate(...)`, `bold()`, `italic()`, `underlined()`, `strikethrough()`,
   and `obfuscated()`.
+- `serializer` module with `Component.toMiniMessage()` and `Component.toPlainText()` wrappers around Adventure's
+  MiniMessage and plain text serializers.
 - `test` module with the first public Kotest component matchers for dogfooding DSL output.
 - `shouldHaveDecoration` and `shouldNotHaveDecoration` matchers for root component decoration assertions.
 - Explicit `AdventureDsl` registry slots for MiniMessage tag providers, themes, animation drivers, and platform

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ This project aims to:
 
 | Module                          | Purpose                                                                          |
 |---------------------------------|----------------------------------------------------------------------------------|
-| `core`                          | Component / style / colour DSL, themes, audience-send DSL, serializer extensions |
+| `core`                          | Component / style / colour DSL, themes, audience-send DSL                        |
+| `serializer`                    | Optional Adventure serializer extension functions                                |
 | `minimessage`                   | Typed MiniMessage templates, validation, MiniMessage ⇄ DSL converter             |
 | `i18n`                          | Translation registry + per-player locale DSL                                     |
 | `test`                          | Kotest/JUnit component matchers + snapshot testing                               |
@@ -54,9 +55,11 @@ See [`docs/DESIGN.md`](docs/DESIGN.md) for the full design and the [Roadmap](doc
 
 ## ✅ Implemented So Far
 
-The current build enables the first two lazy modules:
+The current build enables the first lazy modules:
 
 - `kotventure-core` — the plain component builder and explicit startup registry
+- `kotventure-serializer` — `Component.toMiniMessage()` and `Component.toPlainText()` wrappers around Adventure
+  serializers
 - `kotventure-test` — Kotest component matchers consumed test-scoped by library modules
 
 The first `core` slice exposes a plain component builder:
@@ -76,6 +79,14 @@ val message = component {
 
 `AdventureDsl` stores typed extension registrations for MiniMessage tag providers, theme providers, animation drivers,
 and the active platform adapter. Registration is explicit at startup; there is no classpath scanning.
+
+Serializer helpers live in `kotventure-serializer` so `kotventure-core` can stay limited to `adventure-api` while
+callers opt into concrete Adventure serializers:
+
+```kotlin
+val mini = message.toMiniMessage()
+val plain = message.toPlainText()
+```
 
 `kotventure-test` starts the testing toolkit with structural component matchers such as `shouldContainText`,
 `shouldHaveColor`, `shouldHaveDecoration`, `shouldNotHaveDecoration`, and `shouldHaveChildCount`.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -56,7 +56,8 @@ behaviour, and **KSP** for compile‑time codegen. The previous `ServiceLoader`/
 
 | Module                | Depends on                             | Purpose                                                                                                                               |
 |-----------------------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `core`                | `adventure-api`                        | Component/style/colour/gradient DSL, serializer extensions, theme engine, the registry, audience‑send DSL, animation **abstractions** |
+| `core`                | `adventure-api`                        | Component/style/colour/gradient DSL, theme engine, the registry, audience‑send DSL, animation **abstractions**                         |
+| `serializer`          | `adventure-api`, concrete serializers  | Optional `Component` serializer extensions such as MiniMessage and plain text                                                          |
 | `minimessage`         | `core`, `adventure-text-minimessage`   | Typed tag/placeholder DSL, typed templates, validation, MiniMessage ⇄ DSL converter                                                   |
 | `i18n`                | `core`, `minimessage`                  | Translation registry + per‑player locale DSL                                                                                          |
 | `test`                | `core` (test‑scoped for consumers)     | Kotest/JUnit matchers + snapshot testing                                                                                              |
@@ -132,6 +133,8 @@ component shouldHaveColor AQUA
 component shouldContainText "world"
 component.shouldMatchSnapshot()
 println(component.toAnsi())
+println(component.toMiniMessage())
+println(component.toPlainText())
 ```
 
 ## 6. MiniMessage strategy
@@ -239,7 +242,7 @@ with its own tests — to keep changes small and incremental.
 | ANSI terminal preview             | 3                   |
 | Coroutine integration             | 2                   |
 | Gradle build plugin               | 3                   |
-| Serializer extensions             | 0 (seed) → 1 (full) |
+| Serializer extensions             | 0 (seed, `serializer`) → 1 (full) |
 
 ## 13. Open questions / future
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,11 +11,13 @@ configurations {
 }
 
 ext.kotventureDependencies = [
-        "adventure-api"         : catalog.findLibrary('adventure-api').get(),
-        "adventure-bom"         : catalog.findLibrary('adventure-bom').get(),
-        "kctfork-core"          : catalog.findLibrary('kctfork-core').get(),
-        "kotest-assertions-core": catalog.findLibrary('kotest-assertions-core').get(),
-        "kotest-runner-junit5"  : catalog.findLibrary('kotest-runner-junit5').get()
+        "adventure-api"                  : catalog.findLibrary('adventure-api').get(),
+        "adventure-bom"                  : catalog.findLibrary('adventure-bom').get(),
+        "adventure-text-minimessage"     : catalog.findLibrary('adventure-text-minimessage').get(),
+        "adventure-text-serializer-plain": catalog.findLibrary('adventure-text-serializer-plain').get(),
+        "kctfork-core"                   : catalog.findLibrary('kctfork-core').get(),
+        "kotest-assertions-core"         : catalog.findLibrary('kotest-assertions-core').get(),
+        "kotest-runner-junit5"           : catalog.findLibrary('kotest-runner-junit5').get()
 ]
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,8 @@ spotlessKtlint = "1.5.0"
 [libraries]
 adventure-api = { module = "net.kyori:adventure-api", version.ref = "adventureApi" }
 adventure-bom = { module = "net.kyori:adventure-bom", version.ref = "adventureApi" }
+adventure-text-minimessage = { module = "net.kyori:adventure-text-minimessage", version.ref = "adventureApi" }
+adventure-text-serializer-plain = { module = "net.kyori:adventure-text-serializer-plain", version.ref = "adventureApi" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 kctfork-core = { module = "dev.zacsweers.kctfork:core", version.ref = "kctfork" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }

--- a/modules/serializer/build.gradle
+++ b/modules/serializer/build.gradle
@@ -1,0 +1,14 @@
+description = 'Adventure component serializer extension functions.'
+
+// Shared root subproject conventions apply Kotlin/JVM, JDK 25, explicitApi(),
+// dependencies, lint, and test configuration for every module.
+
+dependencies {
+    api kotventureDependencies."adventure-api"
+
+    implementation kotventureDependencies."adventure-text-minimessage"
+    implementation kotventureDependencies."adventure-text-serializer-plain"
+
+    testImplementation project(':core')
+    testImplementation project(':test')
+}

--- a/modules/serializer/src/main/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensions.kt
+++ b/modules/serializer/src/main/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensions.kt
@@ -1,0 +1,15 @@
+package io.github.lmliam.kotventure.serializer
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
+
+/**
+ * Serializes this component to MiniMessage markup using Adventure's default MiniMessage serializer.
+ */
+public fun Component.toMiniMessage(): String = MiniMessage.miniMessage().serialize(this)
+
+/**
+ * Serializes this component to plain text using Adventure's default plain text serializer.
+ */
+public fun Component.toPlainText(): String = PlainTextComponentSerializer.plainText().serialize(this)

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -1,0 +1,54 @@
+package io.github.lmliam.kotventure.serializer
+
+import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.minimessage.MiniMessage
+
+class ComponentSerializerExtensionsTest :
+    StringSpec(
+        {
+            "serializes component text to plain text" {
+                val message =
+                    component {
+                        text("Hello ") {
+                            color(NamedTextColor.AQUA)
+                        }
+                        text("world") {
+                            color(NamedTextColor.GOLD)
+                        }
+                    }
+
+                message.toPlainText() shouldBe "Hello world"
+            }
+
+            "serializes unstyled component text to MiniMessage text" {
+                val message =
+                    component {
+                        content("Hello")
+                    }
+
+                message.toMiniMessage() shouldBe "Hello"
+            }
+
+            "round-trips MiniMessage output through Adventure" {
+                val message =
+                    component {
+                        text("Alert") {
+                            color(NamedTextColor.RED)
+                        }
+                    }
+
+                val serialized = message.toMiniMessage()
+                serialized shouldBe "<red>Alert"
+
+                val roundTripped = MiniMessage.miniMessage().deserialize(serialized)
+
+                roundTripped shouldContainText "Alert"
+                roundTripped shouldHaveColor NamedTextColor.RED
+            }
+        },
+    )

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -8,6 +8,9 @@ import io.kotest.matchers.shouldBe
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.minimessage.MiniMessage
 
+/**
+ * Verifies Kotventure's component serializer extensions delegate to Adventure's concrete serializers.
+ */
 class ComponentSerializerExtensionsTest :
     StringSpec(
         {

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,8 @@ rootProject.name = 'Kotventure'
 // Modules are introduced lazily, one phase at a time (see docs/DESIGN.md §4 and issue #7).
 // Each module lives under modules/<name>; enable only modules that have landed.
 include 'core'
+include 'serializer'
 include 'test'
 project(':core').projectDir = file('modules/core')
+project(':serializer').projectDir = file('modules/serializer')
 project(':test').projectDir = file('modules/test')


### PR DESCRIPTION
## Summary

Adds the first idiomatic Adventure serializer extensions: `Component.toMiniMessage()` and `Component.toPlainText()`. The concrete serializers live in a new lazy `serializer` module so `core` remains limited to `adventure-api`.

## Related Issues

Closes #10

## DSL Impact

Downstream Kotlin callers can opt into `kotventure-serializer` and call `message.toMiniMessage()` or `message.toPlainText()` on any Adventure `Component`.

## Rationale

This proves the serializer-extension ergonomics for the Phase 0 slice while preserving the pay-for-what-you-use dependency boundary. MiniMessage and plain-text serializer artifacts are only pulled by the optional serializer module.

## Testing

- Added `ComponentSerializerExtensionsTest` with value checks for plain text and MiniMessage output.
- Dogfooded `kotventure-test` matchers on the MiniMessage round-trip.
- Verified locally: `./gradlew :serializer:test`, `./gradlew build ktlintCheck spotlessCheck`.

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a serializer module exposing Component.toMiniMessage() and Component.toPlainText() for MiniMessage and plain-text conversions.

* **Documentation**
  * Updated README and design docs to document the serializer module and show MiniMessage/plain-text examples.

* **Tests**
  * Added tests verifying MiniMessage/plain-text serialization and round-trip behavior.

* **Chores**
  * Build configuration and dependency catalog updated to include required serialization libraries and register the new module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->