### PR TITLE
ci(build): validate build, tests and formatting in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  checks: write
   contents: read
 
 jobs:
@@ -39,6 +40,17 @@ jobs:
 
       - name: Run build, tests, and formatting checks
         run: ./gradlew build spotlessCheck ktlintCheck --no-daemon
+
+      - name: Publish JUnit test report
+        if: always()
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+        with:
+          check_name: Gradle Test Report
+          report_paths: modules/*/build/test-results/test/TEST-*.xml
+          require_tests: true
+          fail_on_failure: true
+          fail_on_parse_error: true
+          detailed_summary: true
 
       - name: Upload test results and reports
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,3 +39,23 @@ jobs:
 
       - name: Run build, tests, and formatting checks
         run: ./gradlew build spotlessCheck ktlintCheck --no-daemon
+
+      - name: Upload test results and reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gradle-test-results
+          path: |
+            modules/*/build/test-results/test
+            modules/*/build/reports/tests/test
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gradle-build-artifacts
+          path: build/libs
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up JDK 25 (Adventure 5.x requires Java 21+)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build, Test, and Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 25 (Adventure 5.x requires Java 21+)
+        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+
+      - name: Run build, tests, and formatting checks
+        run: ./gradlew build spotlessCheck ktlintCheck --no-daemon


### PR DESCRIPTION
## Summary

Adds a Build GitHub Actions workflow that runs the Gradle build, tests, Spotless checks, and ktlint checks on every pull request and push to `master`. The workflow provisions JDK 25 explicitly, uses Gradle setup caching/wrapper validation, publishes JUnit XML as a GitHub check named `Gradle Test Report`, and uploads Gradle test diagnostics plus built JAR artifacts for debugging.

## Related Issues

Closes #11

## Scope

- [x] Build tooling
- [x] GitHub Actions workflow
- [ ] Dependency bump
- [ ] Repo config (labels, CODEOWNERS, etc.)

## Notes for Reviewers

This follows the CodeRabbit issue plan: Adventure 5.x drift is covered by the standard `./gradlew build` compilation/test path rather than by a separate version assertion. The JDK setup step calls out that Kotventure builds on Java 25 while Adventure 5.x requires Java 21+.

The workflow publishes test XML through a GitHub check and also uploads module test results/reports plus root `build/libs` outputs with a 7-day retention window. Missing artifacts are ignored so early build failures still preserve whatever diagnostics exist.

No docs or sample updates are included because this is CI-only and not a user-facing DSL/API change. No new Kotlin tests are added because the workflow itself runs the existing test suite; local verification used the exact CI Gradle command.

## Checklist

- [x] Linked related issue (if applicable)
- [x] Verified build/test pass after change

Local verification: `./gradlew build spotlessCheck ktlintCheck --no-daemon` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated build pipeline that runs on pushes and pull requests to master.
  * Enforces a single concurrent run per change and applies a job timeout for faster feedback.
  * Performs build verification, code formatting, and lint checks.
  * Collects build and test artifacts on success or failure and retains them for 7 days.
  * Restricts workflow permissions for safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->