### PR TITLE
feat(core): add adventure key helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 - Block, entity, and storage NBT component DSL support, including interpretation, separators, root styling, nested child
   builders, and NBT-specific test matchers.
 - Block NBT position helper functions for absolute, relative, and string-parsed coordinates.
+- Adventure Key helper functions for namespace/value pairs, infix namespace syntax, and string parsing.
 
 ## [0.0.1] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ val playerName = entityNbt("@p", "CustomName") {
     interpret(true)
 }
 
-val storedTitle = storageNbt(Key.key("kotventure", "messages"), "welcome.title") {
+val storedTitle = storageNbt(key("kotventure", "messages"), "welcome.title") {
     interpret(true)
     separator(Component.text(", "))
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -105,7 +105,7 @@ val msg = component {
     selector("@a") { separator { content(", ") } }
     blockNbt(blockPos(1, 64, 1), "Items[0].id")
     entityNbt("@p", "CustomName") { interpret(true) }
-    storageNbt(Key.key("kotventure", "messages"), "motd") { interpret(true) }
+    storageNbt(key("kotventure", "messages"), "motd") { interpret(true) }
     mini("<gradient:gold:red>Epic</gradient>")
 }
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/key/Key.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/key/Key.kt
@@ -1,0 +1,30 @@
+package io.github.lmliam.kotventure.core.key
+
+import net.kyori.adventure.key.InvalidKeyException
+import net.kyori.adventure.key.Key
+
+/**
+ * Builds an Adventure [Key] from a [namespace] and [value].
+ *
+ * @throws InvalidKeyException when [namespace] or [value] is not valid for an Adventure key.
+ */
+public fun key(
+    namespace: String,
+    value: String,
+): Key = Key.key(namespace, value)
+
+/**
+ * Builds an Adventure [Key] using this string as the namespace and [value] as the value.
+ *
+ * @throws InvalidKeyException when this namespace or [value] is not valid for an Adventure key.
+ */
+public infix fun String.namespace(value: String): Key = Key.key(this, value)
+
+/**
+ * Parses this string as an Adventure [Key].
+ *
+ * Bare values use Adventure's default `minecraft` namespace.
+ *
+ * @throws InvalidKeyException when this string is not valid for an Adventure key.
+ */
+public fun String.asKey(): Key = Key.key(this)

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/key/KeyDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/key/KeyDslTest.kt
@@ -1,7 +1,9 @@
 package io.github.lmliam.kotventure.core.key
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import net.kyori.adventure.key.InvalidKeyException
 import net.kyori.adventure.key.Key
 
 class KeyDslTest :
@@ -38,6 +40,24 @@ class KeyDslTest :
                 adventureKey shouldBe Key.key("minecraft", "stone")
                 adventureKey.namespace() shouldBe "minecraft"
                 adventureKey.value() shouldBe "stone"
+            }
+
+            "throws when building a key with an invalid namespace" {
+                shouldThrow<InvalidKeyException> {
+                    key("not valid", "messages")
+                }
+            }
+
+            "throws when building a key with infix invalid value" {
+                shouldThrow<InvalidKeyException> {
+                    "kotventure" namespace "Not Valid"
+                }
+            }
+
+            "throws when parsing an invalid key string" {
+                shouldThrow<InvalidKeyException> {
+                    "not valid:messages".asKey()
+                }
             }
         },
     )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/key/KeyDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/key/KeyDslTest.kt
@@ -1,0 +1,43 @@
+package io.github.lmliam.kotventure.core.key
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.key.Key
+
+class KeyDslTest :
+    StringSpec(
+        {
+            "builds a key from a namespace and value" {
+                val adventureKey = key("kotventure", "messages")
+
+                adventureKey shouldBe Key.key("kotventure", "messages")
+                adventureKey.namespace() shouldBe "kotventure"
+                adventureKey.value() shouldBe "messages"
+                adventureKey.asString() shouldBe "kotventure:messages"
+            }
+
+            "builds a key with infix namespace syntax" {
+                val adventureKey = "kotventure" namespace "messages"
+
+                adventureKey shouldBe key("kotventure", "messages")
+                adventureKey.namespace() shouldBe "kotventure"
+                adventureKey.value() shouldBe "messages"
+            }
+
+            "parses a key from a namespaced string" {
+                val adventureKey = "kotventure:messages".asKey()
+
+                adventureKey shouldBe Key.key("kotventure", "messages")
+                adventureKey.namespace() shouldBe "kotventure"
+                adventureKey.value() shouldBe "messages"
+            }
+
+            "uses the minecraft namespace when parsing a bare value" {
+                val adventureKey = "stone".asKey()
+
+                adventureKey shouldBe Key.key("minecraft", "stone")
+                adventureKey.namespace() shouldBe "minecraft"
+                adventureKey.value() shouldBe "stone"
+            }
+        },
+    )


### PR DESCRIPTION
## Summary

Adds idiomatic `core.key` helpers that wrap Adventure `Key` factories for namespace/value pairs, infix namespace syntax, and colon-delimited string parsing.

## Related Issues

Closes #114

## DSL Impact

Callers can use `key("kotventure", "messages")`, `"kotventure" namespace "messages"`, or `"kotventure:messages".asKey()` instead of reaching for `Key.key(...)` in DSL-facing code.

## Rationale

`Key` appears throughout Adventure features such as storage NBT, sounds, registries, and item types. Keeping the common construction forms in Kotventure's DSL surface reduces raw Adventure factory noise without reimplementing validation.

## Testing

- Added `KeyDslTest` coverage for all helper forms and Adventure's default `minecraft` namespace parsing for bare values.
- Ran `./gradlew ktlintFormat`.
- Ran `./gradlew ktlintCheck spotlessCheck`.
- Ran `./gradlew build`.

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simple helpers for creating and parsing Adventure Keys (namespace/value builder, infix namespace syntax, and string parsing) with validation and default namespace behavior.

* **Documentation**
  * Updated README and design docs examples to reflect the new key construction API.

* **Tests**
  * Added tests covering construction, parsing, default namespace behavior, and invalid-input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->