### PR TITLE
feat(core): complete text component builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 
 ## [Unreleased]
 
+### Added
+
+- Text DSL composition helpers: `append(Component)`, `newline()`, and inline `style { }` blocks for the current
+  component.
+
 ## [0.0.1] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The current build enables the first lazy modules:
 - `kotventure-test` — Kotest component matchers consumed test-scoped by library modules
 - `kotventure-bom` — a Gradle/Maven BOM aligning enabled Kotventure artifacts and Adventure 5.1.1 dependencies
 
-The first `core` slice exposes a plain component builder:
+The `core` module exposes a composable text builder:
 
 ```kotlin
 val badge = Component.text("[new]", NamedTextColor.GREEN)

--- a/README.md
+++ b/README.md
@@ -67,15 +67,21 @@ The current build enables the first lazy modules:
 The first `core` slice exposes a plain component builder:
 
 ```kotlin
+val badge = Component.text("[new]", NamedTextColor.GREEN)
+
 val message = component {
     text("Hello ") {
-        color(NamedTextColor.AQUA)
-        bold()
+        style {
+            color(NamedTextColor.AQUA)
+            bold()
+        }
     }
+    newline()
     text {
         content("world")
         decorate(TextDecoration.UNDERLINED)
     }
+    append(badge)
 }
 ```
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleBuilder.kt
@@ -1,0 +1,39 @@
+package io.github.lmliam.kotventure.core.style
+
+import net.kyori.adventure.text.format.Style
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+internal class StyleBuilder : StyleScope {
+    private val builder: Style.Builder = Style.style()
+
+    override fun color(color: TextColor) {
+        builder.color(color)
+    }
+
+    override fun decorate(decoration: TextDecoration) {
+        builder.decoration(decoration, true)
+    }
+
+    override fun bold() {
+        decorate(TextDecoration.BOLD)
+    }
+
+    override fun italic() {
+        decorate(TextDecoration.ITALIC)
+    }
+
+    override fun underlined() {
+        decorate(TextDecoration.UNDERLINED)
+    }
+
+    override fun strikethrough() {
+        decorate(TextDecoration.STRIKETHROUGH)
+    }
+
+    override fun obfuscated() {
+        decorate(TextDecoration.OBFUSCATED)
+    }
+
+    internal fun build(): Style = builder.build()
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleScope.kt
@@ -1,0 +1,46 @@
+package io.github.lmliam.kotventure.core.style
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+/**
+ * Scope for configuring an Adventure style inline.
+ */
+@KotventureDslMarker
+public interface StyleScope {
+    /**
+     * Applies a text color to the style being configured.
+     */
+    public fun color(color: TextColor)
+
+    /**
+     * Enables [decoration] on the style being configured.
+     */
+    public fun decorate(decoration: TextDecoration)
+
+    /**
+     * Enables bold text on the style being configured.
+     */
+    public fun bold()
+
+    /**
+     * Enables italic text on the style being configured.
+     */
+    public fun italic()
+
+    /**
+     * Enables underlined text on the style being configured.
+     */
+    public fun underlined()
+
+    /**
+     * Enables strikethrough text on the style being configured.
+     */
+    public fun strikethrough()
+
+    /**
+     * Enables obfuscated text on the style being configured.
+     */
+    public fun obfuscated()
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextComponentBuilder.kt
@@ -1,5 +1,7 @@
 package io.github.lmliam.kotventure.core.text
 
+import io.github.lmliam.kotventure.core.style.StyleBuilder
+import io.github.lmliam.kotventure.core.style.StyleScope
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.format.Style
@@ -19,6 +21,10 @@ internal class TextComponentBuilder : TextScope {
 
     override fun style(style: Style) {
         builder.style(style)
+    }
+
+    override fun style(init: StyleScope.() -> Unit) {
+        builder.style(StyleBuilder().apply(init).build())
     }
 
     override fun decorate(decoration: TextDecoration) {
@@ -57,6 +63,14 @@ internal class TextComponentBuilder : TextScope {
 
     override fun text(init: TextScope.() -> Unit) {
         builder.append(TextComponentBuilder().apply(init).build())
+    }
+
+    override fun append(component: Component) {
+        builder.append(component)
+    }
+
+    override fun newline() {
+        builder.append(Component.newline())
     }
 
     internal fun build(): Component = builder.build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextComponentBuilder.kt
@@ -1,6 +1,5 @@
 package io.github.lmliam.kotventure.core.text
 
-import io.github.lmliam.kotventure.core.style.StyleBuilder
 import io.github.lmliam.kotventure.core.style.StyleScope
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
@@ -24,7 +23,7 @@ internal class TextComponentBuilder : TextScope {
     }
 
     override fun style(init: StyleScope.() -> Unit) {
-        builder.style(StyleBuilder().apply(init).build())
+        TextStyleScope(builder).init()
     }
 
     override fun decorate(decoration: TextDecoration) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextScope.kt
@@ -1,6 +1,8 @@
 package io.github.lmliam.kotventure.core.text
 
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.core.style.StyleScope
+import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
@@ -24,6 +26,11 @@ public interface TextScope {
      * Applies a complete Adventure style to the component being configured.
      */
     public fun style(style: Style)
+
+    /**
+     * Applies style attributes from [init] to the component being configured.
+     */
+    public fun style(init: StyleScope.() -> Unit)
 
     /**
      * Enables [decoration] on the component being configured.
@@ -62,6 +69,16 @@ public interface TextScope {
         value: String,
         init: TextScope.() -> Unit = {},
     )
+
+    /**
+     * Appends an existing Adventure [Component] as a child of the component being configured.
+     */
+    public fun append(component: Component)
+
+    /**
+     * Appends an Adventure newline component as a child of the component being configured.
+     */
+    public fun newline()
 
     /**
      * Appends a nested text child configured by [init].

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextStyleScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextStyleScope.kt
@@ -1,12 +1,13 @@
-package io.github.lmliam.kotventure.core.style
+package io.github.lmliam.kotventure.core.text
 
-import net.kyori.adventure.text.format.Style
+import io.github.lmliam.kotventure.core.style.StyleScope
+import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
 
-internal class StyleBuilder : StyleScope {
-    private val builder: Style.Builder = Style.style()
-
+internal class TextStyleScope(
+    private val builder: TextComponent.Builder,
+) : StyleScope {
     override fun color(color: TextColor) {
         builder.color(color)
     }
@@ -34,6 +35,4 @@ internal class StyleBuilder : StyleScope {
     override fun obfuscated() {
         decorate(TextDecoration.OBFUSCATED)
     }
-
-    internal fun build(): Style = builder.build()
 }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
@@ -156,6 +156,39 @@ class ComponentDslTest :
                 component.childAt(0) shouldNotHaveDecoration TextDecoration.BOLD
             }
 
+            "keeps style blocks additive with surrounding style calls" {
+                val styleAfterColor =
+                    component {
+                        color(NamedTextColor.GOLD)
+                        style {
+                            bold()
+                        }
+                    }
+
+                val colorAfterStyle =
+                    component {
+                        style {
+                            bold()
+                        }
+                        color(NamedTextColor.GOLD)
+                    }
+
+                val styleAfterDecoration =
+                    component {
+                        bold()
+                        style {
+                            color(NamedTextColor.GOLD)
+                        }
+                    }
+
+                styleAfterColor shouldHaveColor NamedTextColor.GOLD
+                styleAfterColor shouldHaveDecoration TextDecoration.BOLD
+                colorAfterStyle shouldHaveColor NamedTextColor.GOLD
+                colorAfterStyle shouldHaveDecoration TextDecoration.BOLD
+                styleAfterDecoration shouldHaveColor NamedTextColor.GOLD
+                styleAfterDecoration shouldHaveDecoration TextDecoration.BOLD
+            }
+
             "applies a decoration to the root text component" {
                 val component =
                     component {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
@@ -13,6 +13,7 @@ import io.github.lmliam.kotventure.test.text.shouldNotHaveDecoration
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextDecoration
@@ -73,6 +74,39 @@ class ComponentDslTest :
                 component.childAt(0) shouldHaveColor NamedTextColor.AQUA
             }
 
+            "appends existing Adventure components in declaration order" {
+                val badge = Component.text("[OK]", NamedTextColor.GREEN)
+
+                val component =
+                    component {
+                        text("Status: ")
+                        append(badge)
+                        text(" ready") {
+                            italic()
+                        }
+                    }
+
+                component shouldHaveChildCount 3
+                component.childAt(0) shouldContainText "Status: "
+                component.childAt(1) shouldBe badge
+                component.childAt(2) shouldContainText " ready"
+                component.childAt(2) shouldHaveDecoration TextDecoration.ITALIC
+            }
+
+            "appends a newline component" {
+                val component =
+                    component {
+                        text("first")
+                        newline()
+                        text("second")
+                    }
+
+                component shouldHaveChildCount 3
+                component.childAt(0) shouldContainText "first"
+                component.childAt(1) shouldBe Component.newline()
+                component.childAt(2) shouldContainText "second"
+            }
+
             "applies a complete Adventure style" {
                 val style = Style.style(NamedTextColor.GOLD, TextDecoration.BOLD)
 
@@ -83,6 +117,43 @@ class ComponentDslTest :
                     }
 
                 component shouldHaveStyle style
+            }
+
+            "applies a style block to the current component" {
+                val component =
+                    component {
+                        content("Title")
+                        style {
+                            color(NamedTextColor.GOLD)
+                            bold()
+                            underlined()
+                        }
+                    }
+
+                component shouldHaveColor NamedTextColor.GOLD
+                component shouldHaveDecoration TextDecoration.BOLD
+                component shouldHaveDecoration TextDecoration.UNDERLINED
+            }
+
+            "keeps nested style blocks scoped to their current child component" {
+                val component =
+                    component {
+                        style {
+                            color(NamedTextColor.GRAY)
+                        }
+                        text("child") {
+                            style {
+                                color(NamedTextColor.AQUA)
+                                obfuscated()
+                            }
+                        }
+                    }
+
+                component shouldHaveColor NamedTextColor.GRAY
+                component shouldHaveChildCount 1
+                component.childAt(0) shouldHaveColor NamedTextColor.AQUA
+                component.childAt(0) shouldHaveDecoration TextDecoration.OBFUSCATED
+                component.childAt(0) shouldNotHaveDecoration TextDecoration.BOLD
             }
 
             "applies a decoration to the root text component" {
@@ -170,6 +241,34 @@ class ComponentDslTest :
                     KotlinCompilation().apply {
                         inheritClassPath = true
                         sources = listOf(SourceFile.kotlin("DslMarkerScopeTest.kt", source))
+                    }
+
+                val result = compilation.compile()
+
+                result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                result.messages shouldContain "implicit receiver"
+            }
+
+            "prevents text scope access inside style blocks" {
+                val source =
+                    """
+                    import io.github.lmliam.kotventure.core.text.component
+                    import net.kyori.adventure.text.format.NamedTextColor
+
+                    fun shouldNotCompile() {
+                        component {
+                            style {
+                                color(NamedTextColor.GOLD)
+                                content("leaked")
+                            }
+                        }
+                    }
+                    """.trimIndent()
+
+                val compilation =
+                    KotlinCompilation().apply {
+                        inheritClassPath = true
+                        sources = listOf(SourceFile.kotlin("StyleScopeLeakTest.kt", source))
                     }
 
                 val result = compilation.compile()


### PR DESCRIPTION
## Summary

Completes the text builder composition slice with `append(Component)`, `newline()`, and inline `style { }` blocks backed by real Adventure components and styles.

## Related Issues

Closes #15

## DSL Impact

- Adds `TextScope.append(Component)` for appending pre-built Adventure components.
- Adds `TextScope.newline()` as a convenience wrapper around `Component.newline()`.
- Adds `TextScope.style { }` with a marked `StyleScope` for applying color and decoration attributes to the current component.

## Rationale

Downstream plugin authors can now compose existing Adventure components with Kotventure-built children, insert line breaks without extra imports, and group inline style changes without pre-building an Adventure `Style`.

## Testing

- `./gradlew :core:test --tests io.github.lmliam.kotventure.core.text.ComponentDslTest` red before implementation, then green after implementation.
- `./gradlew ktlintFormat`
- `./gradlew build`

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run through equivalent `ComponentDslTest` coverage and full build verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified text styling with inline `style { }` blocks for configuring colors and decorations within text components.
  * Added new composition helpers for appending existing components and inserting newlines in text DSL.

* **Documentation**
  * Updated README examples and CHANGELOG documenting new text DSL helpers.

* **Tests**
  * Added comprehensive tests verifying new text composition and styling features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->