### PR TITLE
feat(core): add hover event dsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
   interpolation, and per-code-point gradient text.
 - Click event DSL support for Adventure's typed click actions and server-side callbacks, including file-URI-aware `open`,
   concise `run`/`suggest`/`copy` helpers, Kotlin duration callback options, and click-event component matchers.
+- Hover event DSL support for typed text, item data component, and entity payloads, including reusable hover factories,
+  clearing/prebuilt interop, MiniMessage round-trip coverage, and hover-event component matchers.
 
 ## [0.0.1] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,45 @@ otherwise; `openUrl(...)` and `openFile(...)` remain available when you want the
 Click events are available on reusable styles because Adventure models click events as part of `Style`; Kotventure keeps
 that shape instead of introducing a separate link wrapper.
 
+Hover events use the same component/style scope model and wrap Adventure's typed `HoverEvent` payloads:
+
+```kotlin
+val itemHover = hover {
+    item(
+        key = key("minecraft", "diamond_sword"),
+        count = 1,
+    )
+}
+
+val playerId = UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee")
+
+val hoverMessage = component {
+    text("Need help?") {
+        hover {
+            text("Open the guide") {
+                color(NamedTextColor.AQUA)
+            }
+        }
+    }
+    text(" sword") {
+        hover(itemHover)
+    }
+    text(" player") {
+        hover {
+            entity(
+                type = key("minecraft", "player"),
+                id = playerId,
+            ) {
+                text("Alex")
+            }
+        }
+    }
+}
+```
+
+Use `hover(null)` to clear a hover event, or pass a prebuilt Adventure `HoverEventSource` when you already have one.
+Item hovers accept typed Adventure data components with `Map<Key, DataComponentValue>`.
+
 Colour helpers wrap Adventure `TextColor` factories directly and keep `core` free of serializer dependencies. Lower-case
 named colours such as `red`, `blue`, `gold`, and `aqua` are available from `io.github.lmliam.kotventure.core.color`;
 `NamedTextColor.*` works too when you prefer qualified Adventure constants.
@@ -211,7 +250,8 @@ val plain = message.toPlainText()
 `kotventure-test` starts the testing toolkit with structural component matchers such as `shouldContainText`,
 `shouldHaveColor`, `shouldHaveDecoration`, `shouldNotHaveDecoration`, `shouldHaveChildCount`, and translatable-specific
 assertions for keys, fallbacks, and arguments. It also includes keybind, score, selector, object component, block, entity,
-and storage NBT assertions for the smaller component DSLs, plus click-event assertions for all components.
+and storage NBT assertions for the smaller component DSLs, plus click-event and hover-event assertions for all
+components.
 
 ---
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScope.kt
@@ -2,6 +2,7 @@ package io.github.lmliam.kotventure.core.component
 
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
 import io.github.lmliam.kotventure.core.event.ClickScope
+import io.github.lmliam.kotventure.core.event.HoverScope
 import io.github.lmliam.kotventure.core.keybind.KeybindScope
 import io.github.lmliam.kotventure.core.nbt.BlockNbtScope
 import io.github.lmliam.kotventure.core.nbt.EntityNbtScope
@@ -24,7 +25,9 @@ import net.kyori.adventure.text.`object`.ObjectContents
  * Scope for configuring behavior shared by every Adventure component builder.
  */
 @KotventureDslMarker
-public interface ComponentScope : ClickScope {
+public interface ComponentScope :
+    ClickScope,
+    HoverScope {
     /**
      * Applies a text color to the component being configured.
      */

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScopeBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScopeBuilder.kt
@@ -17,6 +17,7 @@ import net.kyori.adventure.text.BlockNBTComponent
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentBuilder
 import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.event.HoverEventSource
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
@@ -47,6 +48,10 @@ internal abstract class ComponentScopeBuilder<C : Component, B : ComponentBuilde
 
     override fun click(event: ClickEvent<*>?) {
         builder.clickEvent(event)
+    }
+
+    override fun hover(source: HoverEventSource<*>?) {
+        builder.hoverEvent(source)
     }
 
     override fun decorate(decoration: TextDecoration) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverContentScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverContentScope.kt
@@ -1,0 +1,98 @@
+package io.github.lmliam.kotventure.core.event
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.core.text.TextScope
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.key.Keyed
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.text.event.DataComponentValue
+import java.util.UUID
+
+/**
+ * Scope for selecting the single payload shown by a hover event.
+ */
+@KotventureDslMarker
+public interface HoverContentScope {
+    /**
+     * Selects a text hover payload from an existing [component].
+     */
+    public fun text(component: ComponentLike)
+
+    /**
+     * Selects a text hover payload from [value], configured by [init].
+     */
+    public fun text(
+        value: String,
+        init: TextScope.() -> Unit = {},
+    )
+
+    /**
+     * Selects a text hover payload from rich component DSL content.
+     */
+    public fun text(init: ComponentScope.() -> Unit)
+
+    /**
+     * Selects an item hover payload from [key], [count], and typed [dataComponents].
+     *
+     * @throws IllegalArgumentException when [count] is negative.
+     */
+    public fun item(
+        key: Key,
+        count: Int = 1,
+        dataComponents: Map<Key, DataComponentValue> = emptyMap(),
+    )
+
+    /**
+     * Selects an item hover payload from [item], [count], and typed [dataComponents].
+     *
+     * @throws IllegalArgumentException when [count] is negative.
+     */
+    public fun item(
+        item: Keyed,
+        count: Int = 1,
+        dataComponents: Map<Key, DataComponentValue> = emptyMap(),
+    ) {
+        item(item.key(), count, dataComponents)
+    }
+
+    /**
+     * Selects an entity hover payload from [type], [id], and optional [name].
+     */
+    public fun entity(
+        type: Key,
+        id: UUID,
+        name: ComponentLike? = null,
+    )
+
+    /**
+     * Selects an entity hover payload from [type], [id], and a DSL-built name.
+     */
+    public fun entity(
+        type: Key,
+        id: UUID,
+        init: ComponentScope.() -> Unit,
+    )
+
+    /**
+     * Selects an entity hover payload from [type], [id], and optional [name].
+     */
+    public fun entity(
+        type: Keyed,
+        id: UUID,
+        name: ComponentLike? = null,
+    ) {
+        entity(type.key(), id, name)
+    }
+
+    /**
+     * Selects an entity hover payload from [type], [id], and a DSL-built name.
+     */
+    public fun entity(
+        type: Keyed,
+        id: UUID,
+        init: ComponentScope.() -> Unit,
+    ) {
+        entity(type.key(), id, init)
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverContentScopeBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverContentScopeBuilder.kt
@@ -1,0 +1,79 @@
+package io.github.lmliam.kotventure.core.event
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.text.TextComponentBuilder
+import io.github.lmliam.kotventure.core.text.TextScope
+import io.github.lmliam.kotventure.core.text.component
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.text.event.DataComponentValue
+import net.kyori.adventure.text.event.HoverEvent
+import java.util.UUID
+
+internal class HoverContentScopeBuilder : HoverContentScope {
+    private var selected = false
+    private var event: HoverEvent<*>? = null
+
+    override fun text(component: ComponentLike) {
+        set(HoverEvent.showText(component))
+    }
+
+    override fun text(
+        value: String,
+        init: TextScope.() -> Unit,
+    ) {
+        text(
+            TextComponentBuilder()
+                .apply {
+                    content(value)
+                    init()
+                }.build(),
+        )
+    }
+
+    override fun text(init: ComponentScope.() -> Unit) {
+        text(component(init))
+    }
+
+    override fun item(
+        key: Key,
+        count: Int,
+        dataComponents: Map<Key, DataComponentValue>,
+    ) {
+        set(HoverEvent.showItem(key, requireShowItemCount(count), dataComponents))
+    }
+
+    override fun entity(
+        type: Key,
+        id: UUID,
+        name: ComponentLike?,
+    ) {
+        set(HoverEvent.showEntity(type, id, name?.asComponent()))
+    }
+
+    override fun entity(
+        type: Key,
+        id: UUID,
+        init: ComponentScope.() -> Unit,
+    ) {
+        entity(type, id, component(init))
+    }
+
+    internal fun build(): HoverEvent<*> =
+        event ?: error("hover { ... } must choose exactly one payload with text(...), item(...), or entity(...).")
+
+    private fun set(event: HoverEvent<*>) {
+        check(!selected) {
+            "hover { ... } must choose only one payload: text(...), item(...), or entity(...)."
+        }
+        selected = true
+        this.event = event
+    }
+}
+
+private fun requireShowItemCount(count: Int): Int {
+    require(count >= 0) {
+        "Show item count must be greater than or equal to 0, but was <$count>."
+    }
+    return count
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverEvent.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverEvent.kt
@@ -1,0 +1,26 @@
+package io.github.lmliam.kotventure.core.event
+
+import net.kyori.adventure.text.event.HoverEvent
+
+/**
+ * Builds a reusable Adventure hover event from a Kotventure hover-content DSL block.
+ *
+ * @throws IllegalStateException when [init] does not choose exactly one hover payload.
+ * @throws IllegalArgumentException when a payload value is rejected before reaching Adventure.
+ */
+public fun hover(init: HoverContentScope.() -> Unit): HoverEvent<*> = buildHoverEvent(init)
+
+internal fun buildHoverEvent(init: HoverContentScope.() -> Unit): HoverEvent<*> =
+    HoverContentScopeBuilder()
+        .apply(init)
+        .build()
+
+/**
+ * Builds an Adventure hover event from a typed [action] and [value].
+ *
+ * @throws IllegalArgumentException when Adventure rejects the action/value pair.
+ */
+public fun <V : Any> hoverEvent(
+    action: HoverEvent.Action<V>,
+    value: V,
+): HoverEvent<V> = HoverEvent.hoverEvent(action, value)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverScope.kt
@@ -1,0 +1,38 @@
+package io.github.lmliam.kotventure.core.event
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.event.HoverEvent
+import net.kyori.adventure.text.event.HoverEventSource
+
+/**
+ * Scope for applying Adventure hover events.
+ */
+@KotventureDslMarker
+public interface HoverScope {
+    /**
+     * Applies [source] as the hover event, or clears the hover event when [source] is null.
+     */
+    public fun hover(source: HoverEventSource<*>?)
+
+    /**
+     * Applies an Adventure hover event built from a typed [action] and [value].
+     *
+     * @throws IllegalArgumentException when Adventure rejects the action/value pair.
+     */
+    public fun <V : Any> hover(
+        action: HoverEvent.Action<V>,
+        value: V,
+    ) {
+        hover(HoverEvent.hoverEvent(action, value))
+    }
+
+    /**
+     * Applies a hover event built from a Kotventure hover-content DSL block.
+     *
+     * @throws IllegalStateException when [init] does not choose exactly one hover payload.
+     * @throws IllegalArgumentException when a payload value is rejected before reaching Adventure.
+     */
+    public fun hover(init: HoverContentScope.() -> Unit) {
+        hover(buildHoverEvent(init))
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleScope.kt
@@ -2,6 +2,7 @@ package io.github.lmliam.kotventure.core.style
 
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
 import io.github.lmliam.kotventure.core.event.ClickScope
+import io.github.lmliam.kotventure.core.event.HoverScope
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
@@ -11,7 +12,9 @@ import net.kyori.adventure.text.format.TextDecoration.State
  * Scope for configuring Adventure style attributes.
  */
 @KotventureDslMarker
-public interface StyleScope : ClickScope {
+public interface StyleScope :
+    ClickScope,
+    HoverScope {
     /**
      * Applies [color] to the style being configured, or clears the color when [color] is null.
      */

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleScopeBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleScopeBuilder.kt
@@ -2,6 +2,7 @@ package io.github.lmliam.kotventure.core.style
 
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.event.HoverEventSource
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
@@ -24,6 +25,10 @@ internal class StyleScopeBuilder(
 
     override fun click(event: ClickEvent<*>?) {
         builder.clickEvent(event)
+    }
+
+    override fun hover(source: HoverEventSource<*>?) {
+        builder.hoverEvent(source)
     }
 
     override fun decoration(

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/HoverEventDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/HoverEventDslTest.kt
@@ -1,0 +1,224 @@
+package io.github.lmliam.kotventure.core.event
+
+import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.style.style
+import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveHoverAction
+import io.github.lmliam.kotventure.test.text.shouldHaveHoverEntity
+import io.github.lmliam.kotventure.test.text.shouldHaveHoverEvent
+import io.github.lmliam.kotventure.test.text.shouldHaveHoverItem
+import io.github.lmliam.kotventure.test.text.shouldHaveHoverText
+import io.github.lmliam.kotventure.test.text.shouldNotHaveHoverEvent
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.nbt.api.BinaryTagHolder
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.DataComponentValue
+import net.kyori.adventure.text.event.HoverEvent
+import net.kyori.adventure.text.format.NamedTextColor
+import java.util.UUID
+
+class HoverEventDslTest :
+    StringSpec(
+        {
+            "builds reusable text hover events" {
+                val event =
+                    hover {
+                        text("Tooltip") {
+                            color(NamedTextColor.AQUA)
+                        }
+                    }
+
+                event.action() shouldBe HoverEvent.Action.SHOW_TEXT
+                val value = event.value() as Component
+                value shouldContainText "Tooltip"
+                value shouldHaveColor NamedTextColor.AQUA
+            }
+
+            "builds reusable item hover events with typed data components" {
+                val dataComponents =
+                    mapOf<Key, DataComponentValue>(
+                        key("minecraft", "custom_data") to BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
+                    )
+                val event =
+                    hover {
+                        item(
+                            key = key("minecraft", "diamond_sword"),
+                            count = 2,
+                            dataComponents = dataComponents,
+                        )
+                    }
+
+                event.action() shouldBe HoverEvent.Action.SHOW_ITEM
+                event.value() shouldBe
+                        HoverEvent.ShowItem.showItem(key("minecraft", "diamond_sword"), 2, dataComponents)
+            }
+
+            "builds reusable entity hover events with component names" {
+                val id = UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee")
+                val name = Component.text("Alex")
+                val event =
+                    hover {
+                        entity(
+                            type = key("minecraft", "player"),
+                            id = id,
+                            name = name,
+                        )
+                    }
+
+                event.action() shouldBe HoverEvent.Action.SHOW_ENTITY
+                event.value() shouldBe HoverEvent.ShowEntity.showEntity(key("minecraft", "player"), id, name)
+            }
+
+            "applies hover events through component scopes" {
+                val id = UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25")
+                val component =
+                    component {
+                        text("Text") {
+                            hover {
+                                text("Text hover")
+                            }
+                        }
+                        text("Item") {
+                            hover {
+                                item(key("minecraft", "stone"))
+                            }
+                        }
+                        text("Entity") {
+                            hover {
+                                entity(key("minecraft", "zombie"), id)
+                            }
+                        }
+                    }
+
+                component.childAt(0) shouldHaveHoverAction HoverEvent.Action.SHOW_TEXT
+                component.childAt(0) shouldHaveHoverText Component.text("Text hover")
+                component.childAt(1) shouldHaveHoverItem HoverEvent.ShowItem.showItem(key("minecraft", "stone"), 1)
+                component.childAt(2) shouldHaveHoverEntity
+                    HoverEvent.ShowEntity.showEntity(key("minecraft", "zombie"), id)
+            }
+
+            "builds rich hover text from nested component DSL content" {
+                val component =
+                    component {
+                        text("Hover") {
+                            hover {
+                                text {
+                                    text("First") {
+                                        color(NamedTextColor.GREEN)
+                                    }
+                                    newline()
+                                    text("Second") {
+                                        color(NamedTextColor.DARK_GREEN)
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                val hoverText = component.childAt(0).hoverEvent()?.value() as Component
+
+                hoverText shouldContainText "First"
+                hoverText shouldContainText "Second"
+                hoverText.childAt(0) shouldHaveColor NamedTextColor.GREEN
+                hoverText.childAt(2) shouldHaveColor NamedTextColor.DARK_GREEN
+            }
+
+            "applies reusable hover events and styles" {
+                val event =
+                    hover {
+                        text("Reusable")
+                    }
+                val style =
+                    style {
+                        hover(event)
+                    }
+                val component =
+                    component {
+                        text("Styled") {
+                            style(style)
+                        }
+                        text("Inline") {
+                            hover(event)
+                        }
+                    }
+
+                component.childAt(0) shouldHaveHoverEvent event
+                component.childAt(1) shouldHaveHoverEvent event
+            }
+
+            "clears hover events through component and style scopes" {
+                val component =
+                    component {
+                        hover {
+                            text("Tooltip")
+                        }
+                        hover(null)
+                    }
+                val styled =
+                    component {
+                        hover {
+                            text("Tooltip")
+                        }
+                        style {
+                            hover(null)
+                        }
+                    }
+
+                component.shouldNotHaveHoverEvent()
+                styled.shouldNotHaveHoverEvent()
+            }
+
+            "builds typed raw hover events with Adventure validation" {
+                val value = Component.text("Raw")
+                val event = hoverEvent(HoverEvent.Action.SHOW_TEXT, value)
+                val component = component { hover(HoverEvent.Action.SHOW_TEXT, value) }
+
+                event.action() shouldBe HoverEvent.Action.SHOW_TEXT
+                event.value() shouldBe value
+                component shouldHaveHoverEvent event
+            }
+
+            "rejects empty hover content blocks" {
+                val failure =
+                    shouldThrow<IllegalStateException> {
+                        hover {
+                        }
+                    }
+
+                failure.message shouldContain "choose exactly one payload"
+            }
+
+            "rejects hover content blocks with multiple payloads" {
+                val failure =
+                    shouldThrow<IllegalStateException> {
+                        hover {
+                            text("One")
+                            item(key("minecraft", "stone"))
+                        }
+                    }
+
+                failure.message shouldContain "choose only one"
+            }
+
+            "rejects negative item counts before calling Adventure" {
+                val failure =
+                    shouldThrow<IllegalArgumentException> {
+                        hover {
+                            item(
+                                key = key("minecraft", "stone"),
+                                count = -1,
+                            )
+                        }
+                    }
+
+                failure.message shouldContain "Show item count must be greater than or equal to 0"
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/HoverEventDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/HoverEventDslTest.kt
@@ -17,6 +17,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import net.kyori.adventure.key.Key
+import net.kyori.adventure.key.Keyed
 import net.kyori.adventure.nbt.api.BinaryTagHolder
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.event.DataComponentValue
@@ -60,6 +61,20 @@ class HoverEventDslTest :
                         HoverEvent.ShowItem.showItem(key("minecraft", "diamond_sword"), 2, dataComponents)
             }
 
+            "builds reusable item hover events from keyed values and permits zero counts" {
+                val keyedItem = Keyed { key("minecraft", "stone") }
+                val event =
+                    hover {
+                        item(
+                            item = keyedItem,
+                            count = 0,
+                        )
+                    }
+
+                event.action() shouldBe HoverEvent.Action.SHOW_ITEM
+                event.value() shouldBe HoverEvent.ShowItem.showItem(key("minecraft", "stone"), 0)
+            }
+
             "builds reusable entity hover events with component names" {
                 val id = UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee")
                 val name = Component.text("Alex")
@@ -74,6 +89,23 @@ class HoverEventDslTest :
 
                 event.action() shouldBe HoverEvent.Action.SHOW_ENTITY
                 event.value() shouldBe HoverEvent.ShowEntity.showEntity(key("minecraft", "player"), id, name)
+            }
+
+            "builds reusable entity hover events from keyed values" {
+                val id = UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25")
+                val entityType = Keyed { key("minecraft", "zombie") }
+                val event =
+                    hover {
+                        entity(
+                            type = entityType,
+                            id = id,
+                            name = Component.text("Zombie"),
+                        )
+                    }
+
+                event.action() shouldBe HoverEvent.Action.SHOW_ENTITY
+                event.value() shouldBe
+                        HoverEvent.ShowEntity.showEntity(key("minecraft", "zombie"), id, Component.text("Zombie"))
             }
 
             "applies hover events through component scopes" {

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -10,11 +10,20 @@ import io.github.lmliam.kotventure.test.text.shouldBeObjectComponent
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveHoverEntity
+import io.github.lmliam.kotventure.test.text.shouldHaveHoverItem
+import io.github.lmliam.kotventure.test.text.shouldHaveHoverText
 import io.github.lmliam.kotventure.test.text.shouldHaveObjectContents
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.nbt.api.BinaryTagHolder
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.DataComponentValue
+import net.kyori.adventure.text.event.HoverEvent
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.minimessage.MiniMessage
+import java.util.UUID
 
 /**
  * Verifies Kotventure's component serializer extensions delegate to Adventure's concrete serializers.
@@ -116,6 +125,71 @@ class ComponentSerializerExtensionsTest :
                 val roundTripped = MiniMessage.miniMessage().deserialize(serialized).shouldBeObjectComponent()
 
                 roundTripped shouldHaveObjectContents contents
+            }
+
+            "round-trips text hover payloads through MiniMessage" {
+                val message =
+                    component {
+                        text("Hover") {
+                            hover {
+                                text("Tooltip")
+                            }
+                        }
+                    }
+
+                val roundTripped = MiniMessage.miniMessage().deserialize(message.toMiniMessage())
+
+                roundTripped shouldHaveHoverText Component.text("Tooltip")
+            }
+
+            "round-trips item hover payload data components through MiniMessage" {
+                val dataComponents =
+                    mapOf<Key, DataComponentValue>(
+                        key("minecraft", "custom_data") to BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
+                    )
+                val item = HoverEvent.ShowItem.showItem(key("minecraft", "diamond_sword"), 1, dataComponents)
+                val message =
+                    component {
+                        text("Hover") {
+                            hover {
+                                item(
+                                    key = key("minecraft", "diamond_sword"),
+                                    dataComponents = dataComponents,
+                                )
+                            }
+                        }
+                    }
+
+                val roundTripped = MiniMessage.miniMessage().deserialize(message.toMiniMessage())
+
+                roundTripped shouldHaveHoverItem item
+            }
+
+            "round-trips entity hover payloads through MiniMessage" {
+                val id = UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee")
+                val entity =
+                    HoverEvent.ShowEntity.showEntity(
+                        key("minecraft", "player"),
+                        id,
+                        Component.text("Alex"),
+                    )
+                val message =
+                    component {
+                        text("Hover") {
+                            hover {
+                                entity(
+                                    type = key("minecraft", "player"),
+                                    id = id,
+                                ) {
+                                    text("Alex")
+                                }
+                            }
+                        }
+                    }
+
+                val roundTripped = MiniMessage.miniMessage().deserialize(message.toMiniMessage())
+
+                roundTripped shouldHaveHoverEntity entity
             }
         },
     )

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/HoverEventMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/HoverEventMatchers.kt
@@ -1,0 +1,127 @@
+package io.github.lmliam.kotventure.test.text
+
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.should
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.HoverEvent
+
+/**
+ * Asserts that this component has exactly [expected] as its root hover event.
+ */
+public infix fun Component.shouldHaveHoverEvent(expected: HoverEvent<*>): Component =
+    apply {
+        this should haveHoverEvent(expected)
+    }
+
+/**
+ * Asserts that this component has [expected] as its root hover event action.
+ */
+public infix fun Component.shouldHaveHoverAction(expected: HoverEvent.Action<*>): Component =
+    apply {
+        this should haveHoverAction(expected)
+    }
+
+/**
+ * Asserts that this component has [expected] as its root text hover payload.
+ */
+public infix fun Component.shouldHaveHoverText(expected: Component): Component =
+    apply {
+        this should haveHoverText(expected)
+    }
+
+/**
+ * Asserts that this component has [expected] as its root item hover payload.
+ */
+public infix fun Component.shouldHaveHoverItem(expected: HoverEvent.ShowItem): Component =
+    apply {
+        this should haveHoverItem(expected)
+    }
+
+/**
+ * Asserts that this component has [expected] as its root entity hover payload.
+ */
+public infix fun Component.shouldHaveHoverEntity(expected: HoverEvent.ShowEntity): Component =
+    apply {
+        this should haveHoverEntity(expected)
+    }
+
+/**
+ * Asserts that this component has no root hover event.
+ */
+public fun Component.shouldNotHaveHoverEvent(): Component =
+    apply {
+        this should haveNoHoverEvent()
+    }
+
+private fun haveHoverEvent(expected: HoverEvent<*>): Matcher<Component> =
+    Matcher { value ->
+        val actual = value.hoverEvent()
+        MatcherResult(
+            actual == expected,
+            { "Expected hover event <$expected>, but was <${actual ?: "null"}>." },
+            { "Expected hover event not to be <$expected>." },
+        )
+    }
+
+private fun haveHoverAction(expected: HoverEvent.Action<*>): Matcher<Component> =
+    Matcher { value ->
+        val actual = value.hoverEvent()?.action()
+        MatcherResult(
+            actual == expected,
+            { "Expected hover action <$expected>, but was <${actual ?: "null"}>." },
+            { "Expected hover action not to be <$expected>." },
+        )
+    }
+
+private fun haveHoverText(expected: Component): Matcher<Component> =
+    Matcher { value ->
+        val payload = value.hoverEvent()?.value()
+        val actual = payload as? Component
+        MatcherResult(
+            actual == expected,
+            { "Expected hover text payload <$expected>, but was <${actual ?: hoverPayloadDescription(payload)}>." },
+            { "Expected hover text payload not to be <$expected>." },
+        )
+    }
+
+private fun haveHoverItem(expected: HoverEvent.ShowItem): Matcher<Component> =
+    Matcher { value ->
+        val payload = value.hoverEvent()?.value()
+        val actual = payload as? HoverEvent.ShowItem
+        MatcherResult(
+            actual == expected,
+            { "Expected hover item payload <$expected>, but was <${actual ?: hoverPayloadDescription(payload)}>." },
+            { "Expected hover item payload not to be <$expected>." },
+        )
+    }
+
+private fun haveHoverEntity(expected: HoverEvent.ShowEntity): Matcher<Component> =
+    Matcher { value ->
+        val payload = value.hoverEvent()?.value()
+        val actual = payload as? HoverEvent.ShowEntity
+        MatcherResult(
+            actual == expected,
+            { "Expected hover entity payload <$expected>, but was <${actual ?: hoverPayloadDescription(payload)}>." },
+            { "Expected hover entity payload not to be <$expected>." },
+        )
+    }
+
+private fun haveNoHoverEvent(): Matcher<Component> =
+    Matcher { value ->
+        val actual = value.hoverEvent()
+        MatcherResult(
+            actual == null,
+            { "Expected hover event to be absent, but was <$actual>." },
+            { "Expected hover event to be present." },
+        )
+    }
+
+private fun hoverPayloadDescription(payload: Any?): String =
+    when (payload) {
+        null -> "no hover event"
+        is Component -> "text payload <$payload>"
+        is HoverEvent.ShowItem -> "item payload <$payload>"
+        is HoverEvent.ShowEntity -> "entity payload <$payload>"
+        else -> payload.toString()
+    }

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/HoverEventMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/HoverEventMatchersTest.kt
@@ -1,0 +1,188 @@
+package io.github.lmliam.kotventure.test.text
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.HoverEvent
+import java.util.UUID
+
+class HoverEventMatchersTest :
+    StringSpec(
+        {
+            "matches root hover events" {
+                val hoverEvent = HoverEvent.showText(Component.text("Tooltip"))
+
+                Component.text("Hover").hoverEvent(hoverEvent) shouldHaveHoverEvent hoverEvent
+            }
+
+            "matches root hover event actions" {
+                Component
+                    .text("Hover")
+                    .hoverEvent(HoverEvent.showText(Component.text("Tooltip"))) shouldHaveHoverAction
+                    HoverEvent.Action.SHOW_TEXT
+            }
+
+            "matches text hover payloads" {
+                Component
+                    .text("Hover")
+                    .hoverEvent(HoverEvent.showText(Component.text("Tooltip"))) shouldHaveHoverText
+                    Component.text("Tooltip")
+            }
+
+            "matches item hover payloads" {
+                val item = HoverEvent.ShowItem.showItem(Key.key("minecraft", "diamond"), 2)
+
+                Component.text("Hover").hoverEvent(HoverEvent.showItem(item)) shouldHaveHoverItem item
+            }
+
+            "matches entity hover payloads" {
+                val entity =
+                    HoverEvent.ShowEntity.showEntity(
+                        Key.key("minecraft", "player"),
+                        UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee"),
+                        Component.text("Alex"),
+                    )
+
+                Component.text("Hover").hoverEvent(HoverEvent.showEntity(entity)) shouldHaveHoverEntity entity
+            }
+
+            "matches components without hover events" {
+                Component.text("Plain").shouldNotHaveHoverEvent()
+            }
+
+            "reports missing hover events" {
+                val expected = HoverEvent.showText(Component.text("Tooltip"))
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("Plain") shouldHaveHoverEvent expected
+                    }
+                val expectedMessage = "Expected hover event <$expected>, but was <null>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports hover action mismatches" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component
+                            .text("Hover")
+                            .hoverEvent(HoverEvent.showText(Component.text("Tooltip"))) shouldHaveHoverAction
+                            HoverEvent.Action.SHOW_ITEM
+                    }
+                val expectedMessage =
+                    "Expected hover action <${HoverEvent.Action.SHOW_ITEM}>, " +
+                            "but was <${HoverEvent.Action.SHOW_TEXT}>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports text hover payload mismatches" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component
+                            .text("Hover")
+                            .hoverEvent(HoverEvent.showText(Component.text("actual"))) shouldHaveHoverText
+                            Component.text("expected")
+                    }
+                val expectedMessage =
+                    "Expected hover text payload <${Component.text("expected")}>, " +
+                            "but was <${Component.text("actual")}>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports text hover payload type mismatches" {
+                val item = HoverEvent.ShowItem.showItem(Key.key("minecraft", "stone"), 1)
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("Hover").hoverEvent(HoverEvent.showItem(item)) shouldHaveHoverText
+                            Component.text("expected")
+                    }
+                val expectedMessage =
+                    "Expected hover text payload <${Component.text("expected")}>, " +
+                            "but was <item payload <$item>>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports item hover payload mismatches" {
+                val expected = HoverEvent.ShowItem.showItem(Key.key("minecraft", "diamond"), 1)
+                val actual = HoverEvent.ShowItem.showItem(Key.key("minecraft", "stone"), 1)
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("Hover").hoverEvent(HoverEvent.showItem(actual)) shouldHaveHoverItem expected
+                    }
+                val expectedMessage = "Expected hover item payload <$expected>, but was <$actual>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports item hover payload type mismatches" {
+                val expected = HoverEvent.ShowItem.showItem(Key.key("minecraft", "diamond"), 1)
+                val text = Component.text("Tooltip")
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("Hover").hoverEvent(HoverEvent.showText(text)) shouldHaveHoverItem expected
+                    }
+                val expectedMessage = "Expected hover item payload <$expected>, but was <text payload <$text>>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports entity hover payload mismatches" {
+                val expected =
+                    HoverEvent.ShowEntity.showEntity(
+                        Key.key("minecraft", "player"),
+                        UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee"),
+                    )
+                val actual =
+                    HoverEvent.ShowEntity.showEntity(
+                        Key.key("minecraft", "player"),
+                        UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25"),
+                    )
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("Hover").hoverEvent(HoverEvent.showEntity(actual)) shouldHaveHoverEntity expected
+                    }
+                val expectedMessage = "Expected hover entity payload <$expected>, but was <$actual>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports entity hover payload type mismatches" {
+                val expected =
+                    HoverEvent.ShowEntity.showEntity(
+                        Key.key("minecraft", "player"),
+                        UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee"),
+                    )
+                val text = Component.text("Tooltip")
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("Hover").hoverEvent(HoverEvent.showText(text)) shouldHaveHoverEntity expected
+                    }
+                val expectedMessage = "Expected hover entity payload <$expected>, but was <text payload <$text>>."
+
+                failure.message shouldContain expectedMessage
+            }
+
+            "reports unexpected hover events" {
+                val actual = HoverEvent.showText(Component.text("Tooltip"))
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        Component.text("Hover").hoverEvent(actual).shouldNotHaveHoverEvent()
+                    }
+                val expectedMessage = "Expected hover event to be absent, but was <$actual>."
+
+                failure.message shouldContain expectedMessage
+            }
+        },
+    )


### PR DESCRIPTION
## Summary

Adds a Kotlin-first hover event DSL for Adventure text, item, and entity hover payloads, plus reusable hover-event factories and component/style scope application.

## Related Issues

Closes #22

## DSL Impact

- Adds top-level reusable `hover { ... }` events with `text(...)`, `item(...)`, and `entity(...)` payload selectors.
- Adds component/style scope support for `hover { ... }`, `hover(source)`, `hover(null)`, and typed `hover(action, value)` interop.
- Adds hover-event test matchers for component assertions.

## Rationale

Hover events are part of Adventure style state, so downstream Kotlin callers should be able to build and apply them with the same typed DSL shape as components, styles, and click events while still producing real Adventure `HoverEvent` payloads.

## Testing

- `./gradlew :test:test --tests io.github.lmliam.kotventure.test.text.HoverEventMatchersTest`
- `./gradlew :core:test --tests io.github.lmliam.kotventure.core.event.HoverEventDslTest`
- `./gradlew :serializer:test --tests io.github.lmliam.kotventure.serializer.ComponentSerializerExtensionsTest`
- `./gradlew ktlintFormat`
- `./gradlew ktlintCheck spotlessCheck`
- `./gradlew build`

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages (README and CHANGELOG updated; no separate docs page exists for this slice)
- [x] Verified examples build and run (DSL examples are covered by compiling unit tests with equivalent hover usage)
