### PR TITLE
chore(build): tag and publish 0.0.1 pre-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 ### Changed
 
 - Upgraded the Adventure dependency baseline from 4.24.0 to 5.1.1 and aligned enabled modules through the Adventure BOM.
-- Documented the Java 25 build toolchain and Adventure 5.x Java 21+ consumer minimum for early-access users.
+- Kotventure builds with the Java 25 Gradle toolchain; Adventure 5.x sets a Java 21+ consumer minimum.
 
 [Unreleased]: https://github.com/LMLiam/Kotventure/compare/0.0.1...HEAD
 [0.0.1]: https://github.com/LMLiam/Kotventure/releases/tag/0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 
 ## [Unreleased]
 
+## [0.0.1] - 2026-06-08
+
 ### Added
 
 - Project migrated to the `LMLiam` namespace (`io.github.lmliam.kotventure`).
@@ -43,5 +45,7 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 ### Changed
 
 - Upgraded the Adventure dependency baseline from 4.24.0 to 5.1.1 and aligned enabled modules through the Adventure BOM.
+- Documented the Java 25 build toolchain and Adventure 5.x Java 21+ consumer minimum for early-access users.
 
-[Unreleased]: https://github.com/LMLiam/Kotventure/commits/master
+[Unreleased]: https://github.com/LMLiam/Kotventure/compare/0.0.1...HEAD
+[0.0.1]: https://github.com/LMLiam/Kotventure/releases/tag/0.0.1

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'io.github.lmliam.kotventure'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.1'
 
 subprojects {
     group = rootProject.group

--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -47,6 +47,20 @@ def bomConsumerModules = [
 def bomConsumerArtifacts = bomConsumerModules.collect { moduleName ->
     "kotventure-${moduleName}".toString()
 }
+def jitpackBuild = System.getenv('JITPACK') == 'true'
+def jitpackEnvironmentValue = { String name ->
+    def value = System.getenv(name)
+    if (value == null || value.isBlank()) {
+        throw new GradleException("JitPack BOM consumer verification requires the ${name} environment variable.")
+    }
+    value
+}
+def bomConsumerGroup = jitpackBuild
+        ? "${jitpackEnvironmentValue('GROUP')}.${jitpackEnvironmentValue('ARTIFACT')}"
+        : project.group.toString()
+def bomConsumerVersion = jitpackBuild
+        ? jitpackEnvironmentValue('VERSION')
+        : project.version.toString()
 
 configurations {
     bomConsumerVerification {
@@ -57,9 +71,9 @@ configurations {
 }
 
 dependencies {
-    bomConsumerVerification platform("${project.group}:kotventure-bom:${project.version}")
+    bomConsumerVerification platform("${bomConsumerGroup}:kotventure-bom:${bomConsumerVersion}")
     bomConsumerArtifacts.each { artifactName ->
-        bomConsumerVerification "${project.group}:${artifactName}"
+        bomConsumerVerification "${bomConsumerGroup}:${artifactName}"
     }
 }
 
@@ -73,8 +87,8 @@ tasks.register('verifyBomConsumerVersionlessDependencies') {
     dependsOn ':bom:publishToMavenLocal'
 
     doLast {
-        def expectedGroup = project.group.toString()
-        def expectedVersion = project.version.toString()
+        def expectedGroup = bomConsumerGroup
+        def expectedVersion = bomConsumerVersion
         def resolvedVersions = [:]
 
         configurations.bomConsumerVerification.incoming.resolutionResult.allComponents.each { component ->

--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -47,9 +47,9 @@ def bomConsumerModules = [
 def bomConsumerArtifacts = bomConsumerModules.collect { moduleName ->
     "kotventure-${moduleName}".toString()
 }
-def jitpackBuild = System.getenv('JITPACK') == 'true'
+def jitpackBuild = providers.environmentVariable('JITPACK').orNull == 'true'
 def jitpackEnvironmentValue = { String name ->
-    def value = System.getenv(name)
+    def value = providers.environmentVariable(name).orNull
     if (value == null || value.isBlank()) {
         throw new GradleException("JitPack BOM consumer verification requires the ${name} environment variable.")
     }


### PR DESCRIPTION
## Summary

- Release Kotventure `0.0.1` as the first public pre-alpha slice.
- Set the project version to `0.0.1` and add the dated changelog entry.
- Keep BOM consumer verification JitPack-aware so `com.github.LMLiam.Kotventure:*:0.0.1` resolves after tag builds.

## Related Issues

Closes #14

## Scope

- `build.gradle`: publishable version is now `0.0.1`.
- `CHANGELOG.md`: documents the release, JitPack coordinates, Java 25 build toolchain, and Adventure 5.x Java 21+ consumer minimum.
- `gradle/tasks.gradle`: BOM consumer verification uses JitPack group/version when JitPack invokes the build.

## Notes for Reviewers

- GitHub release: https://github.com/LMLiam/Kotventure/releases/tag/0.0.1
- Announcement discussion: https://github.com/LMLiam/Kotventure/discussions/101
- JitPack API reports `status: ok`, commit `5b75627afaf7a42319c8574ad363fe828522e476`, and modules `kotventure-bom`, `kotventure-core`, `kotventure-serializer`, `kotventure-test`.
- Fresh consumer resolution passed against `https://jitpack.io` using the BOM coordinates.

## Checklist

- [x] I read `docs/DESIGN.md`, `docs/ROADMAP.md`, and issue #14 before making changes.
- [x] I kept the slice scoped to the release/tag/JitPack/changelog work.
- [x] I did not weaken tests, lint, or CI checks.
- [x] I verified public release metadata and project metadata after opening the PR.

## Acceptance Criteria

- [x] `0.0.1` tagged and resolvable: tag `0.0.1` points at `5b75627afaf7a42319c8574ad363fe828522e476`; JitPack POMs return 200 for `kotventure-bom`, `kotventure-core`, `kotventure-serializer`, and `kotventure-test`; fresh Gradle consumer resolution passes with `--refresh-dependencies`.
- [x] `CHANGELOG.md` updated for `0.0.1`.
- [x] Tests added/updated where applicable: no behavioral library surface changed; release verification is covered by existing build/tests and the JitPack/BOM consumer checks.
- [x] Docs/sample updated if user-facing: changelog and GitHub release notes document coordinates, Java 25 build toolchain, and Adventure 5.x Java 21+ consumer minimum.

## Testing

- [x] `./gradlew ktlintFormat`
- [x] `git diff --check`
- [x] `./gradlew clean build publishToMavenLocal --no-daemon`
- [x] `JITPACK=true GROUP=com.github.LMLiam ARTIFACT=Kotventure VERSION=0.0.1 ./gradlew clean build publishToMavenLocal --no-daemon -Dmaven.repo.local=<empty-dir>`
- [x] Fresh Gradle consumer: `./gradlew -p /tmp/kotventure-consumer.np9iPD resolveKotventure --refresh-dependencies --no-daemon`
- [x] `gh pr checks 100 --watch`
- [x] Manual full diff self-review after final fix: no new findings.
