### PR TITLE
feat(core): replace direct click helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,10 +105,17 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
   and matching component assertions for style attributes.
 - Colour and gradient helpers for `hex("#RRGGBB")`, `rgb(...)`, normalized `hsv(...)`, named palette aliases,
   interpolation, and per-code-point gradient text.
-- Click event DSL support for Adventure's typed click actions and server-side callbacks, including file-URI-aware `open`,
-  concise `run`/`suggest`/`copy` helpers, Kotlin duration callback options, and click-event component matchers.
+- Click event DSL support for Adventure's typed click actions and server-side callbacks, including reusable `click { }`
+  factories, scoped block application, file-URI-aware `open`, Kotlin duration callback options, and click-event component
+  matchers.
 - Hover event DSL support for typed text, item data component, and entity payloads, including reusable hover factories,
   clearing/prebuilt interop, MiniMessage round-trip coverage, and hover-event component matchers.
+
+### Changed
+
+- Click action helpers now live only inside `click { ... }`; the direct `open(...)`, `openUrl(...)`, `openFile(...)`,
+  `run(...)`, `suggest(...)`, `changePage(...)`, `copy(...)`, and `callback(...)` helpers on component/style scopes were
+  removed before the pre-alpha event DSL settles.
 
 ## [0.0.1] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -97,12 +97,16 @@ val message = component {
 }
 ```
 
-Click events wrap Adventure's typed `ClickEvent` factories directly and can be applied through component scopes or
-reusable styles:
+Click events wrap Adventure's typed `ClickEvent` factories directly. Use `click { ... }` to select one action, either
+as a reusable event factory or inside component and style scopes:
 
 ```kotlin
-val linkStyle = style {
+val linkClick = click {
     open("https://example.com")
+}
+
+val linkStyle = style {
+    click(linkClick)
 }
 
 val actions = component {
@@ -110,20 +114,25 @@ val actions = component {
         style(linkStyle)
     }
     text(" copy invite") {
-        copy("play.example.com")
+        click {
+            copy("play.example.com")
+        }
     }
     text(" claim reward") {
-        callback(uses = 1, lifetime = 5.minutes) { audience ->
-            audience.sendMessage(component { text("Reward claimed") })
+        click {
+            callback(uses = 1, lifetime = 5.minutes) { audience ->
+                audience.sendMessage(component { text("Reward claimed") })
+            }
         }
     }
 }
 ```
 
-Inside component and style scopes, `open(...)` creates an open-file event for `file:` URIs and an open-URL event
-otherwise; `openUrl(...)` and `openFile(...)` remain available when you want the action to be explicit.
-Click events are available on reusable styles because Adventure models click events as part of `Style`; Kotventure keeps
-that shape instead of introducing a separate link wrapper.
+Inside `click { ... }`, `open(...)` creates an open-file event for usable `file:` URIs and an open-URL event otherwise;
+`openUrl(...)` and `openFile(...)` remain available when you want the action to be explicit. Use `click(event)` for a
+prebuilt Adventure click event and `click(null)` to clear one. Click events are available on reusable styles because
+Adventure models click events as part of `Style`; Kotventure keeps that shape instead of introducing a separate link
+wrapper.
 
 Hover events use the same component/style scope model and wrap Adventure's typed `HoverEvent` payloads:
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ClickActionScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ClickActionScope.kt
@@ -1,0 +1,71 @@
+package io.github.lmliam.kotventure.core.event
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.event.ClickCallback
+import kotlin.time.Duration as KotlinDuration
+
+/**
+ * Scope for selecting the single action produced by a click event.
+ */
+@KotventureDslMarker
+public interface ClickActionScope {
+    /**
+     * Selects a click action that opens [target].
+     *
+     * File URI targets are converted to open-file events; all other targets are treated as URLs.
+     */
+    public fun open(target: String)
+
+    /**
+     * Selects a click action that opens [url].
+     */
+    public fun openUrl(url: String)
+
+    /**
+     * Selects a click action that opens a local [file] path.
+     */
+    public fun openFile(file: String)
+
+    /**
+     * Selects a click action that runs [command].
+     */
+    public fun run(command: String)
+
+    /**
+     * Selects a click action that suggests [command] in chat.
+     */
+    public fun suggest(command: String)
+
+    /**
+     * Selects a click action that changes a book to [page].
+     */
+    public fun changePage(page: Int)
+
+    /**
+     * Selects a click action that copies [text] to the clipboard.
+     */
+    public fun copy(text: String)
+
+    /**
+     * Selects a server-side callback click action from [function].
+     */
+    public fun callback(function: ClickCallback<Audience>)
+
+    /**
+     * Selects a server-side callback click action from [function] with [uses] and [lifetime].
+     */
+    public fun callback(
+        uses: Int,
+        lifetime: KotlinDuration,
+        function: ClickCallback<Audience>,
+    )
+
+    /**
+     * Selects a server-side callback click action from [function] with prebuilt [options].
+     */
+    public fun callback(
+        options: ClickCallback.Options,
+        function: ClickCallback<Audience>,
+    )
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ClickActionScopeBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ClickActionScopeBuilder.kt
@@ -1,0 +1,80 @@
+package io.github.lmliam.kotventure.core.event
+
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.event.ClickCallback
+import net.kyori.adventure.text.event.ClickEvent
+import kotlin.time.toJavaDuration
+import kotlin.time.Duration as KotlinDuration
+
+internal class ClickActionScopeBuilder : ClickActionScope {
+    private var selected = false
+    private var event: ClickEvent<*>? = null
+
+    override fun open(target: String) {
+        set(openTarget(target))
+    }
+
+    override fun openUrl(url: String) {
+        set(ClickEvent.openUrl(url))
+    }
+
+    override fun openFile(file: String) {
+        set(ClickEvent.openFile(file))
+    }
+
+    override fun run(command: String) {
+        set(ClickEvent.runCommand(command))
+    }
+
+    override fun suggest(command: String) {
+        set(ClickEvent.suggestCommand(command))
+    }
+
+    override fun changePage(page: Int) {
+        set(ClickEvent.changePage(page))
+    }
+
+    override fun copy(text: String) {
+        set(ClickEvent.copyToClipboard(text))
+    }
+
+    override fun callback(function: ClickCallback<Audience>) {
+        set(ClickEvent.callback(function))
+    }
+
+    override fun callback(
+        uses: Int,
+        lifetime: KotlinDuration,
+        function: ClickCallback<Audience>,
+    ) {
+        set(
+            ClickEvent.callback(function) { options ->
+                options.uses(uses)
+                options.lifetime(lifetime.toJavaDuration())
+            },
+        )
+    }
+
+    override fun callback(
+        options: ClickCallback.Options,
+        function: ClickCallback<Audience>,
+    ) {
+        set(ClickEvent.callback(function, options))
+    }
+
+    internal fun build(): ClickEvent<*> =
+        event
+            ?: error(
+                "click { ... } must choose exactly one action with open(...), openUrl(...), openFile(...), " +
+                        "run(...), suggest(...), changePage(...), copy(...), or callback(...).",
+            )
+
+    private fun set(event: ClickEvent<*>) {
+        check(!selected) {
+            "click { ... } must choose only one action: open(...), openUrl(...), openFile(...), run(...), " +
+                    "suggest(...), changePage(...), copy(...), or callback(...)."
+        }
+        selected = true
+        this.event = event
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ClickEvent.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ClickEvent.kt
@@ -10,6 +10,19 @@ internal fun openTarget(target: String): ClickEvent<ClickEvent.Payload.Text> =
         ?: ClickEvent.openUrl(target)
 
 /**
+ * Builds a reusable Adventure click event from a Kotventure click-action DSL block.
+ *
+ * @throws IllegalStateException when [init] does not choose exactly one click action.
+ * @throws IllegalArgumentException when Adventure rejects the selected action payload.
+ */
+public fun click(init: ClickActionScope.() -> Unit): ClickEvent<*> = buildClickEvent(init)
+
+internal fun buildClickEvent(init: ClickActionScope.() -> Unit): ClickEvent<*> =
+    ClickActionScopeBuilder()
+        .apply(init)
+        .build()
+
+/**
  * Builds an Adventure click event from a typed [action] and [payload].
  *
  * @throws IllegalArgumentException when Adventure rejects the action/payload pair.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ClickScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ClickScope.kt
@@ -1,11 +1,7 @@
 package io.github.lmliam.kotventure.core.event
 
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
-import net.kyori.adventure.audience.Audience
-import net.kyori.adventure.text.event.ClickCallback
 import net.kyori.adventure.text.event.ClickEvent
-import kotlin.time.toJavaDuration
-import kotlin.time.Duration as KotlinDuration
 
 /**
  * Scope for applying Adventure click events.
@@ -30,86 +26,12 @@ public interface ClickScope {
     }
 
     /**
-     * Applies a click event that opens [target].
+     * Applies a click event built from a Kotventure click-action DSL block.
      *
-     * File URI targets are converted to open-file events; all other targets are treated as URLs.
+     * @throws IllegalStateException when [init] does not choose exactly one click action.
+     * @throws IllegalArgumentException when Adventure rejects the selected action payload.
      */
-    public fun open(target: String) {
-        click(openTarget(target))
-    }
-
-    /**
-     * Applies a click event that opens [url].
-     */
-    public fun openUrl(url: String) {
-        click(ClickEvent.openUrl(url))
-    }
-
-    /**
-     * Applies a click event that opens a local [file] path.
-     */
-    public fun openFile(file: String) {
-        click(ClickEvent.openFile(file))
-    }
-
-    /**
-     * Applies a click event that runs [command].
-     */
-    public fun run(command: String) {
-        click(ClickEvent.runCommand(command))
-    }
-
-    /**
-     * Applies a click event that suggests [command] in chat.
-     */
-    public fun suggest(command: String) {
-        click(ClickEvent.suggestCommand(command))
-    }
-
-    /**
-     * Applies a click event that changes a book to [page].
-     */
-    public fun changePage(page: Int) {
-        click(ClickEvent.changePage(page))
-    }
-
-    /**
-     * Applies a click event that copies [text] to the clipboard.
-     */
-    public fun copy(text: String) {
-        click(ClickEvent.copyToClipboard(text))
-    }
-
-    /**
-     * Applies a server-side callback click event from [function].
-     */
-    public fun callback(function: ClickCallback<Audience>) {
-        click(ClickEvent.callback(function))
-    }
-
-    /**
-     * Applies a server-side callback click event from [function] with [uses] and [lifetime].
-     */
-    public fun callback(
-        uses: Int,
-        lifetime: KotlinDuration,
-        function: ClickCallback<Audience>,
-    ) {
-        click(
-            ClickEvent.callback(function) { options ->
-                options.uses(uses)
-                options.lifetime(lifetime.toJavaDuration())
-            },
-        )
-    }
-
-    /**
-     * Applies a server-side callback click event from [function] with prebuilt [options].
-     */
-    public fun callback(
-        options: ClickCallback.Options,
-        function: ClickCallback<Audience>,
-    ) {
-        click(ClickEvent.callback(function, options))
+    public fun click(init: ClickActionScope.() -> Unit) {
+        click(buildClickEvent(init))
     }
 }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/ClickEventDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/ClickEventDslTest.kt
@@ -196,6 +196,12 @@ class ClickEventDslTest :
                     component {
                         click(manualEvent)
                     }
+                val styledComponent =
+                    component {
+                        style {
+                            click(manualEvent)
+                        }
+                    }
                 val clearedComponent =
                     component {
                         click(manualEvent)
@@ -210,6 +216,7 @@ class ClickEventDslTest :
                     }
 
                 component shouldHaveClickEvent manualEvent
+                styledComponent shouldHaveClickEvent manualEvent
                 clearedComponent.shouldNotHaveClickEvent()
                 clearedStyle.shouldNotHaveClickEvent()
             }
@@ -364,32 +371,69 @@ class ClickEventDslTest :
             "removes direct action helpers from explicit click scopes" {
                 val helperCalls =
                     mapOf(
-                        "Open" to """scope.open("https://example.com")""",
-                        "OpenUrl" to """scope.openUrl("https://example.com")""",
-                        "OpenFile" to """scope.openFile("/tmp/example.txt")""",
-                        "Run" to """scope.run("/spawn")""",
-                        "Suggest" to """scope.suggest("/msg Alex ")""",
-                        "ChangePage" to """scope.changePage(2)""",
-                        "Copy" to """scope.copy("secret")""",
+                        "Open" to
+                                CompileFailureCase(
+                                    """scope.open("https://example.com")""",
+                                    "Unresolved reference 'open'",
+                                ),
+                        "OpenUrl" to
+                                CompileFailureCase(
+                                    """scope.openUrl("https://example.com")""",
+                                    "Unresolved reference 'openUrl'",
+                                ),
+                        "OpenFile" to
+                                CompileFailureCase(
+                                    """scope.openFile("/tmp/example.txt")""",
+                                    "Unresolved reference 'openFile'",
+                                ),
+                        "Run" to
+                                CompileFailureCase(
+                                    """scope.run("/spawn")""",
+                                    "Argument type mismatch",
+                                ),
+                        "Suggest" to
+                                CompileFailureCase(
+                                    """scope.suggest("/msg Alex ")""",
+                                    "Unresolved reference 'suggest'",
+                                ),
+                        "ChangePage" to
+                                CompileFailureCase(
+                                    """scope.changePage(2)""",
+                                    "Unresolved reference 'changePage'",
+                                ),
+                        "Copy" to
+                                CompileFailureCase(
+                                    """scope.copy("secret")""",
+                                    "Unresolved reference 'copy'",
+                                ),
                         "Callback" to
-                                """
-                                val callback = ClickCallback<Audience> { }
-                                scope.callback(callback)
-                                """.trimIndent(),
+                                CompileFailureCase(
+                                    """
+                                    val callback = ClickCallback<Audience> { }
+                                    scope.callback(callback)
+                                    """.trimIndent(),
+                                    "Unresolved reference 'callback'",
+                                ),
                         "CallbackWithOptions" to
-                                """
-                                val callback = ClickCallback<Audience> { }
-                                val options = ClickCallback.Options.builder().uses(1).build()
-                                scope.callback(options, callback)
-                                """.trimIndent(),
+                                CompileFailureCase(
+                                    """
+                                    val callback = ClickCallback<Audience> { }
+                                    val options = ClickCallback.Options.builder().uses(1).build()
+                                    scope.callback(options, callback)
+                                    """.trimIndent(),
+                                    "Unresolved reference 'callback'",
+                                ),
                         "CallbackWithUsesAndLifetime" to
-                                """
-                                val callback = ClickCallback<Audience> { }
-                                scope.callback(1, 1.minutes, callback)
-                                """.trimIndent(),
+                                CompileFailureCase(
+                                    """
+                                    val callback = ClickCallback<Audience> { }
+                                    scope.callback(1, 1.minutes, callback)
+                                    """.trimIndent(),
+                                    "Unresolved reference 'callback'",
+                                ),
                     )
 
-                helperCalls.forEach { (name, call) ->
+                helperCalls.forEach { (name, failure) ->
                     assertDoesNotCompile(
                         "Removed${name}ClickScopeHelperTest.kt",
                         """
@@ -399,14 +443,20 @@ class ClickEventDslTest :
                         import kotlin.time.Duration.Companion.minutes
 
                         fun shouldNotCompile(scope: ClickScope) {
-                            $call
+                            ${failure.source}
                         }
                         """.trimIndent(),
+                        failure.expectedMessage,
                     )
                 }
             }
         },
     )
+
+private data class CompileFailureCase(
+    val source: String,
+    val expectedMessage: String,
+)
 
 @OptIn(ExperimentalCompilerApi::class)
 private fun assertDoesNotCompile(

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/ClickEventDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/ClickEventDslTest.kt
@@ -1,5 +1,7 @@
 package io.github.lmliam.kotventure.core.event
 
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
 import io.github.lmliam.kotventure.core.key.key
 import io.github.lmliam.kotventure.core.style.style
 import io.github.lmliam.kotventure.core.text.component
@@ -17,65 +19,59 @@ import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.event.ClickCallback
 import net.kyori.adventure.text.event.ClickEvent
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import java.nio.file.Path
 import kotlin.time.Duration.Companion.minutes
 import java.time.Duration as JavaDuration
 
+@OptIn(ExperimentalCompilerApi::class)
 class ClickEventDslTest :
     StringSpec(
         {
-            "builds every text payload click event action" {
-                val components =
+            "builds reusable text payload click event actions" {
+                val events =
                     listOf(
-                        component { openUrl("https://example.com") } to
+                        click { openUrl("https://example.com") } to
                                 (ClickEvent.Action.OPEN_URL to "https://example.com"),
-                        component { openFile("/tmp/example.txt") } to
+                        click { openFile("/tmp/example.txt") } to
                                 (ClickEvent.Action.OPEN_FILE to "/tmp/example.txt"),
-                        component { run("/spawn") } to
+                        click { run("/spawn") } to
                                 (ClickEvent.Action.RUN_COMMAND to "/spawn"),
-                        component { suggest("/msg Alex ") } to
+                        click { suggest("/msg Alex ") } to
                                 (ClickEvent.Action.SUGGEST_COMMAND to "/msg Alex "),
-                        component { copy("copied") } to
+                        click { copy("copied") } to
                                 (ClickEvent.Action.COPY_TO_CLIPBOARD to "copied"),
                     )
 
-                components.forEach { (component, expected) ->
+                events.forEach { (event, expected) ->
                     val (action, payload) = expected
-                    component shouldHaveClickAction action
-                    component shouldHaveClickTextPayload payload
+                    Component.text("Action").clickEvent(event) shouldHaveClickAction action
+                    Component.text("Action").clickEvent(event) shouldHaveClickTextPayload payload
                 }
             }
 
-            "builds change page click events with integer payloads" {
-                val component = component { changePage(4) }
-
-                component shouldHaveClickAction ClickEvent.Action.CHANGE_PAGE
-                component shouldHaveClickIntPayload 4
-            }
-
-            "builds open and copy helpers" {
-                val openComponent = component { open("https://example.com") }
-                val copyComponent = component { copy("copied") }
-
-                openComponent shouldHaveClickAction ClickEvent.Action.OPEN_URL
-                openComponent shouldHaveClickTextPayload "https://example.com"
-                copyComponent shouldHaveClickAction ClickEvent.Action.COPY_TO_CLIPBOARD
-                copyComponent shouldHaveClickTextPayload "copied"
-            }
-
-            "builds open file events from file uris" {
+            "builds reusable auto-target open click events" {
                 val path =
                     Path
                         .of("build", "click-event-dsl-test.txt")
                         .toAbsolutePath()
                         .normalize()
-                val component = component { open(path.toUri().toString()) }
+                val urlEvent =
+                    click {
+                        open("https://example.com")
+                    }
+                val fileEvent =
+                    click {
+                        open(path.toUri().toString())
+                    }
 
-                component shouldHaveClickAction ClickEvent.Action.OPEN_FILE
-                component shouldHaveClickTextPayload path.toString()
+                Component.text("Url").clickEvent(urlEvent) shouldHaveClickAction ClickEvent.Action.OPEN_URL
+                Component.text("Url").clickEvent(urlEvent) shouldHaveClickTextPayload "https://example.com"
+                Component.text("File").clickEvent(fileEvent) shouldHaveClickAction ClickEvent.Action.OPEN_FILE
+                Component.text("File").clickEvent(fileEvent) shouldHaveClickTextPayload path.toString()
             }
 
-            "keeps explicit open url events for file uris" {
+            "keeps explicit open url and open file click events" {
                 val target =
                     Path
                         .of("build", "click-event-dsl-test.txt")
@@ -83,30 +79,43 @@ class ClickEventDslTest :
                         .normalize()
                         .toUri()
                         .toString()
-                val component = component { openUrl(target) }
+                val urlEvent =
+                    click {
+                        openUrl(target)
+                    }
+                val fileEvent =
+                    click {
+                        openFile("/tmp/example.txt")
+                    }
 
-                component shouldHaveClickAction ClickEvent.Action.OPEN_URL
-                component shouldHaveClickTextPayload target
+                Component.text("Url").clickEvent(urlEvent) shouldHaveClickAction ClickEvent.Action.OPEN_URL
+                Component.text("Url").clickEvent(urlEvent) shouldHaveClickTextPayload target
+                Component.text("File").clickEvent(fileEvent) shouldHaveClickAction ClickEvent.Action.OPEN_FILE
+                Component.text("File").clickEvent(fileEvent) shouldHaveClickTextPayload "/tmp/example.txt"
             }
 
-            "falls back to open url events for file uris that are not paths" {
-                val component = component { open("file:notes.txt") }
+            "builds reusable change page click events with integer payloads" {
+                val event =
+                    click {
+                        changePage(4)
+                    }
 
-                component shouldHaveClickAction ClickEvent.Action.OPEN_URL
-                component shouldHaveClickTextPayload "file:notes.txt"
+                Component.text("Page").clickEvent(event) shouldHaveClickAction ClickEvent.Action.CHANGE_PAGE
+                Component.text("Page").clickEvent(event) shouldHaveClickIntPayload 4
             }
 
-            "falls back to open url events for targets without schemes" {
-                val components =
+            "falls back to open url events for non-path targets" {
+                val events =
                     listOf(
-                        component { open("example.com") } to "example.com",
-                        component { open("/server/rules") } to "/server/rules",
-                        component { open("relative/path") } to "relative/path",
+                        click { open("file:notes.txt") } to "file:notes.txt",
+                        click { open("example.com") } to "example.com",
+                        click { open("/server/rules") } to "/server/rules",
+                        click { open("relative/path") } to "relative/path",
                     )
 
-                components.forEach { (component, target) ->
-                    component shouldHaveClickAction ClickEvent.Action.OPEN_URL
-                    component shouldHaveClickTextPayload target
+                events.forEach { (event, target) ->
+                    Component.text("Open").clickEvent(event) shouldHaveClickAction ClickEvent.Action.OPEN_URL
+                    Component.text("Open").clickEvent(event) shouldHaveClickTextPayload target
                 }
             }
 
@@ -120,24 +129,28 @@ class ClickEventDslTest :
                 component shouldHaveClickEvent event
             }
 
-            "applies click events through component scopes" {
-                val manualEvent = ClickEvent.openUrl("https://example.org")
+            "applies block click events through component scopes" {
                 val component =
                     component {
                         text("Open") {
-                            open("https://example.com")
+                            click {
+                                open("https://example.com")
+                            }
                         }
                         text("Run") {
-                            run("/spawn")
+                            click {
+                                run("/spawn")
+                            }
                         }
                         text("Suggest") {
-                            suggest("/msg Alex ")
+                            click {
+                                suggest("/msg Alex ")
+                            }
                         }
                         text("Copy") {
-                            copy("secret")
-                        }
-                        text("Manual") {
-                            click(manualEvent)
+                            click {
+                                copy("secret")
+                            }
                         }
                     }
 
@@ -149,36 +162,64 @@ class ClickEventDslTest :
                 component.childAt(2) shouldHaveClickTextPayload "/msg Alex "
                 component.childAt(3) shouldHaveClickAction ClickEvent.Action.COPY_TO_CLIPBOARD
                 component.childAt(3) shouldHaveClickTextPayload "secret"
-                component.childAt(4) shouldHaveClickAction ClickEvent.Action.OPEN_URL
-                component.childAt(4) shouldHaveClickTextPayload "https://example.org"
             }
 
-            "applies reusable styles with click events" {
+            "applies reusable click events and block-built style click events" {
+                val event =
+                    click {
+                        run("/spawn")
+                    }
                 val style =
                     style {
-                        open("https://example.com")
+                        click {
+                            copy("style-copy")
+                        }
                     }
-
-                Component.text("Open").style(style) shouldHaveClickAction ClickEvent.Action.OPEN_URL
-                Component.text("Open").style(style) shouldHaveClickTextPayload "https://example.com"
-            }
-
-            "clears click events through style scopes" {
                 val component =
                     component {
-                        openUrl("https://example.com")
+                        text("Reusable") {
+                            click(event)
+                        }
+                        text("Styled") {
+                            style(style)
+                        }
+                    }
+
+                component.childAt(0) shouldHaveClickEvent event
+                component.childAt(1) shouldHaveClickAction ClickEvent.Action.COPY_TO_CLIPBOARD
+                component.childAt(1) shouldHaveClickTextPayload "style-copy"
+            }
+
+            "applies and clears raw click events through component and style scopes" {
+                val manualEvent = ClickEvent.openUrl("https://example.org")
+                val component =
+                    component {
+                        click(manualEvent)
+                    }
+                val clearedComponent =
+                    component {
+                        click(manualEvent)
+                        click(null)
+                    }
+                val clearedStyle =
+                    component {
+                        click(manualEvent)
                         style {
                             click(null)
                         }
                     }
 
-                component.shouldNotHaveClickEvent()
+                component shouldHaveClickEvent manualEvent
+                clearedComponent.shouldNotHaveClickEvent()
+                clearedStyle.shouldNotHaveClickEvent()
             }
 
             "propagates invalid change page validation errors" {
                 val failure =
                     shouldThrow<IllegalArgumentException> {
-                        component { changePage(0) }
+                        click {
+                            changePage(0)
+                        }
                     }
 
                 failure.message shouldContain "Change page payload integer must be greater than or equal to 1"
@@ -188,16 +229,16 @@ class ClickEventDslTest :
                 RecordingClickCallbackProvider.reset()
                 var calledWith: Audience? = null
 
-                val component =
-                    component {
+                val event =
+                    click {
                         callback(uses = 3, lifetime = 10.minutes) { audience ->
                             calledWith = audience
                         }
                     }
-                val event = RecordingClickCallbackProvider.lastEvent
                 val audience = Audience.empty()
 
-                component shouldHaveClickEvent event
+                Component.text("Callback").clickEvent(event) shouldHaveClickEvent
+                    RecordingClickCallbackProvider.lastEvent
                 RecordingClickCallbackProvider.lastOptions?.uses() shouldBe 3
                 RecordingClickCallbackProvider.lastOptions?.lifetime() shouldBe JavaDuration.ofMinutes(10)
 
@@ -210,16 +251,16 @@ class ClickEventDslTest :
                 RecordingClickCallbackProvider.reset()
                 var calledWith: Audience? = null
 
-                val component =
-                    component {
+                val event =
+                    click {
                         callback { audience ->
                             calledWith = audience
                         }
                     }
-                val event = RecordingClickCallbackProvider.lastEvent
                 val audience = Audience.empty()
 
-                component shouldHaveClickEvent event
+                Component.text("Callback").clickEvent(event) shouldHaveClickEvent
+                    RecordingClickCallbackProvider.lastEvent
 
                 RecordingClickCallbackProvider.fire(audience)
 
@@ -236,27 +277,29 @@ class ClickEventDslTest :
                         .lifetime(lifetime)
                         .build()
 
-                val component =
-                    component {
+                val event =
+                    click {
                         callback(options) {
                             // The provider capture is the assertion target for this test.
                         }
                     }
-                val event = RecordingClickCallbackProvider.lastEvent
 
-                component shouldHaveClickEvent event
+                Component.text("Callback").clickEvent(event) shouldHaveClickEvent
+                    RecordingClickCallbackProvider.lastEvent
                 RecordingClickCallbackProvider.lastOptions shouldBe options
                 RecordingClickCallbackProvider.lastOptions?.uses() shouldBe 4
                 RecordingClickCallbackProvider.lastOptions?.lifetime() shouldBe lifetime
             }
 
-            "component scope callbacks accept kotlin durations" {
+            "component scope callbacks accept kotlin durations inside click blocks" {
                 RecordingClickCallbackProvider.reset()
 
                 val component =
                     component {
-                        callback(uses = 1, lifetime = 5.minutes) {
-                            // The provider capture is the assertion target for this test.
+                        click {
+                            callback(uses = 1, lifetime = 5.minutes) {
+                                // The provider capture is the assertion target for this test.
+                            }
                         }
                     }
 
@@ -264,5 +307,123 @@ class ClickEventDslTest :
                 RecordingClickCallbackProvider.lastOptions?.uses() shouldBe 1
                 RecordingClickCallbackProvider.lastOptions?.lifetime() shouldBe JavaDuration.ofMinutes(5)
             }
+
+            "rejects empty click action blocks" {
+                val failure =
+                    shouldThrow<IllegalStateException> {
+                        click {
+                        }
+                    }
+
+                failure.message shouldContain "choose exactly one action"
+            }
+
+            "rejects click action blocks with multiple actions" {
+                val failure =
+                    shouldThrow<IllegalStateException> {
+                        click {
+                            run("/one")
+                            copy("two")
+                        }
+                    }
+
+                failure.message shouldContain "choose only one"
+            }
+
+            "keeps direct action helpers out of component and style scopes" {
+                assertDoesNotCompile(
+                    "ComponentClickActionLeakTest.kt",
+                    """
+                    import io.github.lmliam.kotventure.core.text.component
+
+                    fun shouldNotCompile() {
+                        component {
+                            text("Open") {
+                                openUrl("https://example.com")
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    "Unresolved reference 'openUrl'",
+                )
+                assertDoesNotCompile(
+                    "StyleClickActionLeakTest.kt",
+                    """
+                    import io.github.lmliam.kotventure.core.style.style
+
+                    fun shouldNotCompile() {
+                        style {
+                            copy("secret")
+                        }
+                    }
+                    """.trimIndent(),
+                    "Unresolved reference 'copy'",
+                )
+            }
+
+            "removes direct action helpers from explicit click scopes" {
+                val helperCalls =
+                    mapOf(
+                        "Open" to """scope.open("https://example.com")""",
+                        "OpenUrl" to """scope.openUrl("https://example.com")""",
+                        "OpenFile" to """scope.openFile("/tmp/example.txt")""",
+                        "Run" to """scope.run("/spawn")""",
+                        "Suggest" to """scope.suggest("/msg Alex ")""",
+                        "ChangePage" to """scope.changePage(2)""",
+                        "Copy" to """scope.copy("secret")""",
+                        "Callback" to
+                                """
+                                val callback = ClickCallback<Audience> { }
+                                scope.callback(callback)
+                                """.trimIndent(),
+                        "CallbackWithOptions" to
+                                """
+                                val callback = ClickCallback<Audience> { }
+                                val options = ClickCallback.Options.builder().uses(1).build()
+                                scope.callback(options, callback)
+                                """.trimIndent(),
+                        "CallbackWithUsesAndLifetime" to
+                                """
+                                val callback = ClickCallback<Audience> { }
+                                scope.callback(1, 1.minutes, callback)
+                                """.trimIndent(),
+                    )
+
+                helperCalls.forEach { (name, call) ->
+                    assertDoesNotCompile(
+                        "Removed${name}ClickScopeHelperTest.kt",
+                        """
+                        import io.github.lmliam.kotventure.core.event.ClickScope
+                        import net.kyori.adventure.audience.Audience
+                        import net.kyori.adventure.text.event.ClickCallback
+                        import kotlin.time.Duration.Companion.minutes
+
+                        fun shouldNotCompile(scope: ClickScope) {
+                            $call
+                        }
+                        """.trimIndent(),
+                    )
+                }
+            }
         },
     )
+
+@OptIn(ExperimentalCompilerApi::class)
+private fun assertDoesNotCompile(
+    fileName: String,
+    source: String,
+    expectedMessage: String? = null,
+) {
+    val compilation =
+        KotlinCompilation().apply {
+            inheritClassPath = true
+            sources = listOf(SourceFile.kotlin(fileName, source))
+        }
+
+    val result = compilation.compile()
+
+    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+    if (expectedMessage != null) {
+        result.messages shouldContain expectedMessage
+    }
+}


### PR DESCRIPTION
## Summary

Adds the block-style click event DSL so `click { ... }` builds reusable events and applies events from component/style scopes, matching the hover DSL shape.

## Related Issues

Closes #127

## DSL Impact

Click action helpers now live on `ClickActionScope` inside `click { ... }`. Component and style scopes keep `click(event)`, `click(null)`, and typed `click(action, payload)` interop, but direct `open(...)`, `openUrl(...)`, `openFile(...)`, `run(...)`, `suggest(...)`, `changePage(...)`, `copy(...)`, and `callback(...)` helpers are removed from those scopes.

## Rationale

This keeps the event DSL consistent before the pre-alpha API settles: reusable event factories, scoped block application, raw/prebuilt interop, and clearing all follow the same model as hover events.

## Testing

- `./gradlew :core:test --tests 'io.github.lmliam.kotventure.core.event.ClickEventDslTest'`
- `./gradlew :core:test --tests 'io.github.lmliam.kotventure.core.text.ComponentDslTest'`
- `./gradlew ktlintFormat`
- `./gradlew ktlintCheck spotlessCheck`
- `./gradlew build`
- `rg -n 'openUrl\(|openFile\(|run\(|suggest\(|changePage\(|copy\(|callback\(' README.md docs modules/core/src`

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run through focused DSL tests