### PR TITLE
feat(core): add colour and gradient helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 - Object component matchers for asserting contents and fallback components in Kotest specs.
 - Reusable style DSL support through `style { ... }`, tri-state decoration helpers, font keys, shift-click insertion,
   and matching component assertions for style attributes.
+- Colour and gradient helpers for `hex("#RRGGBB")`, `rgb(...)`, normalized `hsv(...)`, named palette aliases,
+  interpolation, and per-code-point gradient text.
 
 ## [0.0.1] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ val gradientMessage = component {
     text("Brand ") {
         color(brand)
     }
-    gradientText("launch", gold, red, aqua)
+    text("launch") {
+        gradient(gold, red, aqua)
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ val message = component {
 }
 ```
 
-Colour helpers wrap Adventure `TextColor` factories directly and keep `core` free of serializer dependencies:
+Colour helpers wrap Adventure `TextColor` factories directly and keep `core` free of serializer dependencies. Lower-case
+named colours such as `red`, `blue`, `gold`, and `aqua` are available from `io.github.lmliam.kotventure.core.color`;
+`NamedTextColor.*` works too when you prefer qualified Adventure constants.
 
 ```kotlin
 val brand = hex("#5865F2")

--- a/README.md
+++ b/README.md
@@ -97,6 +97,23 @@ val message = component {
 }
 ```
 
+Colour helpers wrap Adventure `TextColor` factories directly and keep `core` free of serializer dependencies:
+
+```kotlin
+val brand = hex("#5865F2")
+val success = rgb(85, 255, 85)
+val warning = hsv(0.12f, 1f, 1f)
+val midpoint = interpolate(0.5f, red, blue)
+val accent = namedColorOrThrow("dark_purple")
+
+val gradientMessage = component {
+    text("Brand ") {
+        color(brand)
+    }
+    gradientText("launch", gold, red, aqua)
+}
+```
+
 It also includes a `TranslatableComponent` builder for client-side translation keys, fallbacks, and typed Adventure
 arguments:
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Color.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Color.kt
@@ -1,0 +1,73 @@
+package io.github.lmliam.kotventure.core.color
+
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.util.HSVLike
+
+private val hexColorPattern: Regex = Regex("#[0-9A-Fa-f]{6}")
+
+/**
+ * Creates an Adventure [TextColor] from an exact `#RRGGBB` hex string.
+ */
+public fun hex(value: String): TextColor {
+    require(hexColorPattern.matches(value)) {
+        "Hex colors must use the exact #RRGGBB format, but was <$value>."
+    }
+    return requireNotNull(TextColor.fromHexString(value)) {
+        "Adventure could not create a TextColor from <$value>."
+    }
+}
+
+/**
+ * Creates an Adventure [TextColor] from red, green, and blue channels in the `0..255` range.
+ */
+public fun rgb(
+    red: Int,
+    green: Int,
+    blue: Int,
+): TextColor {
+    requireColorChannel("red", red)
+    requireColorChannel("green", green)
+    requireColorChannel("blue", blue)
+    return TextColor.color(red, green, blue)
+}
+
+/**
+ * Creates an Adventure [TextColor] from normalized HSV components in the `0f..1f` range.
+ */
+public fun hsv(
+    hue: Float,
+    saturation: Float,
+    value: Float,
+): TextColor {
+    requireHsvComponent("hue", hue)
+    requireHsvComponent("saturation", saturation)
+    requireHsvComponent("value", value)
+    return TextColor.color(HSVLike.hsvLike(hue, saturation, value))
+}
+
+/**
+ * Linearly interpolates from [start] to [end] using Adventure's [TextColor.lerp] semantics.
+ */
+public fun interpolate(
+    progress: Float,
+    start: TextColor,
+    end: TextColor,
+): TextColor = TextColor.lerp(progress, start, end)
+
+private fun requireColorChannel(
+    name: String,
+    value: Int,
+) {
+    require(value in 0..255) {
+        "$name must be in the 0..255 range, but was <$value>."
+    }
+}
+
+private fun requireHsvComponent(
+    name: String,
+    value: Float,
+) {
+    require(value in 0f..1f) {
+        "$name must be in the 0f..1f range, but was <$value>."
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Color.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Color.kt
@@ -52,7 +52,12 @@ public fun interpolate(
     progress: Float,
     start: TextColor,
     end: TextColor,
-): TextColor = TextColor.lerp(progress, start, end)
+): TextColor {
+    require(progress.isFinite()) {
+        "progress must be finite, but was <$progress>."
+    }
+    return TextColor.lerp(progress, start, end)
+}
 
 private fun requireColorChannel(
     name: String,

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
@@ -1,0 +1,104 @@
+package io.github.lmliam.kotventure.core.color
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextColor
+import kotlin.math.floor
+import kotlin.math.min
+
+/**
+ * Immutable Adventure color gradient made from at least two [TextColor] stops.
+ */
+public class ColorGradient public constructor(
+    stops: Iterable<TextColor>,
+) {
+    /**
+     * Ordered color stops used for interpolation.
+     */
+    public val stops: List<TextColor> =
+        stops.toList().also { copiedStops ->
+            require(copiedStops.size >= 2) {
+                "A color gradient requires at least 2 stops."
+            }
+        }
+
+    /**
+     * Returns the interpolated color at [progress], where `0f` is the first stop and `1f` is the final stop.
+     */
+    public fun colorAt(progress: Float): TextColor {
+        require(progress.isFinite()) {
+            "Gradient progress must be finite, but was <$progress>."
+        }
+        val clampedProgress = progress.coerceIn(0f, 1f)
+        val scaledProgress = clampedProgress * (stops.size - 1)
+        val segmentIndex = min(floor(scaledProgress).toInt(), stops.lastIndex - 1)
+        val segmentProgress = scaledProgress - segmentIndex
+        return interpolate(segmentProgress, stops[segmentIndex], stops[segmentIndex + 1])
+    }
+}
+
+/**
+ * Creates an immutable [ColorGradient] from [stops].
+ */
+public fun gradient(vararg stops: TextColor): ColorGradient = ColorGradient(stops.asList())
+
+/**
+ * Creates an immutable [ColorGradient] from [stops].
+ */
+public fun gradient(stops: Iterable<TextColor>): ColorGradient = ColorGradient(stops)
+
+/**
+ * Builds an Adventure component whose direct children are one colored text component per code point in [value].
+ */
+public fun gradientText(
+    value: String,
+    vararg stops: TextColor,
+): Component = gradientText(value, gradient(*stops))
+
+/**
+ * Builds an Adventure component whose direct children are one colored text component per code point in [value].
+ */
+public fun gradientText(
+    value: String,
+    gradient: ColorGradient,
+): Component {
+    val codePoints = value.toCodePointStrings()
+    if (codePoints.isEmpty()) {
+        return Component.empty()
+    }
+
+    val builder = Component.text()
+    codePoints.forEachIndexed { index, text ->
+        val progress = if (codePoints.size == 1) 0f else index.toFloat() / codePoints.lastIndex.toFloat()
+        builder.append(Component.text(text).color(gradient.colorAt(progress)))
+    }
+    return builder.build()
+}
+
+/**
+ * Appends one gradient-colored text component per code point in [value] to this component scope.
+ */
+public fun ComponentScope.gradientText(
+    value: String,
+    vararg stops: TextColor,
+) {
+    gradientText(value, gradient(*stops))
+}
+
+/**
+ * Appends one gradient-colored text component per code point in [value] to this component scope.
+ */
+public fun ComponentScope.gradientText(
+    value: String,
+    gradient: ColorGradient,
+) {
+    val gradientComponent =
+        io.github.lmliam.kotventure.core.color
+        .gradientText(value, gradient)
+    gradientComponent.children().forEach { child -> append(child) }
+}
+
+private fun String.toCodePointStrings(): List<String> =
+    codePoints()
+        .toArray()
+        .map { codePoint -> String(Character.toChars(codePoint)) }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
@@ -1,6 +1,5 @@
 package io.github.lmliam.kotventure.core.color
 
-import io.github.lmliam.kotventure.core.component.ComponentScope
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.TextColor
 import kotlin.math.floor
@@ -70,26 +69,6 @@ public fun gradientText(
     val builder = Component.text()
     children.forEach { child -> builder.append(child) }
     return builder.build()
-}
-
-/**
- * Appends one gradient-colored text component per code point in [value] to this component scope.
- */
-public fun ComponentScope.gradientText(
-    value: String,
-    vararg stops: TextColor,
-) {
-    gradientText(value, gradient(*stops))
-}
-
-/**
- * Appends one gradient-colored text component per code point in [value] to this component scope.
- */
-public fun ComponentScope.gradientText(
-    value: String,
-    gradient: ColorGradient,
-) {
-    gradientTextChildren(value, gradient).forEach { child -> append(child) }
 }
 
 private fun gradientTextChildren(

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
@@ -62,16 +62,13 @@ public fun gradientText(
     value: String,
     gradient: ColorGradient,
 ): Component {
-    val codePoints = value.toCodePointStrings()
-    if (codePoints.isEmpty()) {
+    val children = gradientTextChildren(value, gradient)
+    if (children.isEmpty()) {
         return Component.empty()
     }
 
     val builder = Component.text()
-    codePoints.forEachIndexed { index, text ->
-        val progress = if (codePoints.size == 1) 0f else index.toFloat() / codePoints.lastIndex.toFloat()
-        builder.append(Component.text(text).color(gradient.colorAt(progress)))
-    }
+    children.forEach { child -> builder.append(child) }
     return builder.build()
 }
 
@@ -92,10 +89,18 @@ public fun ComponentScope.gradientText(
     value: String,
     gradient: ColorGradient,
 ) {
-    val gradientComponent =
-        io.github.lmliam.kotventure.core.color
-        .gradientText(value, gradient)
-    gradientComponent.children().forEach { child -> append(child) }
+    gradientTextChildren(value, gradient).forEach { child -> append(child) }
+}
+
+private fun gradientTextChildren(
+    value: String,
+    gradient: ColorGradient,
+): List<Component> {
+    val codePoints = value.toCodePointStrings()
+    return codePoints.mapIndexed { index, text ->
+        val progress = if (codePoints.size == 1) 0f else index.toFloat() / codePoints.lastIndex.toFloat()
+        Component.text(text).color(gradient.colorAt(progress))
+    }
 }
 
 private fun String.toCodePointStrings(): List<String> =

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/NamedColors.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/NamedColors.kt
@@ -1,0 +1,93 @@
+package io.github.lmliam.kotventure.core.color
+
+import net.kyori.adventure.text.format.NamedTextColor
+
+/**
+ * Standard Adventure `black` color.
+ */
+public val black: NamedTextColor = NamedTextColor.BLACK
+
+/**
+ * Standard Adventure `dark_blue` color.
+ */
+public val darkBlue: NamedTextColor = NamedTextColor.DARK_BLUE
+
+/**
+ * Standard Adventure `dark_green` color.
+ */
+public val darkGreen: NamedTextColor = NamedTextColor.DARK_GREEN
+
+/**
+ * Standard Adventure `dark_aqua` color.
+ */
+public val darkAqua: NamedTextColor = NamedTextColor.DARK_AQUA
+
+/**
+ * Standard Adventure `dark_red` color.
+ */
+public val darkRed: NamedTextColor = NamedTextColor.DARK_RED
+
+/**
+ * Standard Adventure `dark_purple` color.
+ */
+public val darkPurple: NamedTextColor = NamedTextColor.DARK_PURPLE
+
+/**
+ * Standard Adventure `gold` color.
+ */
+public val gold: NamedTextColor = NamedTextColor.GOLD
+
+/**
+ * Standard Adventure `gray` color.
+ */
+public val gray: NamedTextColor = NamedTextColor.GRAY
+
+/**
+ * Standard Adventure `dark_gray` color.
+ */
+public val darkGray: NamedTextColor = NamedTextColor.DARK_GRAY
+
+/**
+ * Standard Adventure `blue` color.
+ */
+public val blue: NamedTextColor = NamedTextColor.BLUE
+
+/**
+ * Standard Adventure `green` color.
+ */
+public val green: NamedTextColor = NamedTextColor.GREEN
+
+/**
+ * Standard Adventure `aqua` color.
+ */
+public val aqua: NamedTextColor = NamedTextColor.AQUA
+
+/**
+ * Standard Adventure `red` color.
+ */
+public val red: NamedTextColor = NamedTextColor.RED
+
+/**
+ * Standard Adventure `light_purple` color.
+ */
+public val lightPurple: NamedTextColor = NamedTextColor.LIGHT_PURPLE
+
+/**
+ * Standard Adventure `yellow` color.
+ */
+public val yellow: NamedTextColor = NamedTextColor.YELLOW
+
+/**
+ * Standard Adventure `white` color.
+ */
+public val white: NamedTextColor = NamedTextColor.WHITE
+
+/**
+ * Finds a standard Adventure named color by its exact Adventure name, such as `dark_blue`.
+ */
+public fun namedColor(name: String): NamedTextColor? = NamedTextColor.NAMES.value(name)
+
+/**
+ * Finds a standard Adventure named color by its exact Adventure name, or throws if [name] is unknown.
+ */
+public fun namedColorOrThrow(name: String): NamedTextColor = NamedTextColor.NAMES.valueOrThrow(name)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextComponentBuilder.kt
@@ -1,13 +1,41 @@
 package io.github.lmliam.kotventure.core.text
 
+import io.github.lmliam.kotventure.core.color.ColorGradient
 import io.github.lmliam.kotventure.core.component.ComponentScopeBuilder
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.format.TextColor
+import io.github.lmliam.kotventure.core.color.gradient as colorGradient
+import io.github.lmliam.kotventure.core.color.gradientText as gradientComponent
 
 internal class TextComponentBuilder :
     ComponentScopeBuilder<TextComponent, TextComponent.Builder>(Component.text()),
     TextScope {
+    private var gradient: ColorGradient? = null
+
     override fun content(value: String) {
         builder.content(value)
+    }
+
+    override fun gradient(gradient: ColorGradient) {
+        this.gradient = gradient
+    }
+
+    override fun gradient(vararg stops: TextColor) {
+        gradient(colorGradient(*stops))
+    }
+
+    override fun build(): Component {
+        val component = builder.build()
+        val gradient = gradient ?: return component
+        val content = component.content()
+        if (content.isEmpty()) {
+            return component
+        }
+
+        val builder = Component.text().style(component.style())
+        gradientComponent(content, gradient).children().forEach { child -> builder.append(child) }
+        component.children().forEach { child -> builder.append(child) }
+        return builder.build()
     }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextScope.kt
@@ -1,7 +1,9 @@
 package io.github.lmliam.kotventure.core.text
 
+import io.github.lmliam.kotventure.core.color.ColorGradient
 import io.github.lmliam.kotventure.core.component.ComponentScope
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.format.TextColor
 
 /**
  * Scope for configuring text-specific content on a text component.
@@ -12,4 +14,14 @@ public interface TextScope : ComponentScope {
      * Replaces the text content of the component being configured.
      */
     public fun content(value: String)
+
+    /**
+     * Applies [gradient] across this text component's content, one code point at a time.
+     */
+    public fun gradient(gradient: ColorGradient)
+
+    /**
+     * Applies a gradient built from [stops] across this text component's content, one code point at a time.
+     */
+    public fun gradient(vararg stops: TextColor)
 }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/color/ColorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/color/ColorDslTest.kt
@@ -59,6 +59,10 @@ class ColorDslTest :
                 interpolate(1f, NamedTextColor.BLACK, NamedTextColor.WHITE) shouldBe NamedTextColor.WHITE
                 interpolate(-1f, NamedTextColor.BLACK, NamedTextColor.WHITE) shouldBe NamedTextColor.BLACK
                 interpolate(2f, NamedTextColor.BLACK, NamedTextColor.WHITE) shouldBe NamedTextColor.WHITE
+
+                shouldThrow<IllegalArgumentException> {
+                    interpolate(Float.NaN, NamedTextColor.BLACK, NamedTextColor.WHITE)
+                }.message shouldContain "progress"
             }
 
             "exposes the Adventure named palette through aliases and lookup helpers" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/color/ColorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/color/ColorDslTest.kt
@@ -1,0 +1,90 @@
+package io.github.lmliam.kotventure.core.color
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextColor
+
+class ColorDslTest :
+    StringSpec(
+        {
+            "builds exact Adventure colors from hex rgb and hsv constructors" {
+                hex("#FF00AA") shouldBe TextColor.color(0xFF00AA)
+                hex("#FF00AA").asHexString() shouldBe "#FF00AA"
+                hex("#ffaa00") shouldBe NamedTextColor.GOLD
+
+                rgb(255, 170, 0) shouldBe NamedTextColor.GOLD
+
+                hsv(0f, 1f, 1f) shouldBe TextColor.color(0xFF0000)
+                hsv(1f / 3f, 1f, 1f) shouldBe TextColor.color(0x00FF00)
+                hsv(2f / 3f, 1f, 1f) shouldBe TextColor.color(0x0000FF)
+            }
+
+            "rejects malformed hex and out of range color components" {
+                shouldThrow<IllegalArgumentException> {
+                    hex("FF00AA")
+                }.message shouldContain "#RRGGBB"
+
+                shouldThrow<IllegalArgumentException> {
+                    hex("#F0A")
+                }.message shouldContain "#RRGGBB"
+
+                shouldThrow<IllegalArgumentException> {
+                    hex("#GG00AA")
+                }.message shouldContain "#RRGGBB"
+
+                shouldThrow<IllegalArgumentException> {
+                    rgb(-1, 0, 0)
+                }.message shouldContain "red"
+
+                shouldThrow<IllegalArgumentException> {
+                    rgb(0, 256, 0)
+                }.message shouldContain "green"
+
+                shouldThrow<IllegalArgumentException> {
+                    hsv(-0.01f, 1f, 1f)
+                }.message shouldContain "hue"
+
+                shouldThrow<IllegalArgumentException> {
+                    hsv(0f, 1.01f, 1f)
+                }.message shouldContain "saturation"
+            }
+
+            "delegates interpolation to Adventure TextColor lerp behavior" {
+                interpolate(0f, NamedTextColor.BLACK, NamedTextColor.WHITE) shouldBe NamedTextColor.BLACK
+                interpolate(0.5f, NamedTextColor.BLACK, NamedTextColor.WHITE).asHexString() shouldBe "#808080"
+                interpolate(1f, NamedTextColor.BLACK, NamedTextColor.WHITE) shouldBe NamedTextColor.WHITE
+                interpolate(-1f, NamedTextColor.BLACK, NamedTextColor.WHITE) shouldBe NamedTextColor.BLACK
+                interpolate(2f, NamedTextColor.BLACK, NamedTextColor.WHITE) shouldBe NamedTextColor.WHITE
+            }
+
+            "exposes the Adventure named palette through aliases and lookup helpers" {
+                black shouldBe NamedTextColor.BLACK
+                darkBlue shouldBe NamedTextColor.DARK_BLUE
+                darkGreen shouldBe NamedTextColor.DARK_GREEN
+                darkAqua shouldBe NamedTextColor.DARK_AQUA
+                darkRed shouldBe NamedTextColor.DARK_RED
+                darkPurple shouldBe NamedTextColor.DARK_PURPLE
+                gold shouldBe NamedTextColor.GOLD
+                gray shouldBe NamedTextColor.GRAY
+                darkGray shouldBe NamedTextColor.DARK_GRAY
+                blue shouldBe NamedTextColor.BLUE
+                green shouldBe NamedTextColor.GREEN
+                aqua shouldBe NamedTextColor.AQUA
+                red shouldBe NamedTextColor.RED
+                lightPurple shouldBe NamedTextColor.LIGHT_PURPLE
+                yellow shouldBe NamedTextColor.YELLOW
+                white shouldBe NamedTextColor.WHITE
+
+                namedColor("dark_blue") shouldBe NamedTextColor.DARK_BLUE
+                namedColor("missing").shouldBeNull()
+
+                shouldThrow<NoSuchElementException> {
+                    namedColorOrThrow("missing")
+                }.message shouldContain "missing"
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/color/GradientDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/color/GradientDslTest.kt
@@ -1,0 +1,93 @@
+package io.github.lmliam.kotventure.core.color
+
+import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.text.format.NamedTextColor
+
+class GradientDslTest :
+    StringSpec(
+        {
+            "renders a multi stop gradient as one styled child per code point" {
+                val message = gradientText("abcde", NamedTextColor.RED, NamedTextColor.GOLD, NamedTextColor.AQUA)
+
+                message shouldContainText "abcde"
+                message shouldHaveChildCount 5
+                message.childAt(0) shouldContainText "a"
+                message.childAt(0) shouldHaveColor NamedTextColor.RED
+                message.childAt(1) shouldContainText "b"
+                message.childAt(1) shouldHaveColor interpolate(0.5f, NamedTextColor.RED, NamedTextColor.GOLD)
+                message.childAt(2) shouldContainText "c"
+                message.childAt(2) shouldHaveColor NamedTextColor.GOLD
+                message.childAt(3) shouldContainText "d"
+                message.childAt(3) shouldHaveColor interpolate(0.5f, NamedTextColor.GOLD, NamedTextColor.AQUA)
+                message.childAt(4) shouldContainText "e"
+                message.childAt(4) shouldHaveColor NamedTextColor.AQUA
+            }
+
+            "handles empty single character and supplementary code point text deterministically" {
+                val empty = gradientText("", NamedTextColor.RED, NamedTextColor.BLUE)
+                val single = gradientText("x", NamedTextColor.RED, NamedTextColor.BLUE)
+                val symbol = "\uD834\uDD1E"
+                val mixed = gradientText("A${symbol}B", NamedTextColor.RED, NamedTextColor.GOLD)
+
+                empty shouldHaveChildCount 0
+
+                single shouldHaveChildCount 1
+                single.childAt(0) shouldContainText "x"
+                single.childAt(0) shouldHaveColor NamedTextColor.RED
+
+                mixed shouldContainText "A${symbol}B"
+                mixed shouldHaveChildCount 3
+                mixed.childAt(0) shouldContainText "A"
+                mixed.childAt(1) shouldContainText symbol
+                mixed.childAt(2) shouldContainText "B"
+            }
+
+            "appends gradient text directly inside component scopes" {
+                val message =
+                    component {
+                        text(">")
+                        gradientText("abc", NamedTextColor.RED, NamedTextColor.GOLD, NamedTextColor.AQUA)
+                        gradientText("", NamedTextColor.RED, NamedTextColor.BLUE)
+                        text("<")
+                    }
+
+                message shouldContainText ">abc<"
+                message shouldHaveChildCount 5
+                message.childAt(0) shouldContainText ">"
+                message.childAt(1) shouldContainText "a"
+                message.childAt(1) shouldHaveColor NamedTextColor.RED
+                message.childAt(2) shouldContainText "b"
+                message.childAt(2) shouldHaveColor NamedTextColor.GOLD
+                message.childAt(3) shouldContainText "c"
+                message.childAt(3) shouldHaveColor NamedTextColor.AQUA
+                message.childAt(4) shouldContainText "<"
+            }
+
+            "rejects gradients with fewer than two stops" {
+                shouldThrow<IllegalArgumentException> {
+                    gradient(NamedTextColor.RED)
+                }.message shouldContain "at least 2 stops"
+
+                shouldThrow<IllegalArgumentException> {
+                    gradient(emptyList())
+                }.message shouldContain "at least 2 stops"
+            }
+
+            "stores gradient stops immutably" {
+                val stops = mutableListOf(NamedTextColor.RED, NamedTextColor.BLUE)
+                val gradient = gradient(stops)
+
+                stops[0] = NamedTextColor.GREEN
+
+                gradient.stops shouldBe listOf(NamedTextColor.RED, NamedTextColor.BLUE)
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/color/GradientDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/color/GradientDslTest.kt
@@ -50,25 +50,31 @@ class GradientDslTest :
                 mixed.childAt(2) shouldContainText "B"
             }
 
-            "appends gradient text directly inside component scopes" {
+            "applies gradient text inside text scopes" {
                 val message =
                     component {
                         text(">")
-                        gradientText("abc", NamedTextColor.RED, NamedTextColor.GOLD, NamedTextColor.AQUA)
-                        gradientText("", NamedTextColor.RED, NamedTextColor.BLUE)
+                        text("abc") {
+                            gradient(NamedTextColor.RED, NamedTextColor.GOLD, NamedTextColor.AQUA)
+                        }
+                        text("") {
+                            gradient(NamedTextColor.RED, NamedTextColor.BLUE)
+                        }
                         text("<")
                     }
 
                 message shouldContainText ">abc<"
-                message shouldHaveChildCount 5
+                message shouldHaveChildCount 3
                 message.childAt(0) shouldContainText ">"
-                message.childAt(1) shouldContainText "a"
-                message.childAt(1) shouldHaveColor NamedTextColor.RED
-                message.childAt(2) shouldContainText "b"
-                message.childAt(2) shouldHaveColor NamedTextColor.GOLD
-                message.childAt(3) shouldContainText "c"
-                message.childAt(3) shouldHaveColor NamedTextColor.AQUA
-                message.childAt(4) shouldContainText "<"
+                message.childAt(1) shouldContainText "abc"
+                message.childAt(1) shouldHaveChildCount 3
+                message.childAt(1).childAt(0) shouldContainText "a"
+                message.childAt(1).childAt(0) shouldHaveColor NamedTextColor.RED
+                message.childAt(1).childAt(1) shouldContainText "b"
+                message.childAt(1).childAt(1) shouldHaveColor NamedTextColor.GOLD
+                message.childAt(1).childAt(2) shouldContainText "c"
+                message.childAt(1).childAt(2) shouldHaveColor NamedTextColor.AQUA
+                message.childAt(2) shouldContainText "<"
             }
 
             "rejects gradients with fewer than two stops" {

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -1,6 +1,5 @@
 package io.github.lmliam.kotventure.serializer
 
-import io.github.lmliam.kotventure.core.color.gradientText
 import io.github.lmliam.kotventure.core.color.hex
 import io.github.lmliam.kotventure.core.key.key
 import io.github.lmliam.kotventure.core.objectcomponent.display
@@ -81,7 +80,12 @@ class ComponentSerializerExtensionsTest :
             }
 
             "round-trips gradient text formatting through MiniMessage" {
-                val message = gradientText("ace", NamedTextColor.RED, NamedTextColor.GOLD, NamedTextColor.AQUA)
+                val message =
+                    component {
+                        text("ace") {
+                            gradient(NamedTextColor.RED, NamedTextColor.GOLD, NamedTextColor.AQUA)
+                        }
+                    }
 
                 val serialized = message.toMiniMessage()
                 serialized shouldBe "<red>a</red><gold>c</gold><aqua>e"

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -1,11 +1,15 @@
 package io.github.lmliam.kotventure.serializer
 
+import io.github.lmliam.kotventure.core.color.gradientText
+import io.github.lmliam.kotventure.core.color.hex
 import io.github.lmliam.kotventure.core.key.key
 import io.github.lmliam.kotventure.core.objectcomponent.display
 import io.github.lmliam.kotventure.core.objectcomponent.sprite
 import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldBeObjectComponent
 import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldHaveObjectContents
 import io.kotest.core.spec.style.StringSpec
@@ -57,6 +61,38 @@ class ComponentSerializerExtensionsTest :
 
                 roundTripped shouldContainText "Alert"
                 roundTripped shouldHaveColor NamedTextColor.RED
+            }
+
+            "serializes hex colors with Adventure MiniMessage formatting" {
+                val message =
+                    component {
+                        text("Brand") {
+                            color(hex("#123ABC"))
+                        }
+                    }
+
+                val serialized = message.toMiniMessage()
+                serialized shouldBe "<#123ABC>Brand"
+
+                val roundTripped = MiniMessage.miniMessage().deserialize(serialized)
+
+                roundTripped shouldContainText "Brand"
+                roundTripped shouldHaveColor hex("#123ABC")
+            }
+
+            "round-trips gradient text formatting through MiniMessage" {
+                val message = gradientText("ace", NamedTextColor.RED, NamedTextColor.GOLD, NamedTextColor.AQUA)
+
+                val serialized = message.toMiniMessage()
+                serialized shouldBe "<red>a</red><gold>c</gold><aqua>e"
+
+                val roundTripped = MiniMessage.miniMessage().deserialize(serialized)
+
+                roundTripped shouldContainText "ace"
+                roundTripped shouldHaveChildCount 3
+                roundTripped.childAt(0) shouldHaveColor NamedTextColor.RED
+                roundTripped.childAt(1) shouldHaveColor NamedTextColor.GOLD
+                roundTripped.childAt(2) shouldHaveColor NamedTextColor.AQUA
             }
 
             "serializes object components to plain text" {


### PR DESCRIPTION
## Summary

Adds a small `core.color` DSL surface for Adventure `TextColor` construction, named palette aliases, interpolation, and per-code-point gradient text components.

## Related Issues

Closes #20

## DSL Impact

- Adds `hex("#RRGGBB")`, `rgb(...)`, normalized `hsv(...)`, and `interpolate(...)` helpers.
- Adds named palette aliases plus `namedColor(...)` / `namedColorOrThrow(...)` lookup helpers.
- Adds `ColorGradient`, `gradient(...)`, standalone `gradientText(...)`, and `TextScope.gradient(...)` for `text("...") { gradient(...) }` usage.

## Rationale

Downstream Kotlin plugin authors need common colour construction and gradient helpers without pulling serializer or platform dependencies into `core`. The implementation delegates to Adventure 5.1.1 factories and `TextColor.lerp(...)` rather than introducing custom colour implementations.

## Testing

- `./gradlew ktlintFormat`
- `./gradlew :core:test :serializer:test`
- `./gradlew ktlintCheck spotlessCheck`
- `./gradlew build`
- `./gradlew ktlintFormat :core:test :serializer:test ktlintCheck spotlessCheck build`

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run
