### PR TITLE
feat(core): add design-system themes and a registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,51 @@ content. Provide a fallback when the component might appear in places that do no
 as server MOTDs or plain-text logs. Call `stoneIcon.renderObjectFallbacks()` before handing the component to renderer
 paths that should replace configured object fallbacks with regular components.
 
-`AdventureDsl` stores typed extension registrations for MiniMessage tag providers, theme providers, animation drivers,
-and the active platform adapter. Registration is explicit at startup; there is no classpath scanning.
+Design-system themes are Kotlin objects extending `Theme`. Palette values are ordinary properties and semantic styles
+are delegated properties built with the style DSL, so `Brand.header` is compile-checked while the property name doubles
+as the key for dynamic lookup. Standalone components come from the top-level `text(...)` factory and `styled`:
+
+```kotlin
+object Brand : Theme("brand") {
+    val primary = hex("#5865F2")
+
+    val header: Style by style {
+        color(primary)
+        bold()
+        italic(false)
+    }
+
+    val danger: Style by style {
+        color(red)
+        bold()
+    }
+
+    val callout: Style by style("call-out") {
+        color(primary)
+        underlined()
+    }
+}
+
+Brand.register()                                   // explicit startup wiring; register(default = true) marks the default
+
+val title = text("Welcome") styled Brand.header    // compile-checked semantic styles
+
+val message = component {
+    text("Careful") {
+        style(Brand.danger)
+    }
+}
+
+val dynamic = AdventureDsl.theme("brand")?.style("header")   // dynamic interop lookup
+val fallback = AdventureDsl.defaultTheme()?.style("header")
+```
+
+Declaring a theme never registers it; call `register()` during startup. Use `style("call-out") { ... }` when the
+dynamic key should differ from the property name, and declare palette properties before the styles that use them.
+
+`AdventureDsl` stores typed extension registrations for MiniMessage tag providers, theme providers (including an
+optional default theme), animation drivers, and the active platform adapter. Registration is explicit at startup;
+there is no classpath scanning.
 
 Serializer helpers live in `kotventure-serializer` so `kotventure-core` can stay limited to `adventure-api` while
 callers opt into concrete Adventure serializers:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -125,11 +125,15 @@ val title = component {
 }
 
 // ── Themes (design system, registered once) ────────────────────
-val Brand = theme {
-    palette { primary = hex("#5865F2"); error = RED }
-    style("header") { color(primary); bold() }
+object Brand : Theme("brand") {
+    val primary = hex("#5865F2")
+
+    val header: Style by style { color(primary); bold() }
+    val error: Style by style { color(RED) }
 }
-text("Title") styled Brand.header
+Brand.register()                             // explicit startup wiring
+text("Title") styled Brand.header            // compile-checked property
+AdventureDsl.theme("brand")?.style("header") // dynamic interop lookup
 
 // ── Sending (Audience extensions) ──────────────────────────────
 player.message { text("hi") }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/registry/AdventureDsl.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/registry/AdventureDsl.kt
@@ -16,6 +16,7 @@ import io.github.lmliam.kotventure.core.theme.ThemeProvider
 public object AdventureDsl {
     private val miniMessageTagProviders: MutableMap<String, MiniMessageTagProvider> = mutableMapOf()
     private val themeProviders: MutableMap<String, ThemeProvider> = mutableMapOf()
+    private var defaultThemeName: String? = null
     private val animationDrivers: MutableMap<String, AnimationDriver> = mutableMapOf()
     private var platformAdapter: PlatformAdapter? = null
 
@@ -37,16 +38,28 @@ public object AdventureDsl {
     public fun miniMessageTags(): Map<String, MiniMessageTagProvider> = miniMessageTagProviders.immutableSnapshot()
 
     /**
-     * Registers [provider] as the active theme provider for its name.
+     * Registers [provider] as the active theme provider for its name, optionally marking it as
+     * the [default] theme.
      */
-    public fun registerTheme(provider: ThemeProvider) {
+    public fun registerTheme(
+        provider: ThemeProvider,
+        default: Boolean = false,
+    ) {
         themeProviders[provider.name] = provider
+        if (default) {
+            defaultThemeName = provider.name
+        }
     }
 
     /**
      * Returns the theme provider registered as [name], or null when none exists.
      */
     public fun theme(name: String): ThemeProvider? = themeProviders[name]
+
+    /**
+     * Returns the theme provider registered as the default theme, or null when none exists.
+     */
+    public fun defaultTheme(): ThemeProvider? = defaultThemeName?.let(::theme)
 
     /**
      * Returns an immutable snapshot of registered theme providers by name.
@@ -85,6 +98,7 @@ public object AdventureDsl {
     internal fun reset() {
         miniMessageTagProviders.clear()
         themeProviders.clear()
+        defaultThemeName = null
         animationDrivers.clear()
         platformAdapter = null
     }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/registry/AdventureDsl.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/registry/AdventureDsl.kt
@@ -40,11 +40,14 @@ public object AdventureDsl {
     /**
      * Registers [provider] as the active theme provider for its name, optionally marking it as
      * the [default] theme.
+     *
+     * @throws IllegalArgumentException when the provider name is blank.
      */
     public fun registerTheme(
         provider: ThemeProvider,
         default: Boolean = false,
     ) {
+        require(provider.name.isNotBlank()) { "Theme provider name must not be blank." }
         themeProviders[provider.name] = provider
         if (default) {
             defaultThemeName = provider.name

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/Styled.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/Styled.kt
@@ -1,0 +1,9 @@
+package io.github.lmliam.kotventure.core.style
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.Style
+
+/**
+ * Returns a copy of this component with [style] applied, replacing any existing style.
+ */
+public infix fun Component.styled(style: Style): Component = style(style)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Text.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Text.kt
@@ -3,7 +3,7 @@ package io.github.lmliam.kotventure.core.text
 import net.kyori.adventure.text.Component
 
 /**
- * Builds an Adventure text [Component] with [value] as its content, configured by [init].
+ * Builds an Adventure text [Component] with [value] as its initial content, configured by [init].
  */
 public fun text(
     value: String,

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Text.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Text.kt
@@ -1,0 +1,20 @@
+package io.github.lmliam.kotventure.core.text
+
+import net.kyori.adventure.text.Component
+
+/**
+ * Builds an Adventure text [Component] with [value] as its content, configured by [init].
+ */
+public fun text(
+    value: String,
+    init: TextScope.() -> Unit = {},
+): Component =
+    text {
+        content(value)
+        init()
+    }
+
+/**
+ * Builds an Adventure text [Component] from a Kotventure text DSL block.
+ */
+public fun text(init: TextScope.() -> Unit): Component = TextComponentBuilder().apply(init).build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/Theme.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/Theme.kt
@@ -28,7 +28,7 @@ import io.github.lmliam.kotventure.core.style.style as buildStyle
  * Declaring a theme does not register it; call [register] explicitly during startup.
  */
 public abstract class Theme(
-    override val name: String,
+    public override val name: String,
 ) : ThemeProvider {
     private val styles: LinkedHashMap<String, Style> = LinkedHashMap()
 
@@ -36,7 +36,7 @@ public abstract class Theme(
         require(name.isNotBlank()) { "Theme name must not be blank." }
     }
 
-    override fun style(name: String): Style? = styles[name]
+    public override fun style(name: String): Style? = styles[name]
 
     /**
      * Returns an immutable snapshot of the declared styles keyed by semantic name.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/Theme.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/Theme.kt
@@ -39,7 +39,8 @@ public abstract class Theme(
     public override fun style(name: String): Style? = styles[name]
 
     /**
-     * Returns an immutable snapshot of the declared styles keyed by semantic name.
+     * Returns an immutable snapshot of the declared styles keyed by semantic name, in
+     * declaration order.
      */
     public fun styles(): Map<String, Style> =
         buildMap {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/Theme.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/Theme.kt
@@ -1,0 +1,81 @@
+package io.github.lmliam.kotventure.core.theme
+
+import io.github.lmliam.kotventure.core.style.StyleScope
+import net.kyori.adventure.text.format.Style
+import kotlin.properties.PropertyDelegateProvider
+import kotlin.properties.ReadOnlyProperty
+import io.github.lmliam.kotventure.core.style.style as buildStyle
+
+/**
+ * Base class for design-system themes declared as Kotlin objects.
+ *
+ * Semantic styles are declared as delegated properties so references like `Brand.header` are
+ * compile-checked, while the property names double as the keys served through the dynamic
+ * [ThemeProvider.style] lookup. Styles are recorded in declaration order during object
+ * initialization, so palette properties must be declared before the styles that use them.
+ *
+ * ```kotlin
+ * object Brand : Theme("brand") {
+ *     val primary = hex("#5865F2")
+ *
+ *     val header: Style by style {
+ *         color(primary)
+ *         bold()
+ *     }
+ * }
+ * ```
+ *
+ * Declaring a theme does not register it; call [register] explicitly during startup.
+ */
+public abstract class Theme(
+    override val name: String,
+) : ThemeProvider {
+    private val styles: LinkedHashMap<String, Style> = LinkedHashMap()
+
+    init {
+        require(name.isNotBlank()) { "Theme name must not be blank." }
+    }
+
+    override fun style(name: String): Style? = styles[name]
+
+    /**
+     * Returns an immutable snapshot of the declared styles keyed by semantic name.
+     */
+    public fun styles(): Map<String, Style> =
+        buildMap {
+            putAll(styles)
+        }
+
+    /**
+     * Declares a semantic style property whose name doubles as its dynamic lookup key.
+     *
+     * @throws IllegalArgumentException when the key is already declared by this theme.
+     */
+    protected fun style(init: StyleScope.() -> Unit): PropertyDelegateProvider<Theme, ReadOnlyProperty<Theme, Style>> =
+        styleDelegate(key = null, init = init)
+
+    /**
+     * Declares a semantic style property resolvable dynamically as [name] instead of the
+     * property name.
+     *
+     * @throws IllegalArgumentException when [name] is blank or already declared by this theme.
+     */
+    protected fun style(
+        name: String,
+        init: StyleScope.() -> Unit,
+    ): PropertyDelegateProvider<Theme, ReadOnlyProperty<Theme, Style>> = styleDelegate(key = name, init = init)
+
+    private fun styleDelegate(
+        key: String?,
+        init: StyleScope.() -> Unit,
+    ): PropertyDelegateProvider<Theme, ReadOnlyProperty<Theme, Style>> =
+        PropertyDelegateProvider { theme, property ->
+            val styleKey = key ?: property.name
+            require(styleKey.isNotBlank()) { "Theme style name must not be blank." }
+            val built = buildStyle(init)
+            require(theme.styles.put(styleKey, built) == null) {
+                "Duplicate style '$styleKey' in theme '${theme.name}'."
+            }
+            ReadOnlyProperty { _, _ -> built }
+        }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistration.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistration.kt
@@ -1,0 +1,12 @@
+package io.github.lmliam.kotventure.core.theme
+
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+
+/**
+ * Registers this theme provider with the explicit [AdventureDsl] registry and returns it,
+ * optionally marking it as the [default] theme.
+ */
+public fun <T : ThemeProvider> T.register(default: Boolean = false): T =
+    apply {
+        AdventureDsl.registerTheme(this, default = default)
+    }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/registry/AdventureDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/registry/AdventureDslTest.kt
@@ -11,6 +11,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.Style
@@ -46,6 +47,14 @@ class AdventureDslTest :
 
                 AdventureDsl.theme("brand") shouldBe provider
                 AdventureDsl.themes() shouldContainExactly mapOf("brand" to provider)
+            }
+
+            "rejects theme providers with blank names" {
+                shouldThrow<IllegalArgumentException> {
+                    AdventureDsl.registerTheme(TestThemeProvider(" ", emptyMap()))
+                }
+
+                AdventureDsl.themes() shouldContainExactly emptyMap()
             }
 
             "returns null when no default theme is registered" {
@@ -96,7 +105,7 @@ class AdventureDslTest :
 
                 val returned = provider.register()
 
-                returned shouldBe provider
+                returned shouldBeSameInstanceAs provider
                 AdventureDsl.theme("brand") shouldBe provider
                 AdventureDsl.defaultTheme().shouldBeNull()
             }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/registry/AdventureDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/registry/AdventureDslTest.kt
@@ -5,6 +5,7 @@ import io.github.lmliam.kotventure.core.minimessage.MiniMessageTagProvider
 import io.github.lmliam.kotventure.core.platform.PlatformAdapter
 import io.github.lmliam.kotventure.core.platform.PlatformTask
 import io.github.lmliam.kotventure.core.theme.ThemeProvider
+import io.github.lmliam.kotventure.core.theme.register
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.maps.shouldContainExactly
@@ -45,6 +46,67 @@ class AdventureDslTest :
 
                 AdventureDsl.theme("brand") shouldBe provider
                 AdventureDsl.themes() shouldContainExactly mapOf("brand" to provider)
+            }
+
+            "returns null when no default theme is registered" {
+                AdventureDsl.registerTheme(TestThemeProvider("brand", emptyMap()))
+
+                AdventureDsl.defaultTheme().shouldBeNull()
+            }
+
+            "registers and retrieves the default theme provider" {
+                val provider = TestThemeProvider("server", emptyMap())
+
+                AdventureDsl.registerTheme(provider, default = true)
+
+                AdventureDsl.defaultTheme() shouldBe provider
+                AdventureDsl.theme("server") shouldBe provider
+            }
+
+            "replaces the default theme when another provider registers as default" {
+                val first = TestThemeProvider("server", emptyMap())
+                val second = TestThemeProvider("brand", emptyMap())
+
+                AdventureDsl.registerTheme(first, default = true)
+                AdventureDsl.registerTheme(second, default = true)
+
+                AdventureDsl.defaultTheme() shouldBe second
+            }
+
+            "keeps the default theme when another provider registers without default" {
+                val first = TestThemeProvider("server", emptyMap())
+                val second = TestThemeProvider("brand", emptyMap())
+
+                AdventureDsl.registerTheme(first, default = true)
+                AdventureDsl.registerTheme(second)
+
+                AdventureDsl.defaultTheme() shouldBe first
+            }
+
+            "clears the default theme on reset" {
+                AdventureDsl.registerTheme(TestThemeProvider("server", emptyMap()), default = true)
+
+                AdventureDsl.reset()
+
+                AdventureDsl.defaultTheme().shouldBeNull()
+            }
+
+            "registers theme providers through the register extension" {
+                val provider = TestThemeProvider("brand", emptyMap())
+
+                val returned = provider.register()
+
+                returned shouldBe provider
+                AdventureDsl.theme("brand") shouldBe provider
+                AdventureDsl.defaultTheme().shouldBeNull()
+            }
+
+            "registers a default theme through the register extension" {
+                val provider = TestThemeProvider("server", emptyMap())
+
+                provider.register(default = true)
+
+                AdventureDsl.defaultTheme() shouldBe provider
             }
 
             "registers and retrieves animation drivers by name" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/style/StyledDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/style/StyledDslTest.kt
@@ -1,0 +1,43 @@
+package io.github.lmliam.kotventure.core.style
+
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.github.lmliam.kotventure.test.text.shouldHaveInsertion
+import io.github.lmliam.kotventure.test.text.shouldHaveStyle
+import io.kotest.core.spec.style.StringSpec
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+class StyledDslTest :
+    StringSpec(
+        {
+            "applies a complete style to a component" {
+                val header =
+                    style {
+                        color(NamedTextColor.GOLD)
+                        bold()
+                        insertion("/help")
+                    }
+
+                val title = text("Title") styled header
+
+                title shouldContainText "Title"
+                title shouldHaveStyle header
+                title shouldHaveColor NamedTextColor.GOLD
+                title shouldHaveDecoration TextDecoration.BOLD
+                title shouldHaveInsertion "/help"
+            }
+
+            "replaces any style already present on the component" {
+                val original = Component.text("Title", NamedTextColor.RED)
+                val replacement = style { color(NamedTextColor.GREEN) }
+
+                val styled = original styled replacement
+
+                styled shouldHaveColor NamedTextColor.GREEN
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/TextDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/TextDslTest.kt
@@ -1,0 +1,44 @@
+package io.github.lmliam.kotventure.core.text
+
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.kotest.core.spec.style.StringSpec
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+class TextDslTest :
+    StringSpec(
+        {
+            "builds a text component from a value" {
+                val component = text("Title")
+
+                component shouldContainText "Title"
+                component shouldHaveChildCount 0
+            }
+
+            "builds a text component from a value and a configuration block" {
+                val component =
+                    text("Title") {
+                        color(NamedTextColor.AQUA)
+                        bold()
+                    }
+
+                component shouldContainText "Title"
+                component shouldHaveColor NamedTextColor.AQUA
+                component shouldHaveDecoration TextDecoration.BOLD
+            }
+
+            "builds a text component from a configuration block alone" {
+                val component =
+                    text {
+                        content("Title")
+                        color(NamedTextColor.GOLD)
+                    }
+
+                component shouldContainText "Title"
+                component shouldHaveColor NamedTextColor.GOLD
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeDslTest.kt
@@ -106,6 +106,7 @@ class ThemeDslTest :
                         "danger" to BrandTheme.danger,
                         "call-out" to BrandTheme.callout,
                     )
+                snapshot.keys.toList() shouldBe listOf("header", "saved", "danger", "call-out")
                 shouldThrow<UnsupportedOperationException> {
                     @Suppress("UNCHECKED_CAST")
                     (snapshot as MutableMap<String, Style>)["other"] = Style.empty()

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeDslTest.kt
@@ -1,0 +1,168 @@
+package io.github.lmliam.kotventure.core.theme
+
+import io.github.lmliam.kotventure.core.color.green
+import io.github.lmliam.kotventure.core.color.hex
+import io.github.lmliam.kotventure.core.color.red
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+import io.github.lmliam.kotventure.core.style.styled
+import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.github.lmliam.kotventure.test.text.shouldHaveFont
+import io.github.lmliam.kotventure.test.text.shouldHaveStyle
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.format.Style
+import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.format.TextDecoration.State
+
+private object BrandTheme : Theme("brand") {
+    val primary = hex("#5865F2")
+    val headerFont: Key = Key.key("minecraft", "uniform")
+
+    val header: Style by style {
+        color(primary)
+        bold()
+        italic(false)
+        font(headerFont)
+    }
+
+    val saved: Style by style {
+        color(green)
+    }
+
+    val danger: Style by style {
+        color(red)
+        bold()
+        underlined(false)
+    }
+
+    val callout: Style by style("call-out") {
+        color(primary)
+        underlined()
+    }
+}
+
+class ThemeDslTest :
+    StringSpec(
+        {
+            "exposes semantic styles as compile-checked properties" {
+                val title = text("Welcome") styled BrandTheme.header
+
+                title shouldContainText "Welcome"
+                title shouldHaveColor BrandTheme.primary
+                title shouldHaveFont BrandTheme.headerFont
+                title.shouldHaveDecoration(TextDecoration.BOLD, State.TRUE)
+                title.shouldHaveDecoration(TextDecoration.ITALIC, State.FALSE)
+            }
+
+            "applies semantic styles to nested text children" {
+                val message =
+                    component {
+                        text("Welcome") {
+                            style(BrandTheme.header)
+                        }
+                        text("Careful") {
+                            style(BrandTheme.danger)
+                        }
+                    }
+
+                message shouldHaveChildCount 2
+                message.childAt(0) shouldHaveStyle BrandTheme.header
+                message.childAt(1) shouldHaveStyle BrandTheme.danger
+            }
+
+            "resolves semantic styles dynamically by property name" {
+                BrandTheme.style("header") shouldBe BrandTheme.header
+                BrandTheme.style("saved") shouldBe BrandTheme.saved
+                BrandTheme.style("danger") shouldBe BrandTheme.danger
+            }
+
+            "uses an explicit key instead of the property name when one is given" {
+                BrandTheme.style("call-out") shouldBe BrandTheme.callout
+                BrandTheme.style("callout").shouldBeNull()
+            }
+
+            "returns null for missing dynamic style lookups" {
+                BrandTheme.style("missing").shouldBeNull()
+            }
+
+            "exposes an immutable snapshot of declared styles" {
+                val snapshot = BrandTheme.styles()
+
+                snapshot shouldContainExactly
+                    mapOf(
+                        "header" to BrandTheme.header,
+                        "saved" to BrandTheme.saved,
+                        "danger" to BrandTheme.danger,
+                        "call-out" to BrandTheme.callout,
+                    )
+                shouldThrow<UnsupportedOperationException> {
+                    @Suppress("UNCHECKED_CAST")
+                    (snapshot as MutableMap<String, Style>)["other"] = Style.empty()
+                }
+            }
+
+            "can be defined, registered, and applied end to end" {
+                AdventureDsl.reset()
+                try {
+                    BrandTheme.register()
+
+                    val registered = AdventureDsl.theme("brand")
+                    registered shouldBe BrandTheme
+                    val header = registered?.style("header")
+                    header shouldBe BrandTheme.header
+                    val title = text("Welcome") styled checkNotNull(header)
+                    title shouldHaveColor BrandTheme.primary
+                } finally {
+                    AdventureDsl.reset()
+                }
+            }
+
+            "rejects blank theme names" {
+                val failure =
+                    shouldThrow<IllegalArgumentException> {
+                        object : Theme(" ") {}
+                    }
+
+                failure.message shouldContain "blank"
+            }
+
+            "rejects blank explicit style keys" {
+                val failure =
+                    shouldThrow<IllegalArgumentException> {
+                        object : Theme("blank-key") {
+                            @Suppress("unused")
+                            val broken: Style by style(" ") {}
+                        }
+                    }
+
+                failure.message shouldContain "blank"
+            }
+
+            "rejects duplicate style keys within one theme" {
+                val failure =
+                    shouldThrow<IllegalArgumentException> {
+                        object : Theme("duplicate") {
+                            @Suppress("unused")
+                            val header: Style by style {}
+
+                            @Suppress("unused")
+                            val other: Style by style("header") {}
+                        }
+                    }
+
+                failure.message shouldContain "header"
+                failure.message shouldContain "duplicate"
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeDslTest.kt
@@ -100,12 +100,12 @@ class ThemeDslTest :
                 val snapshot = BrandTheme.styles()
 
                 snapshot shouldContainExactly
-                    mapOf(
-                        "header" to BrandTheme.header,
-                        "saved" to BrandTheme.saved,
-                        "danger" to BrandTheme.danger,
-                        "call-out" to BrandTheme.callout,
-                    )
+                        mapOf(
+                            "header" to BrandTheme.header,
+                            "saved" to BrandTheme.saved,
+                            "danger" to BrandTheme.danger,
+                            "call-out" to BrandTheme.callout,
+                        )
                 snapshot.keys.toList() shouldBe listOf("header", "saved", "danger", "call-out")
                 shouldThrow<UnsupportedOperationException> {
                     @Suppress("UNCHECKED_CAST")

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeDslTest.kt
@@ -3,6 +3,7 @@ package io.github.lmliam.kotventure.core.theme
 import io.github.lmliam.kotventure.core.color.green
 import io.github.lmliam.kotventure.core.color.hex
 import io.github.lmliam.kotventure.core.color.red
+import io.github.lmliam.kotventure.core.key.key
 import io.github.lmliam.kotventure.core.registry.AdventureDsl
 import io.github.lmliam.kotventure.core.style.styled
 import io.github.lmliam.kotventure.core.text.component
@@ -27,7 +28,7 @@ import net.kyori.adventure.text.format.TextDecoration.State
 
 private object BrandTheme : Theme("brand") {
     val primary = hex("#5865F2")
-    val headerFont: Key = Key.key("minecraft", "uniform")
+    val headerFont: Key = key("minecraft", "uniform")
 
     val header: Style by style {
         color(primary)


### PR DESCRIPTION
## Summary

Adds the design-system theme DSL to `core`. Themes are Kotlin objects extending `Theme("name")`: palette values are ordinary properties, and semantic styles are delegated properties built with the existing style DSL, so `Brand.header` is compile-checked while the property name doubles as the key served through the dynamic `ThemeProvider.style(name)` lookup. Registration stays explicit at startup via `Brand.register()` / `ServerTheme.register(default = true)`, backed by new `AdventureDsl` default-theme support. Top-level `text(...)` factories and the `Component styled Style` infix complete the application surface from the issue.

## Related Issues

Closes #23

## DSL Impact

```kotlin
object Brand : Theme("brand") {
    val primary = hex("#5865F2")

    val header: Style by style { color(primary); bold() }
    val callout: Style by style("call-out") { color(primary); underlined() }
}

Brand.register()                                   // explicit startup wiring

val title = text("Welcome") styled Brand.header    // compile-checked semantic styles
val dynamic = AdventureDsl.theme("brand")?.style("header")
val fallback = AdventureDsl.defaultTheme()?.style("header")
```

- New `core.theme.Theme` base class with delegated `style { ... }` / `style("key") { ... }` declarations and an immutable `styles()` snapshot.
- New `ThemeProvider.register(default = false)` extension; `AdventureDsl.registerTheme` gains an optional `default` parameter plus `defaultTheme()` (additive, source-compatible).
- New top-level `text(value) { ... }` / `text { ... }` factories and `Component styled Style`.
- Per the review-approved plan on the issue, the original runtime `theme { palette { ... } }` builder sketch was replaced by this object/delegated-property shape; `docs/DESIGN.md` §5 is updated accordingly.

## Rationale

Plugin authors can declare a design system once and reference semantic styles anywhere with compile-time safety — a typo'd style name is a compile error, not a runtime lookup failure — while config/cross-plugin interop keeps a single explicit string bridge through the `AdventureDsl` registry.

## Testing

- `ThemeDslTest` (new, 10 specs): property access, nested builder usage, dynamic resolution by property name and explicit key, missing-lookup null, immutable snapshot, define→register→apply end-to-end, blank-name/blank-key/duplicate-key failures.
- `AdventureDslTest` (+7 specs): default-theme registration, replacement, retention, reset, and the `register()` extension.
- `TextDslTest` (new, 3 specs) and `StyledDslTest` (new, 2 specs) for the factories and infix.
- All tests dogfood the `kotventure-test` matchers; `./gradlew build` (compile + Kotest + ktlint + spotless) is green locally.

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
