### PR TITLE
feat(core): add block nbt position helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 - Keybind, score, and selector component matchers for dogfooding the new DSL output.
 - Block, entity, and storage NBT component DSL support, including interpretation, separators, root styling, nested child
   builders, and NBT-specific test matchers.
+- Block NBT position helper functions for absolute, relative, and string-parsed coordinates.
 
 ## [0.0.1] - 2026-06-08
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -103,7 +103,7 @@ val msg = component {
     keybind("key.jump") { color(YELLOW) }
     score("Alex", "kills")
     selector("@a") { separator { content(", ") } }
-    blockNbt(BlockNBTComponent.Pos.fromString("1 64 1"), "Items[0].id")
+    blockNbt(blockPos(1, 64, 1), "Items[0].id")
     entityNbt("@p", "CustomName") { interpret(true) }
     storageNbt(Key.key("kotventure", "messages"), "motd") { interpret(true) }
     mini("<gradient:gold:red>Epic</gradient>")

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockPos.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockPos.kt
@@ -32,5 +32,7 @@ public fun relativeBlockPos(
 
 /**
  * Parses [coords] as an Adventure block NBT position.
+ *
+ * @throws IllegalArgumentException when [coords] is not a valid Adventure block position.
  */
 public fun blockPos(coords: String): BlockNBTComponent.Pos = BlockNBTComponent.Pos.fromString(coords)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockPos.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockPos.kt
@@ -1,0 +1,36 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import net.kyori.adventure.text.BlockNBTComponent
+
+/**
+ * Builds an absolute block NBT position from world coordinates.
+ */
+public fun blockPos(
+    x: Int,
+    y: Int,
+    z: Int,
+): BlockNBTComponent.Pos =
+    BlockNBTComponent.WorldPos.worldPos(
+        BlockNBTComponent.WorldPos.Coordinate.absolute(x),
+        BlockNBTComponent.WorldPos.Coordinate.absolute(y),
+        BlockNBTComponent.WorldPos.Coordinate.absolute(z),
+    )
+
+/**
+ * Builds a relative block NBT position from offsets from the current position.
+ */
+public fun relativeBlockPos(
+    dx: Int = 0,
+    dy: Int = 0,
+    dz: Int = 0,
+): BlockNBTComponent.Pos =
+    BlockNBTComponent.WorldPos.worldPos(
+        BlockNBTComponent.WorldPos.Coordinate.relative(dx),
+        BlockNBTComponent.WorldPos.Coordinate.relative(dy),
+        BlockNBTComponent.WorldPos.Coordinate.relative(dz),
+    )
+
+/**
+ * Parses [coords] as an Adventure block NBT position.
+ */
+public fun blockPos(coords: String): BlockNBTComponent.Pos = BlockNBTComponent.Pos.fromString(coords)

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/BlockPosDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/BlockPosDslTest.kt
@@ -1,5 +1,6 @@
 package io.github.lmliam.kotventure.core.nbt
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import net.kyori.adventure.text.BlockNBTComponent
@@ -31,11 +32,29 @@ class BlockPosDslTest :
                 pos.asString() shouldBe "~1 ~0 ~-2"
             }
 
+            "builds a relative block position from zero offsets by default" {
+                val pos = relativeBlockPos()
+
+                pos shouldBe
+                    BlockNBTComponent.WorldPos.worldPos(
+                        BlockNBTComponent.WorldPos.Coordinate.relative(0),
+                        BlockNBTComponent.WorldPos.Coordinate.relative(0),
+                        BlockNBTComponent.WorldPos.Coordinate.relative(0),
+                    )
+                pos.asString() shouldBe "~0 ~0 ~0"
+            }
+
             "parses a block position from a coordinate string" {
                 val pos = blockPos("~1 ~2 ~3")
 
                 pos shouldBe BlockNBTComponent.Pos.fromString("~1 ~2 ~3")
                 pos.asString() shouldBe "~1 ~2 ~3"
+            }
+
+            "throws when parsing an invalid coordinate string" {
+                shouldThrow<IllegalArgumentException> {
+                    blockPos("not coordinates")
+                }
             }
         },
     )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/BlockPosDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/BlockPosDslTest.kt
@@ -21,15 +21,15 @@ class BlockPosDslTest :
             }
 
             "builds a relative block position from integer offsets" {
-                val pos = relativeBlockPos(1, 0, -2)
+                val pos = relativeBlockPos(1, 2, -2)
 
                 pos shouldBe
                     BlockNBTComponent.WorldPos.worldPos(
                         BlockNBTComponent.WorldPos.Coordinate.relative(1),
-                        BlockNBTComponent.WorldPos.Coordinate.relative(0),
+                        BlockNBTComponent.WorldPos.Coordinate.relative(2),
                         BlockNBTComponent.WorldPos.Coordinate.relative(-2),
                     )
-                pos.asString() shouldBe "~1 ~0 ~-2"
+                pos.asString() shouldBe "~1 ~2 ~-2"
             }
 
             "builds a relative block position from zero offsets by default" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/BlockPosDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/BlockPosDslTest.kt
@@ -10,37 +10,40 @@ class BlockPosDslTest :
         {
             "builds an absolute block position from integer coordinates" {
                 val pos = blockPos(1, 64, -3)
-
-                pos shouldBe
+                val expected =
                     BlockNBTComponent.WorldPos.worldPos(
                         BlockNBTComponent.WorldPos.Coordinate.absolute(1),
                         BlockNBTComponent.WorldPos.Coordinate.absolute(64),
                         BlockNBTComponent.WorldPos.Coordinate.absolute(-3),
                     )
+
+                pos shouldBe expected
                 pos.asString() shouldBe "1 64 -3"
             }
 
             "builds a relative block position from integer offsets" {
                 val pos = relativeBlockPos(1, 2, -2)
-
-                pos shouldBe
+                val expected =
                     BlockNBTComponent.WorldPos.worldPos(
                         BlockNBTComponent.WorldPos.Coordinate.relative(1),
                         BlockNBTComponent.WorldPos.Coordinate.relative(2),
                         BlockNBTComponent.WorldPos.Coordinate.relative(-2),
                     )
+
+                pos shouldBe expected
                 pos.asString() shouldBe "~1 ~2 ~-2"
             }
 
             "builds a relative block position from zero offsets by default" {
                 val pos = relativeBlockPos()
-
-                pos shouldBe
+                val expected =
                     BlockNBTComponent.WorldPos.worldPos(
                         BlockNBTComponent.WorldPos.Coordinate.relative(0),
                         BlockNBTComponent.WorldPos.Coordinate.relative(0),
                         BlockNBTComponent.WorldPos.Coordinate.relative(0),
                     )
+
+                pos shouldBe expected
                 pos.asString() shouldBe "~0 ~0 ~0"
             }
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/BlockPosDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/BlockPosDslTest.kt
@@ -1,0 +1,41 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.BlockNBTComponent
+
+class BlockPosDslTest :
+    StringSpec(
+        {
+            "builds an absolute block position from integer coordinates" {
+                val pos = blockPos(1, 64, -3)
+
+                pos shouldBe
+                    BlockNBTComponent.WorldPos.worldPos(
+                        BlockNBTComponent.WorldPos.Coordinate.absolute(1),
+                        BlockNBTComponent.WorldPos.Coordinate.absolute(64),
+                        BlockNBTComponent.WorldPos.Coordinate.absolute(-3),
+                    )
+                pos.asString() shouldBe "1 64 -3"
+            }
+
+            "builds a relative block position from integer offsets" {
+                val pos = relativeBlockPos(1, 0, -2)
+
+                pos shouldBe
+                    BlockNBTComponent.WorldPos.worldPos(
+                        BlockNBTComponent.WorldPos.Coordinate.relative(1),
+                        BlockNBTComponent.WorldPos.Coordinate.relative(0),
+                        BlockNBTComponent.WorldPos.Coordinate.relative(-2),
+                    )
+                pos.asString() shouldBe "~1 ~0 ~-2"
+            }
+
+            "parses a block position from a coordinate string" {
+                val pos = blockPos("~1 ~2 ~3")
+
+                pos shouldBe BlockNBTComponent.Pos.fromString("~1 ~2 ~3")
+                pos.asString() shouldBe "~1 ~2 ~3"
+            }
+        },
+    )


### PR DESCRIPTION
## Summary

Adds small DSL factory helpers for `BlockNBTComponent.Pos`: absolute world coordinates, relative world offsets, and string-form parsing.

## Related Issues

Closes #113

## DSL Impact

Callers can now write `blockNbt(blockPos(1, 64, 1), "Items[0].id")`, `relativeBlockPos(...)`, or `blockPos("~1 ~2 ~3")` without reaching for the raw Adventure API.

## Rationale

This keeps the block NBT DSL self-contained for the common position cases introduced by the NBT component slice.

## Testing

- `./gradlew :core:test --tests io.github.lmliam.kotventure.core.nbt.BlockPosDslTest`
- `./gradlew ktlintFormat`
- `./gradlew build`
- `./gradlew ktlintCheck spotlessCheck`

## Checklist

- [x] Linked related issue
- [x] Updated `docs/DESIGN.md` and `CHANGELOG.md`
- [x] Verified the new DSL helpers with Kotest coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helper utilities to build NBT block positions: absolute coordinates, relative offsets with defaults, and parsing from coordinate strings.

* **Documentation**
  * Updated design example to use the new position helper.
  * Added changelog entry describing the new helpers.

* **Tests**
  * Added tests covering absolute, relative, default, string-parsed positions and invalid-input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->