### PR TITLE
refactor(core): internalize the registry behind feature facades

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,16 +280,18 @@ val message = component {
     }
 }
 
-val dynamic = AdventureDsl.theme("brand")?.style("header")   // dynamic interop lookup
-val fallback = AdventureDsl.defaultTheme()?.style("header")
+val dynamic = theme("brand")?.style("header")      // dynamic interop lookup
+val fallback = defaultTheme()?.style("header")
 ```
 
 Declaring a theme never registers it; call `register()` during startup. Use `style("call-out") { ... }` when the
 dynamic key should differ from the property name, and declare palette properties before the styles that use them.
 
-`AdventureDsl` stores typed extension registrations for MiniMessage tag providers, theme providers (including an
-optional default theme), animation drivers, and the active platform adapter. Registration is explicit at startup;
-there is no classpath scanning.
+Kotventure keeps typed extension registrations — MiniMessage tag providers, theme providers (including an optional
+default theme), animation drivers, and the active platform adapter — in an internal registry. Each feature package
+exposes its own small facade: a `register()` extension on the extension-point type plus a lookup such as
+`theme(name)`, `defaultTheme()`, `miniMessageTag(name)`, `animationDriver(name)`, or `platformAdapter()`.
+Registration is explicit at startup; there is no classpath scanning.
 
 Serializer helpers live in `kotventure-serializer` so `kotventure-core` can stay limited to `adventure-api` while
 callers opt into concrete Adventure serializers:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -75,7 +75,9 @@ Modules are introduced **lazily, per phase** — not all scaffolded up front —
 
 ### 4.1 The registry (extension points)
 
-A single explicit `AdventureDsl` registry (plain Kotlin, no classpath scanning) holds the pluggable pieces:
+A single explicit internal registry (plain Kotlin, no classpath scanning) holds the pluggable pieces. Application code
+never touches the registry directly: each feature package exposes a small public facade — a `register()` extension on
+the extension-point type plus a lookup function — and the registry stays an implementation detail behind them:
 
 - **Custom MiniMessage tags** (`TagResolver`s) registered by name.
 - **Theme providers** — named design systems resolvable across the app.
@@ -133,7 +135,7 @@ object Brand : Theme("brand") {
 }
 Brand.register()                             // explicit startup wiring
 text("Title") styled Brand.header            // compile-checked property
-AdventureDsl.theme("brand")?.style("header") // dynamic interop lookup
+theme("brand")?.style("header")              // dynamic interop lookup
 
 // ── Sending (Audience extensions) ──────────────────────────────
 player.message { text("hi") }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/animation/AnimationDriverLookup.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/animation/AnimationDriverLookup.kt
@@ -1,0 +1,8 @@
+package io.github.lmliam.kotventure.core.animation
+
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+
+/**
+ * Returns the animation driver registered as [name], or null when none exists.
+ */
+public fun animationDriver(name: String): AnimationDriver? = AdventureDsl.animationDriver(name)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/animation/AnimationDriverRegistration.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/animation/AnimationDriverRegistration.kt
@@ -6,6 +6,8 @@ import io.github.lmliam.kotventure.core.registry.AdventureDsl
  * Registers this animation driver with Kotventure's startup registry and returns it.
  *
  * Registering another driver with the same name replaces the previous registration.
+ *
+ * @throws IllegalArgumentException when the driver name is blank.
  */
 public fun <T : AnimationDriver> T.register(): T =
     apply {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/animation/AnimationDriverRegistration.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/animation/AnimationDriverRegistration.kt
@@ -1,0 +1,13 @@
+package io.github.lmliam.kotventure.core.animation
+
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+
+/**
+ * Registers this animation driver with Kotventure's startup registry and returns it.
+ *
+ * Registering another driver with the same name replaces the previous registration.
+ */
+public fun <T : AnimationDriver> T.register(): T =
+    apply {
+        AdventureDsl.registerAnimationDriver(this)
+    }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/minimessage/MiniMessageTagLookup.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/minimessage/MiniMessageTagLookup.kt
@@ -1,0 +1,8 @@
+package io.github.lmliam.kotventure.core.minimessage
+
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+
+/**
+ * Returns the MiniMessage tag provider registered as [name], or null when none exists.
+ */
+public fun miniMessageTag(name: String): MiniMessageTagProvider? = AdventureDsl.miniMessageTag(name)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/minimessage/MiniMessageTagRegistration.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/minimessage/MiniMessageTagRegistration.kt
@@ -1,0 +1,13 @@
+package io.github.lmliam.kotventure.core.minimessage
+
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+
+/**
+ * Registers this MiniMessage tag provider with Kotventure's startup registry and returns it.
+ *
+ * Registering another provider with the same name replaces the previous registration.
+ */
+public fun <T : MiniMessageTagProvider> T.register(): T =
+    apply {
+        AdventureDsl.registerMiniMessageTag(this)
+    }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/minimessage/MiniMessageTagRegistration.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/minimessage/MiniMessageTagRegistration.kt
@@ -6,6 +6,8 @@ import io.github.lmliam.kotventure.core.registry.AdventureDsl
  * Registers this MiniMessage tag provider with Kotventure's startup registry and returns it.
  *
  * Registering another provider with the same name replaces the previous registration.
+ *
+ * @throws IllegalArgumentException when the provider name is blank.
  */
 public fun <T : MiniMessageTagProvider> T.register(): T =
     apply {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/platform/PlatformAdapterLookup.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/platform/PlatformAdapterLookup.kt
@@ -1,0 +1,8 @@
+package io.github.lmliam.kotventure.core.platform
+
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+
+/**
+ * Returns the active platform adapter, or null when no platform has registered one.
+ */
+public fun platformAdapter(): PlatformAdapter? = AdventureDsl.platformAdapter()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/platform/PlatformAdapterRegistration.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/platform/PlatformAdapterRegistration.kt
@@ -3,7 +3,7 @@ package io.github.lmliam.kotventure.core.platform
 import io.github.lmliam.kotventure.core.registry.AdventureDsl
 
 /**
- * Registers this platform adapter as the active platform adapter and returns it.
+ * Registers this adapter as the active platform adapter and returns it.
  *
  * Registering another adapter replaces the previous registration; only one platform adapter is
  * active at a time.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/platform/PlatformAdapterRegistration.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/platform/PlatformAdapterRegistration.kt
@@ -1,0 +1,14 @@
+package io.github.lmliam.kotventure.core.platform
+
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+
+/**
+ * Registers this platform adapter as the active platform adapter and returns it.
+ *
+ * Registering another adapter replaces the previous registration; only one platform adapter is
+ * active at a time.
+ */
+public fun <T : PlatformAdapter> T.register(): T =
+    apply {
+        AdventureDsl.registerPlatformAdapter(this)
+    }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/registry/AdventureDsl.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/registry/AdventureDsl.kt
@@ -8,12 +8,14 @@ import io.github.lmliam.kotventure.core.theme.ThemeProvider
 /**
  * Explicit startup registry for Kotventure extension points.
  *
- * Register extensions during application startup before concurrent use. The registry stores
- * MiniMessage tag providers, theme providers, animation drivers, and a single active platform
- * adapter without classpath scanning. Concrete MiniMessage resolver adaptation belongs to the
- * MiniMessage module so `core` depends only on Adventure API.
+ * This registry is an implementation detail: application code registers and resolves extensions
+ * through the public facades in each feature package (`core.theme`, `core.minimessage`,
+ * `core.animation`, `core.platform`). Register extensions during application startup before
+ * concurrent use. The registry stores MiniMessage tag providers, theme providers, animation
+ * drivers, and a single active platform adapter without classpath scanning. Concrete MiniMessage
+ * resolver adaptation belongs to the MiniMessage module so `core` depends only on Adventure API.
  */
-public object AdventureDsl {
+internal object AdventureDsl {
     private val miniMessageTagProviders: MutableMap<String, MiniMessageTagProvider> = mutableMapOf()
     private val themeProviders: MutableMap<String, ThemeProvider> = mutableMapOf()
     private var defaultThemeName: String? = null

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/registry/AdventureDsl.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/registry/AdventureDsl.kt
@@ -24,8 +24,11 @@ internal object AdventureDsl {
 
     /**
      * Registers [provider] as the active MiniMessage tag provider for its name.
+     *
+     * @throws IllegalArgumentException when the provider name is blank.
      */
     public fun registerMiniMessageTag(provider: MiniMessageTagProvider) {
+        require(provider.name.isNotBlank()) { "MiniMessage tag provider name must not be blank." }
         miniMessageTagProviders[provider.name] = provider
     }
 
@@ -73,8 +76,11 @@ internal object AdventureDsl {
 
     /**
      * Registers [driver] as the active animation driver for its name.
+     *
+     * @throws IllegalArgumentException when the driver name is blank.
      */
     public fun registerAnimationDriver(driver: AnimationDriver) {
+        require(driver.name.isNotBlank()) { "Animation driver name must not be blank." }
         animationDrivers[driver.name] = driver
     }
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeLookup.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeLookup.kt
@@ -1,0 +1,13 @@
+package io.github.lmliam.kotventure.core.theme
+
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+
+/**
+ * Returns the theme provider registered as [name], or null when none exists.
+ */
+public fun theme(name: String): ThemeProvider? = AdventureDsl.theme(name)
+
+/**
+ * Returns the theme provider registered as the default theme, or null when none exists.
+ */
+public fun defaultTheme(): ThemeProvider? = AdventureDsl.defaultTheme()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistration.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistration.kt
@@ -3,8 +3,12 @@ package io.github.lmliam.kotventure.core.theme
 import io.github.lmliam.kotventure.core.registry.AdventureDsl
 
 /**
- * Registers this theme provider with the explicit [AdventureDsl] registry and returns it,
- * optionally marking it as the [default] theme.
+ * Registers this theme provider with Kotventure's startup registry and returns it, optionally
+ * marking it as the [default] theme.
+ *
+ * Registering another provider with the same name replaces the previous registration.
+ *
+ * @throws IllegalArgumentException when the provider name is blank.
  */
 public fun <T : ThemeProvider> T.register(default: Boolean = false): T =
     apply {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/animation/AnimationDriverRegistrationTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/animation/AnimationDriverRegistrationTest.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.kotventure.core.animation
 
 import io.github.lmliam.kotventure.core.registry.AdventureDsl
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -38,6 +39,12 @@ class AnimationDriverRegistrationTest :
 
             "returns null for unknown animation driver names" {
                 animationDriver("missing").shouldBeNull()
+            }
+
+            "rejects animation drivers with blank names" {
+                shouldThrow<IllegalArgumentException> {
+                    TestAnimationDriver(" ").register()
+                }
             }
         },
     )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/animation/AnimationDriverRegistrationTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/animation/AnimationDriverRegistrationTest.kt
@@ -1,0 +1,56 @@
+package io.github.lmliam.kotventure.core.animation
+
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+class AnimationDriverRegistrationTest :
+    StringSpec(
+        {
+            beforeTest {
+                AdventureDsl.reset()
+            }
+
+            afterTest {
+                AdventureDsl.reset()
+            }
+
+            "registers animation drivers through the register extension" {
+                val driver = TestAnimationDriver("test")
+
+                val returned = driver.register()
+
+                returned shouldBeSameInstanceAs driver
+                animationDriver("test") shouldBe driver
+            }
+
+            "replaces an animation driver registered with the same name" {
+                val first = TestAnimationDriver("test")
+                val second = TestAnimationDriver("test")
+
+                first.register()
+                second.register()
+
+                animationDriver("test") shouldBeSameInstanceAs second
+            }
+
+            "returns null for unknown animation driver names" {
+                animationDriver("missing").shouldBeNull()
+            }
+        },
+    )
+
+private class TestAnimationDriver(
+    override val name: String,
+) : AnimationDriver {
+    override fun start(
+        animationId: String,
+        onTick: () -> Unit,
+    ): Unit = onTick()
+
+    override fun tick(animationId: String): Unit = Unit
+
+    override fun stop(animationId: String): Unit = Unit
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/animation/AnimationDriverRegistrationTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/animation/AnimationDriverRegistrationTest.kt
@@ -45,6 +45,8 @@ class AnimationDriverRegistrationTest :
                 shouldThrow<IllegalArgumentException> {
                     TestAnimationDriver(" ").register()
                 }
+
+                animationDriver(" ").shouldBeNull()
             }
         },
     )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/minimessage/MiniMessageTagRegistrationTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/minimessage/MiniMessageTagRegistrationTest.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.kotventure.core.minimessage
 
 import io.github.lmliam.kotventure.core.registry.AdventureDsl
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -38,6 +39,12 @@ class MiniMessageTagRegistrationTest :
 
             "returns null for unknown tag provider names" {
                 miniMessageTag("missing").shouldBeNull()
+            }
+
+            "rejects tag providers with blank names" {
+                shouldThrow<IllegalArgumentException> {
+                    TestMiniMessageTagProvider(" ").register()
+                }
             }
         },
     )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/minimessage/MiniMessageTagRegistrationTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/minimessage/MiniMessageTagRegistrationTest.kt
@@ -45,6 +45,8 @@ class MiniMessageTagRegistrationTest :
                 shouldThrow<IllegalArgumentException> {
                     TestMiniMessageTagProvider(" ").register()
                 }
+
+                miniMessageTag(" ").shouldBeNull()
             }
         },
     )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/minimessage/MiniMessageTagRegistrationTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/minimessage/MiniMessageTagRegistrationTest.kt
@@ -1,0 +1,47 @@
+package io.github.lmliam.kotventure.core.minimessage
+
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+class MiniMessageTagRegistrationTest :
+    StringSpec(
+        {
+            beforeTest {
+                AdventureDsl.reset()
+            }
+
+            afterTest {
+                AdventureDsl.reset()
+            }
+
+            "registers tag providers through the register extension" {
+                val provider = TestMiniMessageTagProvider("player")
+
+                val returned = provider.register()
+
+                returned shouldBeSameInstanceAs provider
+                miniMessageTag("player") shouldBe provider
+            }
+
+            "replaces a tag provider registered with the same name" {
+                val first = TestMiniMessageTagProvider("player")
+                val second = TestMiniMessageTagProvider("player")
+
+                first.register()
+                second.register()
+
+                miniMessageTag("player") shouldBeSameInstanceAs second
+            }
+
+            "returns null for unknown tag provider names" {
+                miniMessageTag("missing").shouldBeNull()
+            }
+        },
+    )
+
+private class TestMiniMessageTagProvider(
+    override val name: String,
+) : MiniMessageTagProvider

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/platform/PlatformAdapterRegistrationTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/platform/PlatformAdapterRegistrationTest.kt
@@ -1,0 +1,59 @@
+package io.github.lmliam.kotventure.core.platform
+
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import net.kyori.adventure.audience.Audience
+
+class PlatformAdapterRegistrationTest :
+    StringSpec(
+        {
+            beforeTest {
+                AdventureDsl.reset()
+            }
+
+            afterTest {
+                AdventureDsl.reset()
+            }
+
+            "registers the active platform adapter through the register extension" {
+                val adapter = TestPlatformAdapter("paper")
+
+                val returned = adapter.register()
+
+                returned shouldBeSameInstanceAs adapter
+                platformAdapter() shouldBe adapter
+            }
+
+            "replaces the active platform adapter on re-registration" {
+                val first = TestPlatformAdapter("paper")
+                val second = TestPlatformAdapter("velocity")
+
+                first.register()
+                second.register()
+
+                platformAdapter() shouldBeSameInstanceAs second
+            }
+
+            "returns null when no platform adapter is registered" {
+                platformAdapter().shouldBeNull()
+            }
+        },
+    )
+
+private class TestPlatformAdapter(
+    override val name: String,
+) : PlatformAdapter {
+    override fun console(): Audience = Audience.empty()
+
+    override fun players(): Iterable<Audience> = emptyList()
+
+    override fun all(): Audience = Audience.empty()
+
+    override fun schedule(task: () -> Unit): PlatformTask {
+        task()
+        return PlatformTask { }
+    }
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeDslTest.kt
@@ -119,7 +119,7 @@ class ThemeDslTest :
                 try {
                     BrandTheme.register()
 
-                    val registered = AdventureDsl.theme("brand")
+                    val registered = theme("brand")
                     registered shouldBe BrandTheme
                     val header = registered?.style("header")
                     header shouldBe BrandTheme.header

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeLookupTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeLookupTest.kt
@@ -1,0 +1,52 @@
+package io.github.lmliam.kotventure.core.theme
+
+import io.github.lmliam.kotventure.core.registry.AdventureDsl
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.format.Style
+
+class ThemeLookupTest :
+    StringSpec(
+        {
+            beforeTest {
+                AdventureDsl.reset()
+            }
+
+            afterTest {
+                AdventureDsl.reset()
+            }
+
+            "resolves registered themes by name" {
+                val provider = TestThemeProvider("brand")
+
+                provider.register()
+
+                theme("brand") shouldBe provider
+            }
+
+            "returns null for unknown theme names" {
+                theme("missing").shouldBeNull()
+            }
+
+            "resolves the registered default theme" {
+                val provider = TestThemeProvider("server")
+
+                provider.register(default = true)
+
+                defaultTheme() shouldBe provider
+            }
+
+            "returns null when no default theme is registered" {
+                TestThemeProvider("brand").register()
+
+                defaultTheme().shouldBeNull()
+            }
+        },
+    )
+
+private class TestThemeProvider(
+    override val name: String,
+) : ThemeProvider {
+    override fun style(name: String): Style? = null
+}


### PR DESCRIPTION
## Summary

Hides the `AdventureDsl` registry from application developers, as decided in the [PR #130 review discussion](https://github.com/LMLiam/Kotventure/pull/130#discussion_r3403937625):

- `AdventureDsl` is now `internal`. All four extension points currently live in `core`, so full internalization works today; future modules consume registrations through the public facades (noted in the issue's technical notes).
- Each feature package exposes a minimal public facade — a `register()` extension on the extension-point type plus a name lookup:
  - `core.theme`: existing `ThemeProvider.register(default = …)` kept; new top-level `theme(name)` and `defaultTheme()` lookups.
  - `core.minimessage`: `MiniMessageTagProvider.register()` + `miniMessageTag(name)`.
  - `core.animation`: `AnimationDriver.register()` + `animationDriver(name)`.
  - `core.platform`: `PlatformAdapter.register()` + `platformAdapter()`.
- Registry behaviour (replacement semantics, default theme, `reset()`) is unchanged; the snapshot views (`themes()` etc.) are no longer public surface — per the smallest-surface rule, lookup sugar can be added later if a real consumer needs enumeration.
- `README.md` and `docs/DESIGN.md` examples now use only the facades.

## Related issues

Closes #131

## Type of change

- [ ] feat — new capability
- [ ] fix — bug fix
- [x] refactor — internal, no behaviour change
- [x] docs
- [x] test
- [ ] chore / build / ci

## Testing

- New Kotest specs per facade: `ThemeLookupTest` (4), `MiniMessageTagRegistrationTest` (3), `AnimationDriverRegistrationTest` (3), `PlatformAdapterRegistrationTest` (3) — registration via extension, lookup, replacement semantics, and null for missing names.
- `ThemeDslTest`'s end-to-end spec now resolves through the `theme("brand")` facade instead of `AdventureDsl`.
- Existing `AdventureDslTest` still covers the internal registry (test source set sees internals).
- `./gradlew build` passes (compile + all module tests + ktlint/spotless).

## Checklist

- [x] Title and commit subjects follow `verb(area): something`
- [x] Linked the related issue
- [x] Tests added/updated (dogfood the `test` matchers where applicable)
- [x] `./gradlew ktlintCheck spotlessCheck` clean; `explicitApi()` satisfied with KDoc on public API
- [x] Updated `docs/` and `CHANGELOG.md` if user-facing (CHANGELOG is release-please-generated; conventional title covers it)
