### PR TITLE
feat(core): add translatable component builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 
 - Text DSL composition helpers: `append(Component)`, `newline()`, and inline `style { }` blocks for the current
   component.
+- Translatable component DSL support for translation keys, fallback text, component arguments, boolean arguments, numeric
+  arguments, root styling, and child components.
+- Translatable component matchers for asserting keys, fallback text, and translation arguments in Kotest specs.
 
 ## [0.0.1] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ val message = component {
 }
 ```
 
+It also includes a `TranslatableComponent` builder for client-side translation keys, fallbacks, and typed Adventure
+arguments:
+
+```kotlin
+val itemCount = translatable("item.count") {
+    fallback("You have an item stack")
+    arg(Component.text("Diamond", NamedTextColor.AQUA))
+    arg(3)
+}
+```
+
 `AdventureDsl` stores typed extension registrations for MiniMessage tag providers, theme providers, animation drivers,
 and the active platform adapter. Registration is explicit at startup; there is no classpath scanning.
 
@@ -97,7 +108,8 @@ val plain = message.toPlainText()
 ```
 
 `kotventure-test` starts the testing toolkit with structural component matchers such as `shouldContainText`,
-`shouldHaveColor`, `shouldHaveDecoration`, `shouldNotHaveDecoration`, and `shouldHaveChildCount`.
+`shouldHaveColor`, `shouldHaveDecoration`, `shouldNotHaveDecoration`, `shouldHaveChildCount`, and translatable-specific
+assertions for keys, fallbacks, and arguments.
 
 ---
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/Translatable.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/Translatable.kt
@@ -1,0 +1,11 @@
+package io.github.lmliam.kotventure.core.translatable
+
+import net.kyori.adventure.text.Component
+
+/**
+ * Builds an Adventure translatable [Component] from a Kotventure DSL block.
+ */
+public fun translatable(
+    key: String,
+    init: TranslatableScope.() -> Unit = {},
+): Component = TranslatableComponentBuilder(key).apply(init).build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableComponentBuilder.kt
@@ -1,0 +1,79 @@
+package io.github.lmliam.kotventure.core.translatable
+
+import io.github.lmliam.kotventure.core.style.StyleScope
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.text.TranslatableComponent
+import net.kyori.adventure.text.TranslationArgument
+import net.kyori.adventure.text.format.Style
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+internal class TranslatableComponentBuilder(
+    key: String,
+) : TranslatableScope {
+    private val builder: TranslatableComponent.Builder = Component.translatable().key(key)
+    private val arguments = mutableListOf<TranslationArgument>()
+
+    override fun fallback(fallback: String) {
+        builder.fallback(fallback)
+    }
+
+    override fun arg(value: ComponentLike) {
+        arguments += TranslationArgument.component(value)
+    }
+
+    override fun arg(value: Boolean) {
+        arguments += TranslationArgument.bool(value)
+    }
+
+    override fun arg(value: Number) {
+        arguments += TranslationArgument.numeric(value)
+    }
+
+    override fun args(vararg values: ComponentLike) {
+        arguments += values.map(TranslationArgument::component)
+    }
+
+    override fun color(color: TextColor) {
+        builder.color(color)
+    }
+
+    override fun style(style: Style) {
+        builder.style(style)
+    }
+
+    override fun style(init: StyleScope.() -> Unit) {
+        TranslatableStyleScope(builder).init()
+    }
+
+    override fun decorate(decoration: TextDecoration) {
+        builder.decoration(decoration, true)
+    }
+
+    override fun bold() {
+        decorate(TextDecoration.BOLD)
+    }
+
+    override fun italic() {
+        decorate(TextDecoration.ITALIC)
+    }
+
+    override fun underlined() {
+        decorate(TextDecoration.UNDERLINED)
+    }
+
+    override fun strikethrough() {
+        decorate(TextDecoration.STRIKETHROUGH)
+    }
+
+    override fun obfuscated() {
+        decorate(TextDecoration.OBFUSCATED)
+    }
+
+    override fun append(component: Component) {
+        builder.append(component)
+    }
+
+    internal fun build(): Component = builder.arguments(arguments).build()
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableComponentBuilder.kt
@@ -35,6 +35,14 @@ internal class TranslatableComponentBuilder(
         arguments += values.map(TranslationArgument::component)
     }
 
+    override fun args(vararg values: Boolean) {
+        arguments += values.map(TranslationArgument::bool)
+    }
+
+    override fun args(vararg values: Number) {
+        arguments += values.map(TranslationArgument::numeric)
+    }
+
     override fun color(color: TextColor) {
         builder.color(color)
     }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableScope.kt
@@ -1,0 +1,90 @@
+package io.github.lmliam.kotventure.core.translatable
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.core.style.StyleScope
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.text.format.Style
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+/**
+ * Scope for configuring a translatable component with fallback text, arguments, style, and children.
+ */
+@KotventureDslMarker
+public interface TranslatableScope {
+    /**
+     * Applies fallback text for clients that cannot resolve the translation key.
+     */
+    public fun fallback(fallback: String)
+
+    /**
+     * Appends a component-like translation argument.
+     */
+    public fun arg(value: ComponentLike)
+
+    /**
+     * Appends a boolean translation argument.
+     */
+    public fun arg(value: Boolean)
+
+    /**
+     * Appends a numeric translation argument.
+     */
+    public fun arg(value: Number)
+
+    /**
+     * Appends multiple component-like translation arguments in declaration order.
+     */
+    public fun args(vararg values: ComponentLike)
+
+    /**
+     * Applies a text color to the component being configured.
+     */
+    public fun color(color: TextColor)
+
+    /**
+     * Applies a complete Adventure style to the component being configured.
+     */
+    public fun style(style: Style)
+
+    /**
+     * Applies style attributes from [init] to the component being configured.
+     */
+    public fun style(init: StyleScope.() -> Unit)
+
+    /**
+     * Enables [decoration] on the component being configured.
+     */
+    public fun decorate(decoration: TextDecoration)
+
+    /**
+     * Enables bold text on the component being configured.
+     */
+    public fun bold()
+
+    /**
+     * Enables italic text on the component being configured.
+     */
+    public fun italic()
+
+    /**
+     * Enables underlined text on the component being configured.
+     */
+    public fun underlined()
+
+    /**
+     * Enables strikethrough text on the component being configured.
+     */
+    public fun strikethrough()
+
+    /**
+     * Enables obfuscated text on the component being configured.
+     */
+    public fun obfuscated()
+
+    /**
+     * Appends an existing Adventure [Component] as a child of the component being configured.
+     */
+    public fun append(component: Component)
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableScope.kt
@@ -39,6 +39,16 @@ public interface TranslatableScope {
     public fun args(vararg values: ComponentLike)
 
     /**
+     * Appends multiple boolean translation arguments in declaration order.
+     */
+    public fun args(vararg values: Boolean)
+
+    /**
+     * Appends multiple numeric translation arguments in declaration order.
+     */
+    public fun args(vararg values: Number)
+
+    /**
      * Applies a text color to the component being configured.
      */
     public fun color(color: TextColor)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableStyleScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableStyleScope.kt
@@ -1,0 +1,38 @@
+package io.github.lmliam.kotventure.core.translatable
+
+import io.github.lmliam.kotventure.core.style.StyleScope
+import net.kyori.adventure.text.TranslatableComponent
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+internal class TranslatableStyleScope(
+    private val builder: TranslatableComponent.Builder,
+) : StyleScope {
+    override fun color(color: TextColor) {
+        builder.color(color)
+    }
+
+    override fun decorate(decoration: TextDecoration) {
+        builder.decoration(decoration, true)
+    }
+
+    override fun bold() {
+        decorate(TextDecoration.BOLD)
+    }
+
+    override fun italic() {
+        decorate(TextDecoration.ITALIC)
+    }
+
+    override fun underlined() {
+        decorate(TextDecoration.UNDERLINED)
+    }
+
+    override fun strikethrough() {
+        decorate(TextDecoration.STRIKETHROUGH)
+    }
+
+    override fun obfuscated() {
+        decorate(TextDecoration.OBFUSCATED)
+    }
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableDslTest.kt
@@ -1,0 +1,133 @@
+package io.github.lmliam.kotventure.core.translatable
+
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldHaveArgumentCount
+import io.github.lmliam.kotventure.test.text.shouldHaveArguments
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.github.lmliam.kotventure.test.text.shouldHaveFallback
+import io.github.lmliam.kotventure.test.text.shouldHaveTranslationKey
+import io.github.lmliam.kotventure.test.text.shouldNotHaveFallback
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TranslationArgument
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+class TranslatableDslTest :
+    StringSpec(
+        {
+            "builds a translatable component with a key" {
+                val component = translatable("item.minecraft.diamond")
+
+                component shouldHaveTranslationKey "item.minecraft.diamond"
+                component.shouldNotHaveFallback()
+                component shouldHaveArgumentCount 0
+            }
+
+            "applies fallback text" {
+                val component =
+                    translatable("missing.key") {
+                        fallback("Missing translation")
+                    }
+
+                component shouldHaveTranslationKey "missing.key"
+                component shouldHaveFallback "Missing translation"
+            }
+
+            "adds a component argument" {
+                val item = Component.text("Diamond")
+
+                val component =
+                    translatable("item.count") {
+                        arg(item)
+                    }
+
+                component.shouldHaveArguments(TranslationArgument.component(item))
+            }
+
+            "adds boolean and numeric arguments" {
+                val component =
+                    translatable("settings.toggle") {
+                        arg(true)
+                        arg(3)
+                    }
+
+                component.shouldHaveArguments(
+                    TranslationArgument.bool(true),
+                    TranslationArgument.numeric(3),
+                )
+            }
+
+            "adds multiple component arguments at once" {
+                val player = Component.text("Alex")
+                val item = Component.text("Diamond")
+
+                val component =
+                    translatable("chat.type.item") {
+                        args(player, item)
+                    }
+
+                component.shouldHaveArguments(
+                    TranslationArgument.component(player),
+                    TranslationArgument.component(item),
+                )
+            }
+
+            "applies style to the translatable root" {
+                val component =
+                    translatable("menu.title") {
+                        color(NamedTextColor.GOLD)
+                        bold()
+                        style {
+                            underlined()
+                        }
+                    }
+
+                component shouldHaveColor NamedTextColor.GOLD
+                component shouldHaveDecoration TextDecoration.BOLD
+                component shouldHaveDecoration TextDecoration.UNDERLINED
+            }
+
+            "appends child components" {
+                val suffix = Component.text(" unlocked")
+
+                val component =
+                    translatable("advancements.toast.task") {
+                        append(suffix)
+                    }
+
+                component shouldHaveChildCount 1
+                component.childAt(0) shouldBe suffix
+            }
+
+            "combines fallback arguments style and children" {
+                val player = Component.text("Alex")
+                val suffix = Component.text("!")
+
+                val component =
+                    translatable("quest.progress") {
+                        fallback("Quest progress")
+                        arg(player)
+                        arg(false)
+                        arg(12.5)
+                        color(NamedTextColor.AQUA)
+                        italic()
+                        append(suffix)
+                    }
+
+                component shouldHaveTranslationKey "quest.progress"
+                component shouldHaveFallback "Quest progress"
+                component.shouldHaveArguments(
+                    TranslationArgument.component(player),
+                    TranslationArgument.bool(false),
+                    TranslationArgument.numeric(12.5),
+                )
+                component shouldHaveColor NamedTextColor.AQUA
+                component shouldHaveDecoration TextDecoration.ITALIC
+                component.childAt(0) shouldBe suffix
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableDslTest.kt
@@ -76,6 +76,30 @@ class TranslatableDslTest :
                 )
             }
 
+            "adds multiple boolean arguments at once" {
+                val component =
+                    translatable("settings.flags") {
+                        args(true, false)
+                    }
+
+                component.shouldHaveArguments(
+                    TranslationArgument.bool(true),
+                    TranslationArgument.bool(false),
+                )
+            }
+
+            "adds multiple numeric arguments at once" {
+                val component =
+                    translatable("stats.values") {
+                        args(1, 2.5)
+                    }
+
+                component.shouldHaveArguments(
+                    TranslationArgument.numeric(1),
+                    TranslationArgument.numeric(2.5),
+                )
+            }
+
             "applies style to the translatable root" {
                 val component =
                     translatable("menu.title") {

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -5,6 +5,8 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.TranslatableComponent
+import net.kyori.adventure.text.TranslationArgument
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
@@ -56,6 +58,46 @@ public infix fun Component.shouldNotHaveDecoration(expected: TextDecoration): Co
 public infix fun Component.shouldHaveChildCount(expected: Int): Component =
     apply {
         this should haveChildCount(expected)
+    }
+
+/**
+ * Asserts that this component is translatable and has [expected] as its translation key.
+ */
+public infix fun Component.shouldHaveTranslationKey(expected: String): Component =
+    apply {
+        this should haveTranslationKey(expected)
+    }
+
+/**
+ * Asserts that this component is translatable and has [expected] as its fallback text.
+ */
+public infix fun Component.shouldHaveFallback(expected: String): Component =
+    apply {
+        this should haveFallback(expected)
+    }
+
+/**
+ * Asserts that this component is translatable and has no fallback text.
+ */
+public fun Component.shouldNotHaveFallback(): Component =
+    apply {
+        this should haveNoFallback()
+    }
+
+/**
+ * Asserts that this component is translatable and has exactly [expected] translation arguments.
+ */
+public infix fun Component.shouldHaveArgumentCount(expected: Int): Component =
+    apply {
+        this should haveArgumentCount(expected)
+    }
+
+/**
+ * Asserts that this component is translatable and has exactly [expected] translation arguments in order.
+ */
+public fun Component.shouldHaveArguments(vararg expected: TranslationArgument): Component =
+    apply {
+        this should haveArguments(expected.toList())
     }
 
 /**
@@ -138,3 +180,56 @@ private fun haveChildCount(expected: Int): Matcher<Component> =
             { "Expected child component count not to be <$expected>." },
         )
     }
+
+private fun haveTranslationKey(expected: String): Matcher<Component> =
+    Matcher { value ->
+        val actual = value.translatableOrNull()?.key()
+        MatcherResult(
+            actual == expected,
+            { "Expected translation key <$expected>, but was <${actual ?: "not translatable"}>." },
+            { "Expected translation key not to be <$expected>." },
+        )
+    }
+
+private fun haveFallback(expected: String): Matcher<Component> =
+    Matcher { value ->
+        val actual = value.translatableOrNull()?.fallback()
+        MatcherResult(
+            actual == expected,
+            { "Expected translatable fallback <$expected>, but was <${actual ?: "null"}>." },
+            { "Expected translatable fallback not to be <$expected>." },
+        )
+    }
+
+private fun haveNoFallback(): Matcher<Component> =
+    Matcher { value ->
+        val translatable = value.translatableOrNull()
+        val actual = translatable?.fallback()
+        MatcherResult(
+            translatable != null && actual == null,
+            { "Expected translatable fallback to be absent, but was <${actual ?: "not translatable"}>." },
+            { "Expected translatable fallback to be present." },
+        )
+    }
+
+private fun haveArgumentCount(expected: Int): Matcher<Component> =
+    Matcher { value ->
+        val actual = value.translatableOrNull()?.arguments()?.size
+        MatcherResult(
+            actual == expected,
+            { "Expected <$expected> translation arguments, but found <${actual ?: "not translatable"}>." },
+            { "Expected translation argument count not to be <$expected>." },
+        )
+    }
+
+private fun haveArguments(expected: List<TranslationArgument>): Matcher<Component> =
+    Matcher { value ->
+        val actual = value.translatableOrNull()?.arguments()
+        MatcherResult(
+            actual == expected,
+            { "Expected translation arguments <$expected>, but found <${actual ?: "not translatable"}>." },
+            { "Expected translation arguments not to be <$expected>." },
+        )
+    }
+
+private fun Component.translatableOrNull(): TranslatableComponent? = this as? TranslatableComponent

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -193,10 +193,12 @@ private fun haveTranslationKey(expected: String): Matcher<Component> =
 
 private fun haveFallback(expected: String): Matcher<Component> =
     Matcher { value ->
-        val actual = value.translatableOrNull()?.fallback()
+        val translatable = value.translatableOrNull()
+        val actual = translatable?.fallback()
+        val actualDescription = if (translatable == null) "not translatable" else actual ?: "null"
         MatcherResult(
-            actual == expected,
-            { "Expected translatable fallback <$expected>, but was <${actual ?: "null"}>." },
+            translatable != null && actual == expected,
+            { "Expected translatable fallback <$expected>, but was <$actualDescription>." },
             { "Expected translatable fallback not to be <$expected>." },
         )
     }

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.string.shouldContain
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TranslationArgument
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextDecoration
@@ -158,6 +159,106 @@ class ComponentMatchersTest :
                         Component.text("Hello").childAt(0)
                     }
                 val expectedMessage = "Expected child at index <0>, but component has <0> children."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "matches translatable component keys" {
+                Component.translatable("item.minecraft.diamond") shouldHaveTranslationKey "item.minecraft.diamond"
+            }
+
+            "reports translation key mismatch with expected and actual keys" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.translatable("item.minecraft.diamond") shouldHaveTranslationKey
+                            "item.minecraft.emerald"
+                    }
+                val expectedMessage =
+                    "Expected translation key <item.minecraft.emerald>, " +
+                            "but was <item.minecraft.diamond>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "matches translatable fallback text" {
+                Component.translatable("missing.key", "Missing key") shouldHaveFallback "Missing key"
+            }
+
+            "reports fallback mismatch with expected and actual fallback text" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.translatable("missing.key", "Missing key") shouldHaveFallback "Other fallback"
+                    }
+                val expectedMessage =
+                    "Expected translatable fallback <Other fallback>, " +
+                            "but was <Missing key>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "matches absent translatable fallback text" {
+                Component.translatable("missing.key").shouldNotHaveFallback()
+            }
+
+            "reports unexpected translatable fallback text" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.translatable("missing.key", "Missing key").shouldNotHaveFallback()
+                    }
+                val expectedMessage = "Expected translatable fallback to be absent, but was <Missing key>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports absent fallback checks on non-translatable components" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("plain").shouldNotHaveFallback()
+                    }
+                val expectedMessage = "Expected translatable fallback to be absent, but was <not translatable>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "matches translatable argument counts" {
+                val argument = TranslationArgument.component(Component.text("Diamond"))
+
+                Component.translatable("item.count", null as String?, argument) shouldHaveArgumentCount 1
+            }
+
+            "reports argument count mismatch with expected and actual counts" {
+                val argument = TranslationArgument.component(Component.text("Diamond"))
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.translatable("item.count", null as String?, argument) shouldHaveArgumentCount 2
+                    }
+                val expectedMessage = "Expected <2> translation arguments, but found <1>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "matches translatable arguments exactly" {
+                val item = TranslationArgument.component(Component.text("Diamond"))
+                val amount = TranslationArgument.numeric(3)
+
+                Component.translatable("item.count", null as String?, item, amount).shouldHaveArguments(item, amount)
+            }
+
+            "reports argument mismatch with expected and actual arguments" {
+                val item = TranslationArgument.component(Component.text("Diamond"))
+                val actualAmount = TranslationArgument.numeric(3)
+                val expectedAmount = TranslationArgument.numeric(4)
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component
+                            .translatable("item.count", null as String?, item, actualAmount)
+                            .shouldHaveArguments(item, expectedAmount)
+                    }
+                val expectedMessage =
+                    "Expected translation arguments <${listOf(item, expectedAmount)}>, " +
+                            "but found <${listOf(item, actualAmount)}>."
 
                 failure.message shouldContain expectedMessage
             }

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -196,6 +196,16 @@ class ComponentMatchersTest :
                 failure.message shouldContain expectedMessage
             }
 
+            "reports fallback checks on non-translatable components" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("plain") shouldHaveFallback "Missing key"
+                    }
+                val expectedMessage = "Expected translatable fallback <Missing key>, but was <not translatable>."
+
+                failure.message shouldContain expectedMessage
+            }
+
             "matches absent translatable fallback text" {
                 Component.translatable("missing.key").shouldNotHaveFallback()
             }


### PR DESCRIPTION
## Summary

Adds the core `translatable("key") { ... }` DSL for Adventure `TranslatableComponent` construction, including fallback text, typed component/boolean/numeric arguments, root styling, and child component appending.

## Related Issues

Closes #16

## DSL Impact

Consumers can now build client-side translation components directly from `kotventure-core`:

```kotlin
val itemCount = translatable("item.count") {
    fallback("You have an item stack")
    arg(Component.text("Diamond", NamedTextColor.AQUA))
    arg(3)
}
```

The `kotventure-test` module also gains translatable matchers for keys, fallbacks, argument counts, and exact argument lists.

## Rationale

Translatable components are the backbone for client-side i18n and feed the later translation-store work without mixing registry concerns into this slice. This keeps the builder focused on wrapping Adventure 5.1.1 component APIs.

## Testing

- Added `TranslatableDslTest` for key-only, fallback, component argument, boolean argument, numeric argument, bulk component args, styling, child appending, and combined behavior.
- Added matcher tests for translatable key, fallback, missing fallback, argument count, exact arguments, and non-translatable fallback failure messages.
- Ran `./gradlew ktlintFormat`.
- Ran `./gradlew :test:test :core:test`.
- Ran `./gradlew build`.

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run (`TranslatableDslTest` covers the README example shape; full `./gradlew build` passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a translatable component DSL: translation keys, fallback text, typed arguments (component/boolean/number), root styling, decorations, and appending child components.

* **Tests**
  * Added test assertions and suites to validate translation keys, fallback presence/absence, argument counts/order, styling, and appended children.

* **Documentation**
  * Updated CHANGELOG and README to document the new DSL and test matchers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->