### PR TITLE
chore(build): publish snapshots via jitpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
   adapters.
 - Regression tests covering the new component builder, registry behavior, and absence of SPI wiring in production
   sources.
+- JitPack publishing support for the enabled modules, including `maven-publish` wiring, JDK 25 JitPack setup, and
+  build-time publication metadata checks.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ val plain = message.toPlainText()
 
 ## 🚀 Getting It (early access)
 
-Pre-alpha builds are published via [JitPack](https://jitpack.io). Add JitPack after your primary repositories, then
-depend on the modules you need:
+Tagged pre-alpha releases are available through [JitPack](https://jitpack.io). Add JitPack after your primary
+repositories, then depend on the modules you need:
 
 ```kotlin
 repositories {

--- a/README.md
+++ b/README.md
@@ -95,8 +95,26 @@ val plain = message.toPlainText()
 
 ## 🚀 Getting It (early access)
 
-Pre-alpha snapshots will be published via [JitPack](https://jitpack.io). Coordinates and a worked example land with the
-first tagged slice (`0.0.1`).
+Pre-alpha builds are published via [JitPack](https://jitpack.io). Add JitPack after your primary repositories, then
+depend on the modules you need:
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven("https://jitpack.io")
+}
+
+dependencies {
+    implementation("com.github.LMLiam.Kotventure:kotventure-core:<tag>")
+    implementation("com.github.LMLiam.Kotventure:kotventure-serializer:<tag>")
+
+    testImplementation("com.github.LMLiam.Kotventure:kotventure-test:<tag>")
+}
+```
+
+Replace `<tag>` with a released tag such as `0.0.1`. The `kotventure-test` artifact is intended for test scope only.
+JitPack also exposes an aggregate coordinate, `com.github.LMLiam:Kotventure:<tag>`, when you want every published
+module in one dependency.
 
 ## 🧰 Build & Compatibility
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ group = 'io.github.lmliam.kotventure'
 version = '0.0.1-SNAPSHOT'
 
 subprojects {
+    group = rootProject.group
+    version = rootProject.version
+
     apply plugin: 'java-library'
     apply plugin: 'org.jetbrains.kotlin.jvm'
     apply plugin: 'io.kotest'
@@ -32,6 +35,7 @@ subprojects {
     apply from: rootProject.file('gradle/repositories.gradle')
     apply from: rootProject.file('gradle/versions.gradle')
     apply from: rootProject.file('gradle/dependencies.gradle')
+    apply from: rootProject.file('gradle/publish.gradle')
 
     tasks.withType(Jar).configureEach {
         archiveBaseName.set("kotventure-${project.name}")

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -21,7 +21,9 @@ def publicationArtifactId = "kotventure-${moduleName}"
 def repositoryUrl = 'https://github.com/LMLiam/Kotventure'
 
 afterEvaluate {
-    moduleDescription.set(project.description)
+    if (project.description != null) {
+        moduleDescription.set(project.description)
+    }
 }
 
 publishing {
@@ -63,7 +65,11 @@ tasks.register('verifyMavenPublicationMetadata') {
         if (publication.pom.name.getOrNull() != moduleName) {
             throw new GradleException("${modulePath} POM name must be '${moduleName}'.")
         }
-        if (publication.pom.description.getOrNull() != moduleDescription.get()) {
+        def expectedDescription = moduleDescription.getOrNull()
+        if (expectedDescription == null || expectedDescription.isBlank()) {
+            throw new GradleException("${modulePath} must define a project description for publication.")
+        }
+        if (publication.pom.description.getOrNull() != expectedDescription) {
             throw new GradleException("${modulePath} POM description must match the project description.")
         }
         if (publication.pom.url.getOrNull() != repositoryUrl) {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,0 +1,77 @@
+apply plugin: 'maven-publish'
+
+def jitpackBuild = System.getenv('JITPACK') == 'true'
+def jitpackEnvironmentValue = { String name ->
+    def value = System.getenv(name)
+    if (value == null || value.isBlank()) {
+        throw new GradleException("JitPack publication requires the ${name} environment variable.")
+    }
+    value
+}
+def publicationGroup = jitpackBuild
+        ? "${jitpackEnvironmentValue('GROUP')}.${jitpackEnvironmentValue('ARTIFACT')}"
+        : project.group.toString()
+def publicationVersion = jitpackBuild
+        ? jitpackEnvironmentValue('VERSION')
+        : rootProject.version.toString()
+def moduleName = project.name
+def modulePath = project.path
+def moduleDescription = objects.property(String)
+def publicationArtifactId = "kotventure-${moduleName}"
+def repositoryUrl = 'https://github.com/LMLiam/Kotventure'
+
+afterEvaluate {
+    moduleDescription.set(project.description)
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = publicationGroup
+            artifactId = publicationArtifactId
+            version = publicationVersion
+
+            from components.java
+
+            pom {
+                name = moduleName
+                description.set(moduleDescription)
+                url = repositoryUrl
+            }
+        }
+    }
+}
+
+tasks.register('verifyMavenPublicationMetadata') {
+    group = 'verification'
+    description = 'Verifies the Maven publication coordinates and POM metadata.'
+
+    doLast {
+        def publication = publishing.publications.findByName('maven')
+        if (publication == null) {
+            throw new GradleException("${modulePath} does not define a Maven publication named 'maven'.")
+        }
+        if (publication.groupId != publicationGroup) {
+            throw new GradleException("${modulePath} publishes group '${publication.groupId}', expected '${publicationGroup}'.")
+        }
+        if (publication.artifactId != publicationArtifactId) {
+            throw new GradleException("${modulePath} publishes artifact '${publication.artifactId}', expected '${publicationArtifactId}'.")
+        }
+        if (publication.version != publicationVersion) {
+            throw new GradleException("${modulePath} publishes version '${publication.version}', expected '${publicationVersion}'.")
+        }
+        if (publication.pom.name.getOrNull() != moduleName) {
+            throw new GradleException("${modulePath} POM name must be '${moduleName}'.")
+        }
+        if (publication.pom.description.getOrNull() != moduleDescription.get()) {
+            throw new GradleException("${modulePath} POM description must match the project description.")
+        }
+        if (publication.pom.url.getOrNull() != repositoryUrl) {
+            throw new GradleException("${modulePath} POM URL must be '${repositoryUrl}'.")
+        }
+    }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('verifyMavenPublicationMetadata')
+}

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,6 @@
+before_install:
+  - sdk install java 25-tem
+  - sdk use java 25-tem
+
+install:
+  - ./gradlew clean build publishToMavenLocal --no-daemon


### PR DESCRIPTION
## Summary

- Wire maven-publish for the enabled modules with per-module artifact ids.
- Add JitPack JDK 25 setup and publish install command.
- Document JitPack module coordinates and record the publishing change in the changelog.

## Related Issues

Closes #12

## Scope

- [x] Build tooling
- [ ] GitHub Actions workflow
- [ ] Dependency bump
- [ ] Repo config (labels, CODEOWNERS, etc.)

## Notes for Reviewers

- Adds a check-time Gradle verification task for publication group/artifact/version and POM metadata.
- Simulates JitPack env vars locally so module POMs resolve as com.github.LMLiam.Kotventure:<artifact>:<tag> on JitPack while normal local publishes keep io.github.lmliam.kotventure.

## Checklist

- [x] Linked related issue (if applicable)
- [x] Verified build/test pass after change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with instructions for accessing pre-alpha builds
  * Added changelog entry for publishing support

* **Chores**
  * Configured build system to support pre-alpha artifact publication
  * Added build-time validation for publication metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->