### PR TITLE
chore(bom): add bill of materials module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
   sources.
 - JitPack publishing support for the enabled modules, including `maven-publish` wiring, JDK 25 JitPack setup, and
   build-time publication metadata checks.
+- `bom` module publishing `kotventure-bom` so consumers can align Kotventure artifacts and Adventure 5.1.1 with one
+  platform import.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This project aims to:
 | `paper` / `velocity` / `fabric` | Platform adapters & extras                                                       |
 | `ksp`                           | Typed message-catalog codegen + compile-time validation                          |
 | `gradle-plugin`                 | Validate / pre-compile MiniMessage resource bundles at build time                |
+| `bom`                           | Bill of materials for aligning Kotventure and Adventure module versions          |
 
 See [`docs/DESIGN.md`](docs/DESIGN.md) for the full design and the [Roadmap](docs/ROADMAP.md) for sequencing.
 
@@ -61,6 +62,7 @@ The current build enables the first lazy modules:
 - `kotventure-serializer` — `Component.toMiniMessage()` and `Component.toPlainText()` wrappers around Adventure
   serializers
 - `kotventure-test` — Kotest component matchers consumed test-scoped by library modules
+- `kotventure-bom` — a Gradle/Maven BOM aligning enabled Kotventure artifacts and Adventure 5.1.1 dependencies
 
 The first `core` slice exposes a plain component builder:
 
@@ -96,7 +98,9 @@ val plain = message.toPlainText()
 ## 🚀 Getting It (early access)
 
 Tagged pre-alpha releases are available through [JitPack](https://jitpack.io). Add JitPack after your primary
-repositories, then depend on the modules you need:
+repositories, import the BOM once, then depend on the modules you need without repeating versions.
+
+Gradle Kotlin DSL:
 
 ```kotlin
 repositories {
@@ -105,16 +109,35 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.LMLiam.Kotventure:kotventure-core:<tag>")
-    implementation("com.github.LMLiam.Kotventure:kotventure-serializer:<tag>")
+    implementation(platform("com.github.LMLiam.Kotventure:kotventure-bom:<tag>"))
 
-    testImplementation("com.github.LMLiam.Kotventure:kotventure-test:<tag>")
+    implementation("com.github.LMLiam.Kotventure:kotventure-core")
+    implementation("com.github.LMLiam.Kotventure:kotventure-serializer")
+
+    testImplementation("com.github.LMLiam.Kotventure:kotventure-test")
+}
+```
+
+Gradle Groovy DSL:
+
+```groovy
+repositories {
+    mavenCentral()
+    maven { url = uri('https://jitpack.io') }
+}
+
+dependencies {
+    implementation platform('com.github.LMLiam.Kotventure:kotventure-bom:<tag>')
+
+    implementation 'com.github.LMLiam.Kotventure:kotventure-core'
+    implementation 'com.github.LMLiam.Kotventure:kotventure-serializer'
+
+    testImplementation 'com.github.LMLiam.Kotventure:kotventure-test'
 }
 ```
 
 Replace `<tag>` with a released tag such as `0.0.1`. The `kotventure-test` artifact is intended for test scope only.
-JitPack also exposes an aggregate coordinate, `com.github.LMLiam:Kotventure:<tag>`, when you want every published
-module in one dependency.
+The BOM also aligns Kotventure's Adventure baseline at 5.1.1.
 
 ## 🧰 Build & Compatibility
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,27 +14,33 @@ subprojects {
     group = rootProject.group
     version = rootProject.version
 
-    apply plugin: 'java-library'
-    apply plugin: 'org.jetbrains.kotlin.jvm'
-    apply plugin: 'io.kotest'
-    apply plugin: 'com.diffplug.spotless'
-    apply plugin: 'org.jlleitschuh.gradle.ktlint'
+    def libraryModule = project.name != 'bom'
 
-    kotlin {
-        jvmToolchain(25)
-        // Public API discipline: every public/protected declaration must have an explicit
-        // visibility modifier and an explicit type. App/sample modules may opt out with
-        // `explicitApi = org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode.Disabled`.
-        explicitApi()
-    }
+    if (libraryModule) {
+        apply plugin: 'java-library'
+        apply plugin: 'org.jetbrains.kotlin.jvm'
+        apply plugin: 'io.kotest'
+        apply plugin: 'com.diffplug.spotless'
+        apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
-    test {
-        useJUnitPlatform()
+        kotlin {
+            jvmToolchain(25)
+            // Public API discipline: every public/protected declaration must have an explicit
+            // visibility modifier and an explicit type. App/sample modules may opt out with
+            // `explicitApi = org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode.Disabled`.
+            explicitApi()
+        }
+
+        test {
+            useJUnitPlatform()
+        }
     }
 
     apply from: rootProject.file('gradle/repositories.gradle')
     apply from: rootProject.file('gradle/versions.gradle')
-    apply from: rootProject.file('gradle/dependencies.gradle')
+    if (libraryModule) {
+        apply from: rootProject.file('gradle/dependencies.gradle')
+    }
     apply from: rootProject.file('gradle/publish.gradle')
 
     tasks.withType(Jar).configureEach {
@@ -43,7 +49,9 @@ subprojects {
         destinationDirectory.set(rootProject.layout.buildDirectory.dir("libs"))
     }
 
-    apply from: rootProject.file('gradle/spotless.gradle')
+    if (libraryModule) {
+        apply from: rootProject.file('gradle/spotless.gradle')
+    }
 }
 
 apply from: 'gradle/tasks.gradle'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -24,6 +24,15 @@ afterEvaluate {
     if (project.description != null) {
         moduleDescription.set(project.description)
     }
+    publishing.publications.named('maven') {
+        if (pluginManager.hasPlugin('java-platform')) {
+            from components.javaPlatform
+        } else if (pluginManager.hasPlugin('java')) {
+            from components.java
+        } else {
+            throw new GradleException("${modulePath} must apply java or java-platform to publish Maven metadata.")
+        }
+    }
 }
 
 publishing {
@@ -32,8 +41,6 @@ publishing {
             groupId = publicationGroup
             artifactId = publicationArtifactId
             version = publicationVersion
-
-            from components.java
 
             pom {
                 name = moduleName
@@ -78,6 +85,6 @@ tasks.register('verifyMavenPublicationMetadata') {
     }
 }
 
-tasks.named('check') {
+tasks.matching { it.name == 'check' || it.name == 'build' }.configureEach {
     dependsOn tasks.named('verifyMavenPublicationMetadata')
 }

--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -1,3 +1,8 @@
+def jarSubprojects = subprojects.findAll { subproject ->
+    subproject.tasks.findByName('jar') != null &&
+            subproject.extensions.findByName('sourceSets') != null
+}
+
 tasks.register('allJar', Jar) {
     group = 'build'
     description = 'Assembles a JAR with all modules included.'
@@ -6,10 +11,10 @@ tasks.register('allJar', Jar) {
     archiveVersion.set(version)
     destinationDirectory.set(layout.buildDirectory.dir("libs"))
 
-    dependsOn(subprojects.collect { it.tasks.named('jar') })
+    dependsOn(jarSubprojects.collect { it.tasks.named('jar') })
 
     from {
-        subprojects.collect { it.sourceSets.main.output }
+        jarSubprojects.collect { it.sourceSets.main.output }
     }
 }
 

--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -28,3 +28,72 @@ registerSubprojectAggregateTask('ktlintCheck', 'verification', 'Runs ktlint chec
 registerSubprojectAggregateTask('spotlessCheck', 'verification', 'Runs Spotless checks in all modules.')
 registerSubprojectAggregateTask('ktlintFormat', 'formatting', 'Formats Kotlin sources in all modules with ktlint.')
 registerSubprojectAggregateTask('spotlessApply', 'formatting', 'Formats sources in all modules with Spotless.')
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+def bomConsumerArtifacts = [
+        'kotventure-core',
+        'kotventure-serializer',
+        'kotventure-test'
+]
+
+configurations {
+    bomConsumerVerification {
+        canBeConsumed = false
+        canBeResolved = true
+        description = 'Resolves Kotventure modules through the published BOM without per-artifact versions.'
+    }
+}
+
+dependencies {
+    bomConsumerVerification platform("${project.group}:kotventure-bom:${project.version}")
+    bomConsumerArtifacts.each { artifactName ->
+        bomConsumerVerification "${project.group}:${artifactName}"
+    }
+}
+
+tasks.register('verifyBomConsumerVersionlessDependencies') {
+    group = 'verification'
+    description = 'Verifies that a consumer importing kotventure-bom can omit per-artifact versions.'
+
+    dependsOn ':core:publishToMavenLocal'
+    dependsOn ':serializer:publishToMavenLocal'
+    dependsOn ':test:publishToMavenLocal'
+    dependsOn ':bom:publishToMavenLocal'
+
+    doLast {
+        def expectedGroup = project.group.toString()
+        def expectedVersion = project.version.toString()
+        def resolvedVersions = [:]
+
+        configurations.bomConsumerVerification.incoming.resolutionResult.allComponents.each { component ->
+            def moduleVersion = component.moduleVersion
+            if (moduleVersion != null &&
+                    moduleVersion.group == expectedGroup &&
+                    bomConsumerArtifacts.contains(moduleVersion.name)) {
+                resolvedVersions[moduleVersion.name] = moduleVersion.version
+            }
+        }
+
+        def missingArtifacts = bomConsumerArtifacts.findAll { artifactName ->
+            !resolvedVersions.containsKey(artifactName)
+        }
+        if (!missingArtifacts.isEmpty()) {
+            throw new GradleException("BOM consumer verification did not resolve: ${missingArtifacts.join(', ')}")
+        }
+
+        def mismatchedVersions = resolvedVersions.findAll { artifactName, resolvedVersion ->
+            resolvedVersion != expectedVersion
+        }
+        if (!mismatchedVersions.isEmpty()) {
+            throw new GradleException("BOM consumer verification resolved unexpected versions: ${mismatchedVersions}")
+        }
+    }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('verifyBomConsumerVersionlessDependencies')
+}

--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -39,11 +39,14 @@ repositories {
     mavenCentral()
 }
 
-def bomConsumerArtifacts = [
-        'kotventure-core',
-        'kotventure-serializer',
-        'kotventure-test'
+def bomConsumerModules = [
+        'core',
+        'serializer',
+        'test'
 ]
+def bomConsumerArtifacts = bomConsumerModules.collect { moduleName ->
+    "kotventure-${moduleName}".toString()
+}
 
 configurations {
     bomConsumerVerification {
@@ -64,9 +67,9 @@ tasks.register('verifyBomConsumerVersionlessDependencies') {
     group = 'verification'
     description = 'Verifies that a consumer importing kotventure-bom can omit per-artifact versions.'
 
-    dependsOn ':core:publishToMavenLocal'
-    dependsOn ':serializer:publishToMavenLocal'
-    dependsOn ':test:publishToMavenLocal'
+    bomConsumerModules.each { moduleName ->
+        dependsOn ":${moduleName}:publishToMavenLocal"
+    }
     dependsOn ':bom:publishToMavenLocal'
 
     doLast {

--- a/modules/bom/build.gradle
+++ b/modules/bom/build.gradle
@@ -1,0 +1,21 @@
+description = 'Bill of materials for aligning Kotventure and Adventure module versions.'
+
+apply plugin: 'java-platform'
+
+javaPlatform {
+    allowDependencies()
+}
+
+dependencies {
+    api platform(libs.adventure.bom)
+
+    constraints {
+        api project(':core')
+        api project(':serializer')
+        api project(':test')
+
+        api libs.adventure.api
+        api libs.adventure.text.minimessage
+        api libs.adventure.text.serializer.plain
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,8 @@ rootProject.name = 'Kotventure'
 include 'core'
 include 'serializer'
 include 'test'
+include 'bom'
 project(':core').projectDir = file('modules/core')
 project(':serializer').projectDir = file('modules/serializer')
 project(':test').projectDir = file('modules/test')
+project(':bom').projectDir = file('modules/bom')


### PR DESCRIPTION
## Summary

- Add the `bom` java-platform module and register it in settings.
- Publish `kotventure-bom` with enabled Kotventure module constraints and Adventure 5.1.1 alignment.
- Add a build verification task that publishes locally and resolves versionless module dependencies through the BOM.
- Document BOM usage in README and note the module in CHANGELOG.

## Related Issues

Closes #13

## Scope

- [x] Build tooling
- [ ] GitHub Actions workflow
- [ ] Dependency bump
- [ ] Repo config (labels, CODEOWNERS, etc.)

## Notes for Reviewers

The new `verifyBomConsumerVersionlessDependencies` task is wired into root `check`, so `./gradlew build` verifies that a Maven-local consumer can import `kotventure-bom` and omit versions for `kotventure-core`, `kotventure-serializer`, and `kotventure-test`. I also simulated JitPack publication coordinates with `JITPACK=true GROUP=com.github.LMLiam ARTIFACT=Kotventure VERSION=0.0.1 ./gradlew :bom:generatePomFileForMavenPublication` and inspected the generated BOM POM.

## Checklist

- [x] Linked related issue
- [x] Verified build/test pass after change

Validation:
- `./gradlew ktlintFormat`
- `./gradlew build`
- `./gradlew :bom:publishToMavenLocal`
- `./gradlew ktlintCheck spotlessCheck`
- inspected `~/.m2/repository/io/github/lmliam/kotventure/kotventure-bom/0.0.1-SNAPSHOT/kotventure-bom-0.0.1-SNAPSHOT.pom`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added kotventure-bom module so consumers can import a BOM to manage module versions from a single platform coordinate.

* **Documentation**
  * Installation and module docs updated with BOM usage examples and note that Kotventure aligns with Adventure 5.1.1; guidance simplified to one platform import.

* **Chores**
  * Build and verification updated to publish/verify BOM and consumer modules and enforce BOM-based dependency resolution during CI/build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->