### PR TITLE
feat(core): add object component dsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
   builders, and NBT-specific test matchers.
 - Block NBT position helper functions for absolute, relative, and string-parsed coordinates.
 - Adventure Key helper functions for namespace/value pairs, infix namespace syntax, and string parsing.
+- Object component DSL support through `display(...)`, including fallback components, root styling, nested child
+  builders, explicit renderer coverage, and serializer round-trip coverage.
+- Object component matchers for asserting contents and fallback components in Kotest specs.
 
 ## [0.0.1] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
   builders, and NBT-specific test matchers.
 - Block NBT position helper functions for absolute, relative, and string-parsed coordinates.
 - Adventure Key helper functions for namespace/value pairs, infix namespace syntax, and string parsing.
-- Object component DSL support through `display(...)`, including fallback components, root styling, nested child
-  builders, explicit renderer coverage, and serializer round-trip coverage.
+- Object component DSL support through `display(...)` and `sprite(...)`, including fallback components, root styling,
+  nested child builders, explicit renderer coverage, and serializer round-trip coverage.
 - Object component matchers for asserting contents and fallback components in Kotest specs.
 
 ## [0.0.1] - 2026-06-08

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ val stoneIcon = display(ObjectContents.sprite(key("minecraft", "block/stone"))) 
 
 Use `display` for Adventure object components such as sprites where the client can render structured non-text
 content. Provide a fallback when the component might appear in places that do not support object components, such
-as server MOTDs or plain-text logs.
+as server MOTDs or plain-text logs. Call `stoneIcon.renderObjectFallbacks()` before handing the component to renderer
+paths that should replace configured object fallbacks with regular components.
 
 `AdventureDsl` stores typed extension registrations for MiniMessage tag providers, theme providers, animation drivers,
 and the active platform adapter. Registration is explicit at startup; there is no classpath scanning.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,17 @@ val storedTitle = storageNbt(key("kotventure", "messages"), "welcome.title") {
     interpret(true)
     separator(Component.text(", "))
 }
+
+val stoneIcon = display(ObjectContents.sprite(key("minecraft", "block/stone"))) {
+    fallback {
+        text("[stone]")
+    }
+}
 ```
+
+Use `display` for Adventure object components such as sprites where the client can render structured non-text
+content. Provide a fallback when the component might appear in places that do not support object components, such
+as server MOTDs or plain-text logs.
 
 `AdventureDsl` stores typed extension registrations for MiniMessage tag providers, theme providers, animation drivers,
 and the active platform adapter. Registration is explicit at startup; there is no classpath scanning.
@@ -138,8 +148,8 @@ val plain = message.toPlainText()
 
 `kotventure-test` starts the testing toolkit with structural component matchers such as `shouldContainText`,
 `shouldHaveColor`, `shouldHaveDecoration`, `shouldNotHaveDecoration`, `shouldHaveChildCount`, and translatable-specific
-assertions for keys, fallbacks, and arguments. It also includes keybind, score, and selector assertions for the smaller
-component DSLs, plus block, entity, and storage NBT assertions.
+assertions for keys, fallbacks, and arguments. It also includes keybind, score, selector, object component, block, entity,
+and storage NBT assertions for the smaller component DSLs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ val storedTitle = storageNbt(key("kotventure", "messages"), "welcome.title") {
     separator(Component.text(", "))
 }
 
-val stoneIcon = display(ObjectContents.sprite(key("minecraft", "block/stone"))) {
+val stoneIcon = display(sprite(key("minecraft", "block/stone"))) {
     fallback {
         text("[stone]")
     }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -106,6 +106,7 @@ val msg = component {
     blockNbt(blockPos(1, 64, 1), "Items[0].id")
     entityNbt("@p", "CustomName") { interpret(true) }
     storageNbt(key("kotventure", "messages"), "motd") { interpret(true) }
+    display(ObjectContents.sprite(key("minecraft", "block/stone"))) { fallback { text("[stone]") } }
     mini("<gradient:gold:red>Epic</gradient>")
 }
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -106,7 +106,7 @@ val msg = component {
     blockNbt(blockPos(1, 64, 1), "Items[0].id")
     entityNbt("@p", "CustomName") { interpret(true) }
     storageNbt(key("kotventure", "messages"), "motd") { interpret(true) }
-    display(ObjectContents.sprite(key("minecraft", "block/stone"))) { fallback { text("[stone]") } }
+    display(sprite(key("minecraft", "block/stone"))) { fallback { text("[stone]") } }
     mini("<gradient:gold:red>Epic</gradient>")
 }
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScope.kt
@@ -5,6 +5,7 @@ import io.github.lmliam.kotventure.core.keybind.KeybindScope
 import io.github.lmliam.kotventure.core.nbt.BlockNbtScope
 import io.github.lmliam.kotventure.core.nbt.EntityNbtScope
 import io.github.lmliam.kotventure.core.nbt.StorageNbtScope
+import io.github.lmliam.kotventure.core.objectcomponent.ObjectScope
 import io.github.lmliam.kotventure.core.score.ScoreScope
 import io.github.lmliam.kotventure.core.selector.SelectorScope
 import io.github.lmliam.kotventure.core.style.StyleScope
@@ -16,6 +17,7 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.`object`.ObjectContents
 
 /**
  * Scope for configuring behavior shared by every Adventure component builder.
@@ -148,5 +150,13 @@ public interface ComponentScope {
         storage: Key,
         nbtPath: String,
         init: StorageNbtScope.() -> Unit = {},
+    )
+
+    /**
+     * Appends a nested object child with [contents].
+     */
+    public fun display(
+        contents: ObjectContents,
+        init: ObjectScope.() -> Unit = {},
     )
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScopeBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScopeBuilder.kt
@@ -4,6 +4,7 @@ import io.github.lmliam.kotventure.core.keybind.KeybindScope
 import io.github.lmliam.kotventure.core.nbt.BlockNbtScope
 import io.github.lmliam.kotventure.core.nbt.EntityNbtScope
 import io.github.lmliam.kotventure.core.nbt.StorageNbtScope
+import io.github.lmliam.kotventure.core.objectcomponent.ObjectScope
 import io.github.lmliam.kotventure.core.score.ScoreScope
 import io.github.lmliam.kotventure.core.selector.SelectorScope
 import io.github.lmliam.kotventure.core.style.StyleScope
@@ -17,10 +18,12 @@ import net.kyori.adventure.text.ComponentBuilder
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.`object`.ObjectContents
 import io.github.lmliam.kotventure.core.keybind.keybind as keybindComponent
 import io.github.lmliam.kotventure.core.nbt.blockNbt as blockNbtComponent
 import io.github.lmliam.kotventure.core.nbt.entityNbt as entityNbtComponent
 import io.github.lmliam.kotventure.core.nbt.storageNbt as storageNbtComponent
+import io.github.lmliam.kotventure.core.objectcomponent.display as displayComponent
 import io.github.lmliam.kotventure.core.score.score as scoreComponent
 import io.github.lmliam.kotventure.core.selector.selector as selectorComponent
 import io.github.lmliam.kotventure.core.translatable.translatable as translatableComponent
@@ -137,6 +140,13 @@ internal abstract class ComponentScopeBuilder<C : Component, B : ComponentBuilde
         init: StorageNbtScope.() -> Unit,
     ) {
         append(storageNbtComponent(storage, nbtPath, init))
+    }
+
+    override fun display(
+        contents: ObjectContents,
+        init: ObjectScope.() -> Unit,
+    ) {
+        append(displayComponent(contents, init))
     }
 
     internal open fun build(): Component = builder.build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/Display.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/Display.kt
@@ -1,0 +1,12 @@
+package io.github.lmliam.kotventure.core.objectcomponent
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.`object`.ObjectContents
+
+/**
+ * Builds an Adventure object [Component] from [contents] and a Kotventure DSL block.
+ */
+public fun display(
+    contents: ObjectContents,
+    init: ObjectScope.() -> Unit = {},
+): Component = ObjectComponentBuilder(contents).apply(init).build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentBuilder.kt
@@ -1,0 +1,22 @@
+package io.github.lmliam.kotventure.core.objectcomponent
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.ComponentScopeBuilder
+import io.github.lmliam.kotventure.core.text.TextComponentBuilder
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.text.ObjectComponent
+import net.kyori.adventure.text.`object`.ObjectContents
+
+internal class ObjectComponentBuilder(
+    contents: ObjectContents,
+) : ComponentScopeBuilder<ObjectComponent, ObjectComponent.Builder>(Component.`object`().contents(contents)),
+    ObjectScope {
+    override fun fallback(fallback: ComponentLike?) {
+        builder.fallback(fallback)
+    }
+
+    override fun fallback(init: ComponentScope.() -> Unit) {
+        builder.fallback(TextComponentBuilder().apply(init).build())
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectContentsDsl.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectContentsDsl.kt
@@ -1,0 +1,18 @@
+package io.github.lmliam.kotventure.core.objectcomponent
+
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.`object`.ObjectContents
+import net.kyori.adventure.text.`object`.SpriteObjectContents
+
+/**
+ * Builds sprite object contents using Adventure's default sprite atlas.
+ */
+public fun sprite(sprite: Key): SpriteObjectContents = ObjectContents.sprite(sprite)
+
+/**
+ * Builds sprite object contents from [sprite] in [atlas].
+ */
+public fun sprite(
+    atlas: Key,
+    sprite: Key,
+): SpriteObjectContents = ObjectContents.sprite(atlas, sprite)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectFallbackRenderer.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectFallbackRenderer.kt
@@ -1,0 +1,24 @@
+package io.github.lmliam.kotventure.core.objectcomponent
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ObjectComponent
+import net.kyori.adventure.text.renderer.TranslatableComponentRenderer
+
+/**
+ * Renders object components to their fallback components where a fallback is configured.
+ */
+public fun Component.renderObjectFallbacks(): Component = ObjectFallbackRenderer.render(this, Unit)
+
+private object ObjectFallbackRenderer : TranslatableComponentRenderer<Unit>() {
+    override fun renderObject(
+        component: ObjectComponent,
+        context: Unit,
+    ): Component {
+        val renderedObject = super.renderObject(component, context)
+        val fallback = component.fallback() ?: return renderedObject
+        val renderedFallback = render(fallback, context)
+        val renderedChildren = renderedObject.children()
+
+        return renderedChildren.fold(renderedFallback) { parent, child -> parent.append(child) }
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectScope.kt
@@ -1,0 +1,21 @@
+package io.github.lmliam.kotventure.core.objectcomponent
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Scope for configuring an object component with fallback text, style, and children.
+ */
+@KotventureDslMarker
+public interface ObjectScope : ComponentScope {
+    /**
+     * Sets the component displayed where object components are unsupported, or clears it with `null`.
+     */
+    public fun fallback(fallback: ComponentLike?)
+
+    /**
+     * Builds and applies an inline fallback component for clients that cannot display object components.
+     */
+    public fun fallback(init: ComponentScope.() -> Unit)
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentDslTest.kt
@@ -1,0 +1,118 @@
+package io.github.lmliam.kotventure.core.objectcomponent
+
+import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldBeKeybindComponent
+import io.github.lmliam.kotventure.test.text.shouldBeObjectComponent
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.github.lmliam.kotventure.test.text.shouldHaveKeybind
+import io.github.lmliam.kotventure.test.text.shouldHaveObjectContents
+import io.github.lmliam.kotventure.test.text.shouldHaveObjectFallback
+import io.github.lmliam.kotventure.test.text.shouldNotHaveObjectFallback
+import io.kotest.core.spec.style.StringSpec
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.`object`.ObjectContents
+
+class ObjectComponentDslTest :
+    StringSpec(
+        {
+            "builds an object component with sprite contents" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+
+                val component = display(contents).shouldBeObjectComponent()
+
+                component shouldHaveObjectContents contents
+                component.shouldNotHaveObjectFallback()
+            }
+
+            "applies style and fallback to the object root" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val fallback = Component.text("[stone]")
+
+                val component =
+                    display(contents) {
+                        color(NamedTextColor.GOLD)
+                        bold()
+                        fallback(fallback)
+                    }.shouldBeObjectComponent()
+
+                component shouldHaveObjectContents contents
+                component shouldHaveColor NamedTextColor.GOLD
+                component shouldHaveDecoration TextDecoration.BOLD
+                component shouldHaveObjectFallback fallback
+            }
+
+            "builds fallback text from a component DSL block" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+
+                val component =
+                    display(contents) {
+                        fallback {
+                            text("stone") {
+                                color(NamedTextColor.GRAY)
+                            }
+                        }
+                    }.shouldBeObjectComponent()
+
+                val fallback = checkNotNull(component.fallback())
+                fallback shouldHaveChildCount 1
+                fallback.childAt(0) shouldContainText "stone"
+                fallback.childAt(0) shouldHaveColor NamedTextColor.GRAY
+            }
+
+            "uses the last configured fallback" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val fallback = Component.text("[stone]")
+
+                val component =
+                    display(contents) {
+                        fallback(Component.text("[old]"))
+                        fallback(fallback)
+                    }.shouldBeObjectComponent()
+
+                component shouldHaveObjectFallback fallback
+            }
+
+            "appends child component builders" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+
+                val component =
+                    display(contents) {
+                        text(" item")
+                        keybind("key.attack") {
+                            underlined()
+                        }
+                    }
+
+                component shouldHaveChildCount 2
+                component.childAt(0) shouldContainText " item"
+                val keybind = component.childAt(1).shouldBeKeybindComponent()
+                keybind shouldHaveKeybind "key.attack"
+                keybind shouldHaveDecoration TextDecoration.UNDERLINED
+            }
+
+            "appends object components from component scope" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+
+                val component =
+                    component {
+                        text("Block: ")
+                        display(contents) {
+                            fallback(Component.text("[stone]"))
+                        }
+                    }
+
+                component shouldHaveChildCount 2
+                component.childAt(0) shouldContainText "Block: "
+                val objectChild = component.childAt(1).shouldBeObjectComponent()
+                objectChild shouldHaveObjectContents contents
+                objectChild shouldHaveObjectFallback Component.text("[stone]")
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentDslTest.kt
@@ -14,6 +14,7 @@ import io.github.lmliam.kotventure.test.text.shouldHaveObjectContents
 import io.github.lmliam.kotventure.test.text.shouldHaveObjectFallback
 import io.github.lmliam.kotventure.test.text.shouldNotHaveObjectFallback
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextDecoration
@@ -22,8 +23,25 @@ import net.kyori.adventure.text.`object`.ObjectContents
 class ObjectComponentDslTest :
     StringSpec(
         {
+            "builds sprite object contents with the default atlas" {
+                val spriteKey = key("minecraft", "block/stone")
+
+                val contents = sprite(spriteKey)
+
+                contents shouldBe ObjectContents.sprite(spriteKey)
+            }
+
+            "builds sprite object contents with a custom atlas" {
+                val atlas = key("minecraft", "blocks")
+                val spriteKey = key("minecraft", "block/stone")
+
+                val contents = sprite(atlas, spriteKey)
+
+                contents shouldBe ObjectContents.sprite(atlas, spriteKey)
+            }
+
             "builds an object component with sprite contents" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
 
                 val component = display(contents).shouldBeObjectComponent()
 
@@ -32,7 +50,7 @@ class ObjectComponentDslTest :
             }
 
             "applies style and fallback to the object root" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
                 val fallback = Component.text("[stone]")
 
                 val component =
@@ -49,7 +67,7 @@ class ObjectComponentDslTest :
             }
 
             "builds fallback text from a component DSL block" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
 
                 val component =
                     display(contents) {
@@ -67,7 +85,7 @@ class ObjectComponentDslTest :
             }
 
             "uses the last configured fallback" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
                 val fallback = Component.text("[stone]")
 
                 val component =
@@ -80,7 +98,7 @@ class ObjectComponentDslTest :
             }
 
             "appends child component builders" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
 
                 val component =
                     display(contents) {
@@ -98,7 +116,7 @@ class ObjectComponentDslTest :
             }
 
             "appends object components from component scope" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
 
                 val component =
                     component {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentDslTest.kt
@@ -97,6 +97,18 @@ class ObjectComponentDslTest :
                 component shouldHaveObjectFallback fallback
             }
 
+            "clears fallback when null is provided" {
+                val contents = sprite(key("minecraft", "block/stone"))
+
+                val component =
+                    display(contents) {
+                        fallback(Component.text("[stone]"))
+                        fallback(null)
+                    }.shouldBeObjectComponent()
+
+                component.shouldNotHaveObjectFallback()
+            }
+
             "appends child component builders" {
                 val contents = sprite(key("minecraft", "block/stone"))
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentRendererTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentRendererTest.kt
@@ -12,13 +12,12 @@ import io.kotest.matchers.shouldBe
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ObjectComponent
 import net.kyori.adventure.text.TextComponent
-import net.kyori.adventure.text.`object`.ObjectContents
 
 class ObjectComponentRendererTest :
     StringSpec(
         {
             "renders object components with fallback replacements" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
                 val message =
                     display(contents) {
                         fallback(Component.text("[stone]"))
@@ -35,7 +34,7 @@ class ObjectComponentRendererTest :
             }
 
             "preserves object components without fallback while rendering children" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
                 val message =
                     display(contents) {
                         text(" child")
@@ -49,7 +48,7 @@ class ObjectComponentRendererTest :
             }
 
             "preserves empty object components without fallback or children" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
                 val message = display(contents)
 
                 val rendered = message.renderObjectFallbacks().shouldBeObjectComponent()
@@ -59,7 +58,7 @@ class ObjectComponentRendererTest :
             }
 
             "renders nested object fallbacks in component trees" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
                 val message =
                     component {
                         text("Block: ")
@@ -76,7 +75,7 @@ class ObjectComponentRendererTest :
             }
 
             "preserves fallback children before object children" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
                 val message =
                     display(contents) {
                         fallback {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentRendererTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentRendererTest.kt
@@ -1,0 +1,101 @@
+package io.github.lmliam.kotventure.core.objectcomponent
+
+import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldBeObjectComponent
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveObjectContents
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ObjectComponent
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.`object`.ObjectContents
+
+class ObjectComponentRendererTest :
+    StringSpec(
+        {
+            "renders object components with fallback replacements" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val message =
+                    display(contents) {
+                        fallback(Component.text("[stone]"))
+                        text(" item")
+                    }
+
+                val rendered = message.renderObjectFallbacks()
+
+                rendered.containsObjectComponent() shouldBe false
+                val fallback = rendered as TextComponent
+                fallback.content() shouldBe "[stone]"
+                fallback shouldHaveChildCount 1
+                fallback.childAt(0) shouldContainText " item"
+            }
+
+            "preserves object components without fallback while rendering children" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val message =
+                    display(contents) {
+                        text(" child")
+                    }
+
+                val rendered = message.renderObjectFallbacks().shouldBeObjectComponent()
+
+                rendered shouldHaveObjectContents contents
+                rendered shouldHaveChildCount 1
+                rendered.childAt(0) shouldContainText " child"
+            }
+
+            "preserves empty object components without fallback or children" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val message = display(contents)
+
+                val rendered = message.renderObjectFallbacks().shouldBeObjectComponent()
+
+                rendered shouldHaveObjectContents contents
+                rendered shouldHaveChildCount 0
+            }
+
+            "renders nested object fallbacks in component trees" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val message =
+                    component {
+                        text("Block: ")
+                        display(contents) {
+                            fallback(Component.text("[stone]"))
+                        }
+                    }
+
+                val rendered = message.renderObjectFallbacks()
+
+                rendered shouldHaveChildCount 2
+                rendered.childAt(0) shouldContainText "Block: "
+                rendered.childAt(1) shouldContainText "[stone]"
+            }
+
+            "preserves fallback children before object children" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val message =
+                    display(contents) {
+                        fallback {
+                            text("[stone]")
+                            text(" fallback-child")
+                        }
+                        text(" object-child")
+                    }
+
+                val rendered = message.renderObjectFallbacks()
+
+                rendered.containsObjectComponent() shouldBe false
+                rendered shouldHaveChildCount 3
+                rendered.childAt(0) shouldContainText "[stone]"
+                rendered.childAt(1) shouldContainText " fallback-child"
+                rendered.childAt(2) shouldContainText " object-child"
+            }
+        },
+    )
+
+private fun Component.containsObjectComponent(): Boolean =
+    this is ObjectComponent || children().any { child -> child.containsObjectComponent() }

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -2,6 +2,7 @@ package io.github.lmliam.kotventure.serializer
 
 import io.github.lmliam.kotventure.core.key.key
 import io.github.lmliam.kotventure.core.objectcomponent.display
+import io.github.lmliam.kotventure.core.objectcomponent.sprite
 import io.github.lmliam.kotventure.core.text.component
 import io.github.lmliam.kotventure.test.text.shouldBeObjectComponent
 import io.github.lmliam.kotventure.test.text.shouldContainText
@@ -11,7 +12,6 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.minimessage.MiniMessage
-import net.kyori.adventure.text.`object`.ObjectContents
 
 /**
  * Verifies Kotventure's component serializer extensions delegate to Adventure's concrete serializers.
@@ -60,14 +60,14 @@ class ComponentSerializerExtensionsTest :
             }
 
             "serializes object components to plain text" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
                 val message = display(contents)
 
                 message.toPlainText() shouldBe "[block/stone]"
             }
 
             "round-trips sprite object components through MiniMessage" {
-                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val contents = sprite(key("minecraft", "block/stone"))
                 val message = display(contents)
 
                 val serialized = message.toMiniMessage()

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -1,12 +1,17 @@
 package io.github.lmliam.kotventure.serializer
 
+import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.objectcomponent.display
 import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.test.text.shouldBeObjectComponent
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveObjectContents
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.`object`.ObjectContents
 
 /**
  * Verifies Kotventure's component serializer extensions delegate to Adventure's concrete serializers.
@@ -52,6 +57,25 @@ class ComponentSerializerExtensionsTest :
 
                 roundTripped shouldContainText "Alert"
                 roundTripped shouldHaveColor NamedTextColor.RED
+            }
+
+            "serializes object components to plain text" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val message = display(contents)
+
+                message.toPlainText() shouldBe "[block/stone]"
+            }
+
+            "round-trips sprite object components through MiniMessage" {
+                val contents = ObjectContents.sprite(key("minecraft", "block/stone"))
+                val message = display(contents)
+
+                val serialized = message.toMiniMessage()
+                serialized shouldBe "<sprite:'minecraft:block/stone'>"
+
+                val roundTripped = MiniMessage.miniMessage().deserialize(serialized).shouldBeObjectComponent()
+
+                roundTripped shouldHaveObjectContents contents
             }
         },
     )

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -9,6 +9,7 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.EntityNBTComponent
 import net.kyori.adventure.text.KeybindComponent
 import net.kyori.adventure.text.NBTComponent
+import net.kyori.adventure.text.ObjectComponent
 import net.kyori.adventure.text.ScoreComponent
 import net.kyori.adventure.text.SelectorComponent
 import net.kyori.adventure.text.StorageNBTComponent
@@ -19,6 +20,7 @@ import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.format.TextDecoration.State
+import net.kyori.adventure.text.`object`.ObjectContents
 
 /**
  * Asserts that this component tree contains [expected] in its text content.
@@ -169,6 +171,35 @@ public infix fun SelectorComponent.shouldHaveSelectorSeparator(expected: Compone
 public fun SelectorComponent.shouldNotHaveSelectorSeparator(): SelectorComponent =
     apply {
         this should haveNoSelectorSeparator()
+    }
+
+/**
+ * Asserts that this component is an [ObjectComponent] and returns it typed.
+ */
+public fun Component.shouldBeObjectComponent(): ObjectComponent = shouldBeComponentType("object")
+
+/**
+ * Asserts that this object component has [expected] as its contents.
+ */
+public infix fun ObjectComponent.shouldHaveObjectContents(expected: ObjectContents): ObjectComponent =
+    apply {
+        this should haveObjectContents(expected)
+    }
+
+/**
+ * Asserts that this object component has [expected] as its fallback component.
+ */
+public infix fun ObjectComponent.shouldHaveObjectFallback(expected: Component): ObjectComponent =
+    apply {
+        this should haveObjectFallback(expected)
+    }
+
+/**
+ * Asserts that this object component has no fallback component.
+ */
+public fun ObjectComponent.shouldNotHaveObjectFallback(): ObjectComponent =
+    apply {
+        this should haveNoObjectFallback()
     }
 
 /**
@@ -446,6 +477,36 @@ private fun haveNoSelectorSeparator(): Matcher<SelectorComponent> =
             actual == null,
             { "Expected selector separator to be absent, but was <${actual ?: "null"}>." },
             { "Expected selector separator to be present." },
+        )
+    }
+
+private fun haveObjectContents(expected: ObjectContents): Matcher<ObjectComponent> =
+    Matcher { value ->
+        val actual = value.contents()
+        MatcherResult(
+            actual == expected,
+            { "Expected object contents <$expected>, but was <$actual>." },
+            { "Expected object contents not to be <$expected>." },
+        )
+    }
+
+private fun haveObjectFallback(expected: Component): Matcher<ObjectComponent> =
+    Matcher { value ->
+        val actual = value.fallback()
+        MatcherResult(
+            actual == expected,
+            { "Expected object fallback <$expected>, but was <${actual ?: "null"}>." },
+            { "Expected object fallback not to be <$expected>." },
+        )
+    }
+
+private fun haveNoObjectFallback(): Matcher<ObjectComponent> =
+    Matcher { value ->
+        val actual = value.fallback()
+        MatcherResult(
+            actual == null,
+            { "Expected object fallback to be absent, but was <${actual ?: "null"}>." },
+            { "Expected object fallback to be present." },
         )
     }
 

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -3,11 +3,13 @@ package io.github.lmliam.kotventure.test.text
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TranslationArgument
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.`object`.ObjectContents
 
 class ComponentMatchersTest :
     StringSpec(
@@ -416,6 +418,101 @@ class ComponentMatchersTest :
                         Component.selector("@a", actual).shouldBeSelectorComponent().shouldNotHaveSelectorSeparator()
                     }
                 val expectedMessage = "Expected selector separator to be absent, but was <$actual>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "matches object component contents and fallback" {
+                val contents = ObjectContents.sprite(Key.key("minecraft", "block/stone"))
+                val fallback = Component.text("[stone]")
+                val component =
+                    Component
+                        .`object`()
+                        .contents(contents)
+                        .fallback(fallback)
+                        .build()
+                        .shouldBeObjectComponent()
+
+                component shouldHaveObjectContents contents
+                component shouldHaveObjectFallback fallback
+            }
+
+            "matches object components without fallback" {
+                val contents = ObjectContents.sprite(Key.key("minecraft", "block/stone"))
+
+                Component.`object`(contents).shouldBeObjectComponent().shouldNotHaveObjectFallback()
+            }
+
+            "reports non-object components before object assertions" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("plain").shouldBeObjectComponent()
+                    }
+                val expectedMessage = "Expected object component, but was <TextComponentImpl>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports object contents mismatches" {
+                val actual = ObjectContents.sprite(Key.key("minecraft", "block/stone"))
+                val expected = ObjectContents.sprite(Key.key("minecraft", "block/dirt"))
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.`object`(actual).shouldBeObjectComponent() shouldHaveObjectContents expected
+                    }
+                val expectedMessage = "Expected object contents <$expected>, but was <$actual>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports object fallback mismatches" {
+                val contents = ObjectContents.sprite(Key.key("minecraft", "block/stone"))
+                val actual = Component.text("[stone]")
+                val expected = Component.text("[dirt]")
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component
+                            .`object`()
+                            .contents(contents)
+                            .fallback(actual)
+                            .build()
+                            .shouldBeObjectComponent() shouldHaveObjectFallback expected
+                    }
+                val expectedMessage = "Expected object fallback <$expected>, but was <$actual>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports missing object fallback" {
+                val contents = ObjectContents.sprite(Key.key("minecraft", "block/stone"))
+                val expected = Component.text("[stone]")
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.`object`(contents).shouldBeObjectComponent() shouldHaveObjectFallback expected
+                    }
+                val expectedMessage = "Expected object fallback <$expected>, but was <null>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports unexpected object fallback" {
+                val contents = ObjectContents.sprite(Key.key("minecraft", "block/stone"))
+                val fallback = Component.text("[stone]")
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component
+                            .`object`()
+                            .contents(contents)
+                            .fallback(fallback)
+                            .build()
+                            .shouldBeObjectComponent()
+                            .shouldNotHaveObjectFallback()
+                    }
+                val expectedMessage = "Expected object fallback to be absent, but was <$fallback>."
 
                 failure.message shouldContain expectedMessage
             }


### PR DESCRIPTION
## Summary

Adds the core DSL surface for Adventure object components using `display(contents)`, plus fallback rendering helpers for contexts that need object components rendered to ordinary components.

## Related Issues

Closes #81

## DSL Impact

- Adds `display(ObjectContents.sprite(...)) { ... }` as a top-level builder and nested `ComponentScope` child builder.
- Adds `fallback(...)` and `fallback { ... }` hooks on the object component scope.
- Adds `Component.renderObjectFallbacks()` for explicit renderer handling of object fallbacks.
- Adds object-component Kotest matchers for contents and fallback assertions.

## Rationale

Adventure 5.x introduced object components for structured non-text display. This keeps Kotventure's core DSL aligned with Adventure without exposing implementation internals or inventing custom component types.

## Testing

- Added `ObjectComponentDslTest` for construction, styling, fallback behavior, child builders, and nested `component { display(...) }` usage.
- Added `ObjectComponentRendererTest` for fallback replacement, no-fallback preservation, nested fallback rendering, and fallback-child ordering.
- Added serializer coverage for object plain text and MiniMessage sprite round-trips.
- Added matcher tests for object component contents and fallback assertions.
- Ran `./gradlew ktlintFormat`.
- Ran `./gradlew :core:test :serializer:test :test:test`.
- Ran `./gradlew build`.

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run
