### PR TITLE
feat(core): add block, entity and storage nbt components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 - Keybind, score, and selector component DSL support, including selector separators, root styling, and nested child
   builders.
 - Keybind, score, and selector component matchers for dogfooding the new DSL output.
+- Block, entity, and storage NBT component DSL support, including interpretation, separators, root styling, nested child
+  builders, and NBT-specific test matchers.
 
 ## [0.0.1] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ val onlinePlayers = selector("@a") {
     }
 }
 
+val blockLoot = blockNbt(BlockNBTComponent.Pos.fromString("1 64 1"), "Items[0].id")
+
+val playerName = entityNbt("@p", "CustomName") {
+    interpret(true)
+}
+
 val storedTitle = storageNbt(Key.key("kotventure", "messages"), "welcome.title") {
     interpret(true)
     separator(Component.text(", "))

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ val onlinePlayers = selector("@a") {
         color(NamedTextColor.GRAY)
     }
 }
+
+val storedTitle = storageNbt(Key.key("kotventure", "messages"), "welcome.title") {
+    interpret(true)
+    separator(Component.text(", "))
+}
 ```
 
 `AdventureDsl` stores typed extension registrations for MiniMessage tag providers, theme providers, animation drivers,
@@ -128,7 +133,7 @@ val plain = message.toPlainText()
 `kotventure-test` starts the testing toolkit with structural component matchers such as `shouldContainText`,
 `shouldHaveColor`, `shouldHaveDecoration`, `shouldNotHaveDecoration`, `shouldHaveChildCount`, and translatable-specific
 assertions for keys, fallbacks, and arguments. It also includes keybind, score, and selector assertions for the smaller
-component DSLs.
+component DSLs, plus block, entity, and storage NBT assertions.
 
 ---
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -103,6 +103,7 @@ val msg = component {
     keybind("key.jump") { color(YELLOW) }
     score("Alex", "kills")
     selector("@a") { separator { content(", ") } }
+    storageNbt(Key.key("kotventure", "messages"), "motd") { interpret(true) }
     mini("<gradient:gold:red>Epic</gradient>")
 }
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -103,6 +103,8 @@ val msg = component {
     keybind("key.jump") { color(YELLOW) }
     score("Alex", "kills")
     selector("@a") { separator { content(", ") } }
+    blockNbt(BlockNBTComponent.Pos.fromString("1 64 1"), "Items[0].id")
+    entityNbt("@p", "CustomName") { interpret(true) }
     storageNbt(Key.key("kotventure", "messages"), "motd") { interpret(true) }
     mini("<gradient:gold:red>Epic</gradient>")
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScope.kt
@@ -2,11 +2,16 @@ package io.github.lmliam.kotventure.core.component
 
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
 import io.github.lmliam.kotventure.core.keybind.KeybindScope
+import io.github.lmliam.kotventure.core.nbt.BlockNbtScope
+import io.github.lmliam.kotventure.core.nbt.EntityNbtScope
+import io.github.lmliam.kotventure.core.nbt.StorageNbtScope
 import io.github.lmliam.kotventure.core.score.ScoreScope
 import io.github.lmliam.kotventure.core.selector.SelectorScope
 import io.github.lmliam.kotventure.core.style.StyleScope
 import io.github.lmliam.kotventure.core.text.TextScope
 import io.github.lmliam.kotventure.core.translatable.TranslatableScope
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.BlockNBTComponent
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
@@ -116,5 +121,32 @@ public interface ComponentScope {
     public fun selector(
         pattern: String,
         init: SelectorScope.() -> Unit = {},
+    )
+
+    /**
+     * Appends a nested block NBT child with [pos] and [nbtPath].
+     */
+    public fun blockNbt(
+        pos: BlockNBTComponent.Pos,
+        nbtPath: String,
+        init: BlockNbtScope.() -> Unit = {},
+    )
+
+    /**
+     * Appends a nested entity NBT child with [selector] and [nbtPath].
+     */
+    public fun entityNbt(
+        selector: String,
+        nbtPath: String,
+        init: EntityNbtScope.() -> Unit = {},
+    )
+
+    /**
+     * Appends a nested storage NBT child with [storage] and [nbtPath].
+     */
+    public fun storageNbt(
+        storage: Key,
+        nbtPath: String,
+        init: StorageNbtScope.() -> Unit = {},
     )
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScopeBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScopeBuilder.kt
@@ -1,18 +1,26 @@
 package io.github.lmliam.kotventure.core.component
 
 import io.github.lmliam.kotventure.core.keybind.KeybindScope
+import io.github.lmliam.kotventure.core.nbt.BlockNbtScope
+import io.github.lmliam.kotventure.core.nbt.EntityNbtScope
+import io.github.lmliam.kotventure.core.nbt.StorageNbtScope
 import io.github.lmliam.kotventure.core.score.ScoreScope
 import io.github.lmliam.kotventure.core.selector.SelectorScope
 import io.github.lmliam.kotventure.core.style.StyleScope
 import io.github.lmliam.kotventure.core.text.TextComponentBuilder
 import io.github.lmliam.kotventure.core.text.TextScope
 import io.github.lmliam.kotventure.core.translatable.TranslatableScope
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.BlockNBTComponent
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentBuilder
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
 import io.github.lmliam.kotventure.core.keybind.keybind as keybindComponent
+import io.github.lmliam.kotventure.core.nbt.blockNbt as blockNbtComponent
+import io.github.lmliam.kotventure.core.nbt.entityNbt as entityNbtComponent
+import io.github.lmliam.kotventure.core.nbt.storageNbt as storageNbtComponent
 import io.github.lmliam.kotventure.core.score.score as scoreComponent
 import io.github.lmliam.kotventure.core.selector.selector as selectorComponent
 import io.github.lmliam.kotventure.core.translatable.translatable as translatableComponent
@@ -105,6 +113,30 @@ internal abstract class ComponentScopeBuilder<C : Component, B : ComponentBuilde
         init: SelectorScope.() -> Unit,
     ) {
         append(selectorComponent(pattern, init))
+    }
+
+    override fun blockNbt(
+        pos: BlockNBTComponent.Pos,
+        nbtPath: String,
+        init: BlockNbtScope.() -> Unit,
+    ) {
+        append(blockNbtComponent(pos, nbtPath, init))
+    }
+
+    override fun entityNbt(
+        selector: String,
+        nbtPath: String,
+        init: EntityNbtScope.() -> Unit,
+    ) {
+        append(entityNbtComponent(selector, nbtPath, init))
+    }
+
+    override fun storageNbt(
+        storage: Key,
+        nbtPath: String,
+        init: StorageNbtScope.() -> Unit,
+    ) {
+        append(storageNbtComponent(storage, nbtPath, init))
     }
 
     internal open fun build(): Component = builder.build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockNbt.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockNbt.kt
@@ -1,0 +1,13 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import net.kyori.adventure.text.BlockNBTComponent
+import net.kyori.adventure.text.Component
+
+/**
+ * Builds an Adventure block NBT [Component] from a Kotventure DSL block.
+ */
+public fun blockNbt(
+    pos: BlockNBTComponent.Pos,
+    nbtPath: String,
+    init: BlockNbtScope.() -> Unit = {},
+): Component = BlockNbtComponentBuilder(pos, nbtPath).apply(init).build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockNbtComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockNbtComponentBuilder.kt
@@ -7,9 +7,6 @@ internal class BlockNbtComponentBuilder(
     pos: BlockNBTComponent.Pos,
     nbtPath: String,
 ) : NbtComponentBuilder<BlockNBTComponent, BlockNBTComponent.Builder>(
-        Component
-            .blockNBT()
-            .pos(pos)
-            .nbtPath(nbtPath),
-    ),
+    Component.blockNBT().pos(pos).nbtPath(nbtPath),
+),
     BlockNbtScope

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockNbtComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockNbtComponentBuilder.kt
@@ -1,0 +1,15 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import net.kyori.adventure.text.BlockNBTComponent
+import net.kyori.adventure.text.Component
+
+internal class BlockNbtComponentBuilder(
+    pos: BlockNBTComponent.Pos,
+    nbtPath: String,
+) : NbtComponentBuilder<BlockNBTComponent, BlockNBTComponent.Builder>(
+        Component
+            .blockNBT()
+            .pos(pos)
+            .nbtPath(nbtPath),
+    ),
+    BlockNbtScope

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockNbtScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockNbtScope.kt
@@ -1,0 +1,6 @@
+package io.github.lmliam.kotventure.core.nbt
+
+/**
+ * Scope for configuring a block NBT component with style, children, interpretation, and separators.
+ */
+public interface BlockNbtScope : NbtScope

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/EntityNbt.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/EntityNbt.kt
@@ -1,0 +1,12 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import net.kyori.adventure.text.Component
+
+/**
+ * Builds an Adventure entity NBT [Component] from a Kotventure DSL block.
+ */
+public fun entityNbt(
+    selector: String,
+    nbtPath: String,
+    init: EntityNbtScope.() -> Unit = {},
+): Component = EntityNbtComponentBuilder(selector, nbtPath).apply(init).build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/EntityNbtComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/EntityNbtComponentBuilder.kt
@@ -1,0 +1,15 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.EntityNBTComponent
+
+internal class EntityNbtComponentBuilder(
+    selector: String,
+    nbtPath: String,
+) : NbtComponentBuilder<EntityNBTComponent, EntityNBTComponent.Builder>(
+        Component
+            .entityNBT()
+            .selector(selector)
+            .nbtPath(nbtPath),
+    ),
+    EntityNbtScope

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/EntityNbtComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/EntityNbtComponentBuilder.kt
@@ -7,9 +7,6 @@ internal class EntityNbtComponentBuilder(
     selector: String,
     nbtPath: String,
 ) : NbtComponentBuilder<EntityNBTComponent, EntityNBTComponent.Builder>(
-        Component
-            .entityNBT()
-            .selector(selector)
-            .nbtPath(nbtPath),
-    ),
+    Component.entityNBT().selector(selector).nbtPath(nbtPath),
+),
     EntityNbtScope

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/EntityNbtScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/EntityNbtScope.kt
@@ -1,0 +1,6 @@
+package io.github.lmliam.kotventure.core.nbt
+
+/**
+ * Scope for configuring an entity NBT component with style, children, interpretation, and separators.
+ */
+public interface EntityNbtScope : NbtScope

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtComponentBuilder.kt
@@ -7,12 +7,10 @@ import net.kyori.adventure.text.ComponentLike
 import net.kyori.adventure.text.NBTComponent
 import net.kyori.adventure.text.NBTComponentBuilder
 
-internal abstract class NbtComponentBuilder<C, B>(
+internal abstract class NbtComponentBuilder<C : NBTComponent<C>, B : NBTComponentBuilder<C, B>>(
     builder: B,
 ) : ComponentScopeBuilder<C, B>(builder),
-    NbtScope
-    where C : NBTComponent<C>,
-          B : NBTComponentBuilder<C, B> {
+    NbtScope {
     override fun interpret(interpret: Boolean) {
         builder.interpret(interpret)
     }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtComponentBuilder.kt
@@ -1,0 +1,27 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import io.github.lmliam.kotventure.core.component.ComponentScopeBuilder
+import io.github.lmliam.kotventure.core.text.TextComponentBuilder
+import io.github.lmliam.kotventure.core.text.TextScope
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.text.NBTComponent
+import net.kyori.adventure.text.NBTComponentBuilder
+
+internal abstract class NbtComponentBuilder<C, B>(
+    builder: B,
+) : ComponentScopeBuilder<C, B>(builder),
+    NbtScope
+    where C : NBTComponent<C>,
+          B : NBTComponentBuilder<C, B> {
+    override fun interpret(interpret: Boolean) {
+        builder.interpret(interpret)
+    }
+
+    override fun separator(separator: ComponentLike) {
+        builder.separator(separator)
+    }
+
+    override fun separator(init: TextScope.() -> Unit) {
+        builder.separator(TextComponentBuilder().apply(init).build())
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtScope.kt
@@ -1,0 +1,27 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.core.text.TextScope
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Scope for configuring NBT components with interpretation, separators, style, and children.
+ */
+@KotventureDslMarker
+public interface NbtScope : ComponentScope {
+    /**
+     * Sets whether fetched NBT should be parsed as component JSON.
+     */
+    public fun interpret(interpret: Boolean)
+
+    /**
+     * Applies [separator] between multiple NBT values.
+     */
+    public fun separator(separator: ComponentLike)
+
+    /**
+     * Builds and applies an inline text separator between multiple NBT values.
+     */
+    public fun separator(init: TextScope.() -> Unit)
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/StorageNbt.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/StorageNbt.kt
@@ -1,0 +1,13 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.Component
+
+/**
+ * Builds an Adventure storage NBT [Component] from a Kotventure DSL block.
+ */
+public fun storageNbt(
+    storage: Key,
+    nbtPath: String,
+    init: StorageNbtScope.() -> Unit = {},
+): Component = StorageNbtComponentBuilder(storage, nbtPath).apply(init).build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/StorageNbtComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/StorageNbtComponentBuilder.kt
@@ -8,9 +8,6 @@ internal class StorageNbtComponentBuilder(
     storage: Key,
     nbtPath: String,
 ) : NbtComponentBuilder<StorageNBTComponent, StorageNBTComponent.Builder>(
-        Component
-            .storageNBT()
-            .storage(storage)
-            .nbtPath(nbtPath),
-    ),
+    Component.storageNBT().storage(storage).nbtPath(nbtPath),
+),
     StorageNbtScope

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/StorageNbtComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/StorageNbtComponentBuilder.kt
@@ -1,0 +1,16 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.StorageNBTComponent
+
+internal class StorageNbtComponentBuilder(
+    storage: Key,
+    nbtPath: String,
+) : NbtComponentBuilder<StorageNBTComponent, StorageNBTComponent.Builder>(
+        Component
+            .storageNBT()
+            .storage(storage)
+            .nbtPath(nbtPath),
+    ),
+    StorageNbtScope

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/StorageNbtScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/StorageNbtScope.kt
@@ -1,0 +1,6 @@
+package io.github.lmliam.kotventure.core.nbt
+
+/**
+ * Scope for configuring a storage NBT component with style, children, interpretation, and separators.
+ */
+public interface StorageNbtScope : NbtScope

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/BlockNbtDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/BlockNbtDslTest.kt
@@ -1,0 +1,98 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldBeBlockNbtComponent
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveBlockPos
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.github.lmliam.kotventure.test.text.shouldHaveNbtPath
+import io.github.lmliam.kotventure.test.text.shouldHaveNbtSeparator
+import io.github.lmliam.kotventure.test.text.shouldInterpret
+import io.github.lmliam.kotventure.test.text.shouldNotHaveNbtSeparator
+import io.github.lmliam.kotventure.test.text.shouldNotInterpret
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.BlockNBTComponent
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+class BlockNbtDslTest :
+    StringSpec(
+        {
+            "builds a block nbt component with a position and path" {
+                val pos = BlockNBTComponent.Pos.fromString("~1 ~2 ~3")
+
+                val component = blockNbt(pos, "Items[0].tag.display.Name").shouldBeBlockNbtComponent()
+
+                component shouldHaveBlockPos pos
+                component shouldHaveNbtPath "Items[0].tag.display.Name"
+                component.shouldNotInterpret()
+                component.shouldNotHaveNbtSeparator()
+            }
+
+            "applies style to the block nbt root" {
+                val component =
+                    blockNbt(BlockNBTComponent.Pos.fromString("1 2 3"), "CustomName") {
+                        color(NamedTextColor.AQUA)
+                        bold()
+                        style {
+                            underlined()
+                        }
+                    }
+
+                component shouldHaveColor NamedTextColor.AQUA
+                component shouldHaveDecoration TextDecoration.BOLD
+                component shouldHaveDecoration TextDecoration.UNDERLINED
+            }
+
+            "appends child components" {
+                val suffix = Component.text(" block")
+
+                val component =
+                    blockNbt(BlockNBTComponent.Pos.fromString("1 2 3"), "CustomName") {
+                        append(suffix)
+                    }
+
+                component shouldHaveChildCount 1
+                component.childAt(0) shouldBe suffix
+            }
+
+            "sets interpret true" {
+                val component =
+                    blockNbt(BlockNBTComponent.Pos.fromString("1 2 3"), "CustomName") {
+                        interpret(true)
+                    }
+
+                component.shouldBeBlockNbtComponent().shouldInterpret()
+            }
+
+            "sets a component separator" {
+                val separator = Component.text(", ")
+
+                val component =
+                    blockNbt(BlockNBTComponent.Pos.fromString("1 2 3"), "Items[].id") {
+                        separator(separator)
+                    }
+
+                component.shouldBeBlockNbtComponent() shouldHaveNbtSeparator separator
+            }
+
+            "sets an inline text separator" {
+                val component =
+                    blockNbt(BlockNBTComponent.Pos.fromString("1 2 3"), "Items[].id") {
+                        separator {
+                            content(" | ")
+                            color(NamedTextColor.GRAY)
+                        }
+                    }
+
+                val separator = checkNotNull(component.shouldBeBlockNbtComponent().separator())
+
+                separator shouldHaveColor NamedTextColor.GRAY
+                separator shouldContainText " | "
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/EntityNbtDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/EntityNbtDslTest.kt
@@ -1,0 +1,95 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldBeEntityNbtComponent
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.github.lmliam.kotventure.test.text.shouldHaveEntitySelector
+import io.github.lmliam.kotventure.test.text.shouldHaveNbtPath
+import io.github.lmliam.kotventure.test.text.shouldHaveNbtSeparator
+import io.github.lmliam.kotventure.test.text.shouldInterpret
+import io.github.lmliam.kotventure.test.text.shouldNotHaveNbtSeparator
+import io.github.lmliam.kotventure.test.text.shouldNotInterpret
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+class EntityNbtDslTest :
+    StringSpec(
+        {
+            "builds an entity nbt component with a selector and path" {
+                val component = entityNbt("@p", "Inventory[0].tag.display.Name").shouldBeEntityNbtComponent()
+
+                component shouldHaveEntitySelector "@p"
+                component shouldHaveNbtPath "Inventory[0].tag.display.Name"
+                component.shouldNotInterpret()
+                component.shouldNotHaveNbtSeparator()
+            }
+
+            "applies style to the entity nbt root" {
+                val component =
+                    entityNbt("@r", "CustomName") {
+                        color(NamedTextColor.AQUA)
+                        bold()
+                        style {
+                            underlined()
+                        }
+                    }
+
+                component shouldHaveColor NamedTextColor.AQUA
+                component shouldHaveDecoration TextDecoration.BOLD
+                component shouldHaveDecoration TextDecoration.UNDERLINED
+            }
+
+            "appends child components" {
+                val suffix = Component.text(" entity")
+
+                val component =
+                    entityNbt("@p", "CustomName") {
+                        append(suffix)
+                    }
+
+                component shouldHaveChildCount 1
+                component.childAt(0) shouldBe suffix
+            }
+
+            "sets interpret true" {
+                val component =
+                    entityNbt("@p", "CustomName") {
+                        interpret(true)
+                    }
+
+                component.shouldBeEntityNbtComponent().shouldInterpret()
+            }
+
+            "sets a component separator" {
+                val separator = Component.text(", ")
+
+                val component =
+                    entityNbt("@a", "Inventory[].id") {
+                        separator(separator)
+                    }
+
+                component.shouldBeEntityNbtComponent() shouldHaveNbtSeparator separator
+            }
+
+            "sets an inline text separator" {
+                val component =
+                    entityNbt("@a", "Inventory[].id") {
+                        separator {
+                            content(" | ")
+                            color(NamedTextColor.GRAY)
+                        }
+                    }
+
+                val separator = checkNotNull(component.shouldBeEntityNbtComponent().separator())
+
+                separator shouldHaveColor NamedTextColor.GRAY
+                separator shouldContainText " | "
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/StorageNbtDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/StorageNbtDslTest.kt
@@ -1,0 +1,98 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldBeStorageNbtComponent
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.github.lmliam.kotventure.test.text.shouldHaveNbtPath
+import io.github.lmliam.kotventure.test.text.shouldHaveNbtSeparator
+import io.github.lmliam.kotventure.test.text.shouldHaveStorageKey
+import io.github.lmliam.kotventure.test.text.shouldInterpret
+import io.github.lmliam.kotventure.test.text.shouldNotHaveNbtSeparator
+import io.github.lmliam.kotventure.test.text.shouldNotInterpret
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+class StorageNbtDslTest :
+    StringSpec(
+        {
+            "builds a storage nbt component with a key and path" {
+                val storage = Key.key("kotventure", "messages")
+
+                val component = storageNbt(storage, "welcome.title").shouldBeStorageNbtComponent()
+
+                component shouldHaveStorageKey storage
+                component shouldHaveNbtPath "welcome.title"
+                component.shouldNotInterpret()
+                component.shouldNotHaveNbtSeparator()
+            }
+
+            "applies style to the storage nbt root" {
+                val component =
+                    storageNbt(Key.key("kotventure", "messages"), "welcome.title") {
+                        color(NamedTextColor.AQUA)
+                        bold()
+                        style {
+                            underlined()
+                        }
+                    }
+
+                component shouldHaveColor NamedTextColor.AQUA
+                component shouldHaveDecoration TextDecoration.BOLD
+                component shouldHaveDecoration TextDecoration.UNDERLINED
+            }
+
+            "appends child components" {
+                val suffix = Component.text(" storage")
+
+                val component =
+                    storageNbt(Key.key("kotventure", "messages"), "welcome.title") {
+                        append(suffix)
+                    }
+
+                component shouldHaveChildCount 1
+                component.childAt(0) shouldBe suffix
+            }
+
+            "sets interpret true" {
+                val component =
+                    storageNbt(Key.key("kotventure", "messages"), "welcome.title") {
+                        interpret(true)
+                    }
+
+                component.shouldBeStorageNbtComponent().shouldInterpret()
+            }
+
+            "sets a component separator" {
+                val separator = Component.text(", ")
+
+                val component =
+                    storageNbt(Key.key("kotventure", "messages"), "entries[].id") {
+                        separator(separator)
+                    }
+
+                component.shouldBeStorageNbtComponent() shouldHaveNbtSeparator separator
+            }
+
+            "sets an inline text separator" {
+                val component =
+                    storageNbt(Key.key("kotventure", "messages"), "entries[].id") {
+                        separator {
+                            content(" | ")
+                            color(NamedTextColor.GRAY)
+                        }
+                    }
+
+                val separator = checkNotNull(component.shouldBeStorageNbtComponent().separator())
+
+                separator shouldHaveColor NamedTextColor.GRAY
+                separator shouldContainText " | "
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
@@ -4,24 +4,33 @@ import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
 import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldBeBlockNbtComponent
+import io.github.lmliam.kotventure.test.text.shouldBeEntityNbtComponent
 import io.github.lmliam.kotventure.test.text.shouldBeKeybindComponent
 import io.github.lmliam.kotventure.test.text.shouldBeScoreComponent
 import io.github.lmliam.kotventure.test.text.shouldBeSelectorComponent
+import io.github.lmliam.kotventure.test.text.shouldBeStorageNbtComponent
 import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveBlockPos
 import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.github.lmliam.kotventure.test.text.shouldHaveEntitySelector
 import io.github.lmliam.kotventure.test.text.shouldHaveKeybind
+import io.github.lmliam.kotventure.test.text.shouldHaveNbtPath
 import io.github.lmliam.kotventure.test.text.shouldHaveScoreName
 import io.github.lmliam.kotventure.test.text.shouldHaveScoreObjective
 import io.github.lmliam.kotventure.test.text.shouldHaveSelectorPattern
 import io.github.lmliam.kotventure.test.text.shouldHaveSelectorSeparator
+import io.github.lmliam.kotventure.test.text.shouldHaveStorageKey
 import io.github.lmliam.kotventure.test.text.shouldHaveStyle
 import io.github.lmliam.kotventure.test.text.shouldHaveTranslationKey
 import io.github.lmliam.kotventure.test.text.shouldNotHaveDecoration
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.BlockNBTComponent
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.Style
@@ -145,6 +154,29 @@ class ComponentDslTest :
                 val selector = component.childAt(3).shouldBeSelectorComponent()
                 selector shouldHaveSelectorPattern "@a"
                 selector shouldHaveSelectorSeparator separator
+            }
+
+            "appends nbt component children in declaration order" {
+                val pos = BlockNBTComponent.Pos.fromString("1 2 3")
+                val storage = Key.key("kotventure", "messages")
+
+                val component =
+                    component {
+                        blockNbt(pos, "Items[0].id")
+                        entityNbt("@p", "Inventory[0].id")
+                        storageNbt(storage, "entries[0].id")
+                    }
+
+                component shouldHaveChildCount 3
+                val blockNbt = component.childAt(0).shouldBeBlockNbtComponent()
+                blockNbt shouldHaveBlockPos pos
+                blockNbt shouldHaveNbtPath "Items[0].id"
+                val entityNbt = component.childAt(1).shouldBeEntityNbtComponent()
+                entityNbt shouldHaveEntitySelector "@p"
+                entityNbt shouldHaveNbtPath "Inventory[0].id"
+                val storageNbt = component.childAt(2).shouldBeStorageNbtComponent()
+                storageNbt shouldHaveStorageKey storage
+                storageNbt shouldHaveNbtPath "entries[0].id"
             }
 
             "applies a complete Adventure style" {

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -3,10 +3,15 @@ package io.github.lmliam.kotventure.test.text
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.BlockNBTComponent
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.EntityNBTComponent
 import net.kyori.adventure.text.KeybindComponent
+import net.kyori.adventure.text.NBTComponent
 import net.kyori.adventure.text.ScoreComponent
 import net.kyori.adventure.text.SelectorComponent
+import net.kyori.adventure.text.StorageNBTComponent
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.TranslatableComponent
 import net.kyori.adventure.text.TranslationArgument
@@ -164,6 +169,85 @@ public infix fun SelectorComponent.shouldHaveSelectorSeparator(expected: Compone
 public fun SelectorComponent.shouldNotHaveSelectorSeparator(): SelectorComponent =
     apply {
         this should haveNoSelectorSeparator()
+    }
+
+/**
+ * Asserts that this component is a [BlockNBTComponent] and returns it typed.
+ */
+public fun Component.shouldBeBlockNbtComponent(): BlockNBTComponent = shouldBeComponentType("block NBT")
+
+/**
+ * Asserts that this component is an [EntityNBTComponent] and returns it typed.
+ */
+public fun Component.shouldBeEntityNbtComponent(): EntityNBTComponent = shouldBeComponentType("entity NBT")
+
+/**
+ * Asserts that this component is a [StorageNBTComponent] and returns it typed.
+ */
+public fun Component.shouldBeStorageNbtComponent(): StorageNBTComponent = shouldBeComponentType("storage NBT")
+
+/**
+ * Asserts that this NBT component has [expected] as its NBT path.
+ */
+public infix fun NBTComponent<*>.shouldHaveNbtPath(expected: String): NBTComponent<*> =
+    apply {
+        this should haveNbtPath(expected)
+    }
+
+/**
+ * Asserts that this NBT component interprets fetched NBT as component JSON.
+ */
+public fun NBTComponent<*>.shouldInterpret(): NBTComponent<*> =
+    apply {
+        this should haveInterpretState(true)
+    }
+
+/**
+ * Asserts that this NBT component does not interpret fetched NBT as component JSON.
+ */
+public fun NBTComponent<*>.shouldNotInterpret(): NBTComponent<*> =
+    apply {
+        this should haveInterpretState(false)
+    }
+
+/**
+ * Asserts that this NBT component has [expected] as its separator.
+ */
+public infix fun NBTComponent<*>.shouldHaveNbtSeparator(expected: Component): NBTComponent<*> =
+    apply {
+        this should haveNbtSeparator(expected)
+    }
+
+/**
+ * Asserts that this NBT component has no separator.
+ */
+public fun NBTComponent<*>.shouldNotHaveNbtSeparator(): NBTComponent<*> =
+    apply {
+        this should haveNoNbtSeparator()
+    }
+
+/**
+ * Asserts that this block NBT component has [expected] as its block position.
+ */
+public infix fun BlockNBTComponent.shouldHaveBlockPos(expected: BlockNBTComponent.Pos): BlockNBTComponent =
+    apply {
+        this should haveBlockPos(expected)
+    }
+
+/**
+ * Asserts that this entity NBT component has [expected] as its selector.
+ */
+public infix fun EntityNBTComponent.shouldHaveEntitySelector(expected: String): EntityNBTComponent =
+    apply {
+        this should haveEntitySelector(expected)
+    }
+
+/**
+ * Asserts that this storage NBT component has [expected] as its storage key.
+ */
+public infix fun StorageNBTComponent.shouldHaveStorageKey(expected: Key): StorageNBTComponent =
+    apply {
+        this should haveStorageKey(expected)
     }
 
 /**
@@ -362,6 +446,76 @@ private fun haveNoSelectorSeparator(): Matcher<SelectorComponent> =
             actual == null,
             { "Expected selector separator to be absent, but was <${actual ?: "null"}>." },
             { "Expected selector separator to be present." },
+        )
+    }
+
+private fun haveNbtPath(expected: String): Matcher<NBTComponent<*>> =
+    Matcher { value ->
+        val actual = value.nbtPath()
+        MatcherResult(
+            actual == expected,
+            { "Expected NBT path <$expected>, but was <$actual>." },
+            { "Expected NBT path not to be <$expected>." },
+        )
+    }
+
+private fun haveInterpretState(expected: Boolean): Matcher<NBTComponent<*>> =
+    Matcher { value ->
+        val actual = value.interpret()
+        MatcherResult(
+            actual == expected,
+            { "Expected NBT interpret to be <$expected>, but was <$actual>." },
+            { "Expected NBT interpret not to be <$expected>." },
+        )
+    }
+
+private fun haveNbtSeparator(expected: Component): Matcher<NBTComponent<*>> =
+    Matcher { value ->
+        val actual = value.separator()
+        MatcherResult(
+            actual == expected,
+            { "Expected NBT separator <$expected>, but was <${actual ?: "null"}>." },
+            { "Expected NBT separator not to be <$expected>." },
+        )
+    }
+
+private fun haveNoNbtSeparator(): Matcher<NBTComponent<*>> =
+    Matcher { value ->
+        val actual = value.separator()
+        MatcherResult(
+            actual == null,
+            { "Expected NBT separator to be absent, but was <${actual ?: "null"}>." },
+            { "Expected NBT separator to be present." },
+        )
+    }
+
+private fun haveBlockPos(expected: BlockNBTComponent.Pos): Matcher<BlockNBTComponent> =
+    Matcher { value ->
+        val actual = value.pos()
+        MatcherResult(
+            actual == expected,
+            { "Expected block NBT position <${expected.asString()}>, but was <${actual.asString()}>." },
+            { "Expected block NBT position not to be <${expected.asString()}>." },
+        )
+    }
+
+private fun haveEntitySelector(expected: String): Matcher<EntityNBTComponent> =
+    Matcher { value ->
+        val actual = value.selector()
+        MatcherResult(
+            actual == expected,
+            { "Expected entity NBT selector <$expected>, but was <$actual>." },
+            { "Expected entity NBT selector not to be <$expected>." },
+        )
+    }
+
+private fun haveStorageKey(expected: Key): Matcher<StorageNBTComponent> =
+    Matcher { value ->
+        val actual = value.storage()
+        MatcherResult(
+            actual == expected,
+            { "Expected storage NBT key <$expected>, but was <$actual>." },
+            { "Expected storage NBT key not to be <$expected>." },
         )
     }
 


### PR DESCRIPTION
## Summary

Adds block, entity, and storage NBT component DSL builders backed by Adventure 5.1.1 NBT builders, plus shared NBT scope infrastructure and test matchers.

## Related Issues

Closes #18

## DSL Impact

- Adds top-level `blockNbt(pos, nbtPath)`, `entityNbt(selector, nbtPath)`, and `storageNbt(storage, nbtPath)` entry points.
- Adds `interpret(Boolean)` and `separator(...)` support for all NBT builders.
- Allows NBT components to be nested inside any `component {}` / component scope block.

## Rationale

NBT components are part of Adventure core component coverage and let downstream plugin authors display block, entity, and command-storage NBT through the same typed Kotventure DSL as other component kinds.

## Testing

- Added NBT DSL specs for block, entity, and storage components covering sources, paths, styling, children, interpretation, and separator overloads.
- Added component-scope nesting coverage for all three NBT component kinds.
- Ran `./gradlew ktlintFormat`.
- Ran `./gradlew build`.
- Ran `./gradlew ktlintCheck spotlessCheck`.

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DSL support for Block NBT components with position and path configuration
  * Added DSL support for Entity NBT components with selector and path configuration
  * Added DSL support for Storage NBT components with key and path configuration
  * All NBT components support interpretation toggling and custom separators
  * Added test matchers for asserting NBT component properties

<!-- end of auto-generated comment: release notes by coderabbit.ai -->