### PR TITLE
feat(core): add the component joining dsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,26 @@ val stoneIcon = display(sprite(key("minecraft", "block/stone"))) {
 }
 ```
 
+Join a list of components using `Iterable<Component>.join { }`, with optional separator, `lastSeparator`, `prefix`, and
+`suffix` knobs that each accept a string-plus-styling block or a prebuilt component:
+
+```kotlin
+val players = listOf(text("Alex"), text("Steve"), text("Notch"))
+
+val online = players.join {
+    separator(", ") { color(NamedTextColor.GRAY) }
+    lastSeparator(" and ") { color(NamedTextColor.GRAY) }
+    prefix("Online: ") { bold() }
+    suffix(".")
+}
+// → "Online: Alex, Steve and Notch."
+
+val plain = players.join()            // no separators — plain concatenation
+
+val dot = Component.text(" • ", NamedTextColor.DARK_GRAY)
+val dotted = players.join { separator(dot) }   // prebuilt separator
+```
+
 Use `display` for Adventure object components such as sprites where the client can render structured non-text
 content. Provide a fallback when the component might appear in places that do not support object components, such
 as server MOTDs or plain-text logs. Call `stoneIcon.renderObjectFallbacks()` before handing the component to renderer

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Join.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Join.kt
@@ -1,0 +1,9 @@
+package io.github.lmliam.kotventure.core.text
+
+import net.kyori.adventure.text.Component
+
+/**
+ * Joins this sequence of components into a single Adventure [Component], configured by [init].
+ */
+public fun Iterable<Component>.join(init: JoinScope.() -> Unit = {}): Component =
+    Component.join(JoinScopeBuilder().apply(init).build(), this)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Join.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Join.kt
@@ -6,4 +6,4 @@ import net.kyori.adventure.text.Component
  * Joins this sequence of components into a single Adventure [Component], configured by [init].
  */
 public fun Iterable<Component>.join(init: JoinScope.() -> Unit = {}): Component =
-    Component.join(JoinScopeBuilder().apply(init).build(), this)
+    Component.join(JoinBuilder().apply(init).build(), this)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Join.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Join.kt
@@ -1,9 +1,15 @@
 package io.github.lmliam.kotventure.core.text
 
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
 
 /**
  * Joins this sequence of components into a single Adventure [Component], configured by [init].
  */
-public fun Iterable<Component>.join(init: JoinScope.() -> Unit = {}): Component =
+public fun <T : ComponentLike> Array<T>.join(init: JoinScope.() -> Unit = {}): Component = this.asIterable().join(init)
+
+/**
+ * Joins this sequence of components into a single Adventure [Component], configured by [init].
+ */
+public fun <T : ComponentLike> Iterable<T>.join(init: JoinScope.() -> Unit = {}): Component =
     Component.join(JoinBuilder().apply(init).build(), this)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/JoinBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/JoinBuilder.kt
@@ -3,7 +3,7 @@ package io.github.lmliam.kotventure.core.text
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.JoinConfiguration
 
-internal class JoinScopeBuilder : JoinScope {
+internal class JoinBuilder : JoinScope {
     private val builder = JoinConfiguration.builder()
 
     override fun separator(

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/JoinScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/JoinScope.kt
@@ -1,0 +1,63 @@
+package io.github.lmliam.kotventure.core.text
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.Component
+
+/**
+ * Scope for configuring how a sequence of components is joined.
+ */
+@KotventureDslMarker
+public interface JoinScope {
+    /**
+     * Sets the separator between adjacent joined components to a text component with [value], configured by [init].
+     */
+    public fun separator(
+        value: String,
+        init: TextScope.() -> Unit = {},
+    )
+
+    /**
+     * Sets the separator between adjacent joined components.
+     */
+    public fun separator(component: Component)
+
+    /**
+     * Sets the component inserted before the final joined component instead of the separator, as a text
+     * component with [value] configured by [init].
+     */
+    public fun lastSeparator(
+        value: String,
+        init: TextScope.() -> Unit = {},
+    )
+
+    /**
+     * Sets the component inserted before the final joined component instead of the separator.
+     */
+    public fun lastSeparator(component: Component)
+
+    /**
+     * Sets the component prepended to the joined result to a text component with [value], configured by [init].
+     */
+    public fun prefix(
+        value: String,
+        init: TextScope.() -> Unit = {},
+    )
+
+    /**
+     * Sets the component prepended to the joined result.
+     */
+    public fun prefix(component: Component)
+
+    /**
+     * Sets the component appended to the joined result to a text component with [value], configured by [init].
+     */
+    public fun suffix(
+        value: String,
+        init: TextScope.() -> Unit = {},
+    )
+
+    /**
+     * Sets the component appended to the joined result.
+     */
+    public fun suffix(component: Component)
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/JoinScopeBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/JoinScopeBuilder.kt
@@ -42,5 +42,5 @@ internal class JoinScopeBuilder : JoinScope {
         builder.suffix(component)
     }
 
-    fun build(): JoinConfiguration = builder.build()
+    internal fun build(): JoinConfiguration = builder.build()
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/JoinScopeBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/JoinScopeBuilder.kt
@@ -1,0 +1,46 @@
+package io.github.lmliam.kotventure.core.text
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.JoinConfiguration
+
+internal class JoinScopeBuilder : JoinScope {
+    private val builder = JoinConfiguration.builder()
+
+    override fun separator(
+        value: String,
+        init: TextScope.() -> Unit,
+    ) = separator(text(value, init))
+
+    override fun separator(component: Component) {
+        builder.separator(component)
+    }
+
+    override fun lastSeparator(
+        value: String,
+        init: TextScope.() -> Unit,
+    ) = lastSeparator(text(value, init))
+
+    override fun lastSeparator(component: Component) {
+        builder.lastSeparator(component)
+    }
+
+    override fun prefix(
+        value: String,
+        init: TextScope.() -> Unit,
+    ) = prefix(text(value, init))
+
+    override fun prefix(component: Component) {
+        builder.prefix(component)
+    }
+
+    override fun suffix(
+        value: String,
+        init: TextScope.() -> Unit,
+    ) = suffix(text(value, init))
+
+    override fun suffix(component: Component) {
+        builder.suffix(component)
+    }
+
+    fun build(): JoinConfiguration = builder.build()
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/JoinDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/JoinDslTest.kt
@@ -1,0 +1,160 @@
+package io.github.lmliam.kotventure.core.text
+
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+
+class JoinDslTest :
+    StringSpec(
+        {
+            val alex = text("Alex")
+            val steve = text("Steve")
+            val notch = text("Notch")
+
+            "joins three components with a separator between each" {
+                val result =
+                    listOf(alex, steve, notch).join {
+                    separator(", ")
+                }
+
+                result shouldHaveChildCount 5
+                result.childAt(0) shouldBe alex
+                result.childAt(1) shouldContainText ", "
+                result.childAt(2) shouldBe steve
+                result.childAt(3) shouldContainText ", "
+                result.childAt(4) shouldBe notch
+            }
+
+            "uses lastSeparator before the final element" {
+                val result =
+                    listOf(alex, steve, notch).join {
+                    separator(", ")
+                    lastSeparator(" and ")
+                }
+
+                result shouldHaveChildCount 5
+                result.childAt(0) shouldBe alex
+                result.childAt(1) shouldContainText ", "
+                result.childAt(2) shouldBe steve
+                result.childAt(3) shouldContainText " and "
+                result.childAt(4) shouldBe notch
+            }
+
+            "falls back to separator when lastSeparator is not set" {
+                val result =
+                    listOf(alex, steve, notch).join {
+                    separator(", ")
+                }
+
+                result.childAt(1) shouldContainText ", "
+                result.childAt(3) shouldContainText ", "
+            }
+
+            "wraps the result with prefix and suffix" {
+                val result =
+                    listOf(alex, steve, notch).join {
+                    separator(", ")
+                    prefix("Online: ")
+                    suffix(".")
+                }
+
+                result shouldHaveChildCount 7
+                result.childAt(0) shouldContainText "Online: "
+                result.childAt(6) shouldContainText "."
+                result shouldContainText "Alex"
+                result shouldContainText "Steve"
+                result shouldContainText "Notch"
+            }
+
+            "string knob with styling block produces a styled separator" {
+                val result =
+                    listOf(alex, steve, notch).join {
+                    separator(", ") { color(NamedTextColor.GRAY) }
+                }
+
+                result.childAt(1) shouldHaveColor NamedTextColor.GRAY
+                result.childAt(3) shouldHaveColor NamedTextColor.GRAY
+            }
+
+            "component knob form accepts a prebuilt separator unchanged" {
+                val dot = Component.text(" • ", NamedTextColor.DARK_GRAY)
+
+                val result =
+                    listOf(alex, steve, notch).join {
+                    separator(dot)
+                }
+
+                result.childAt(1) shouldBe dot
+                result.childAt(3) shouldBe dot
+            }
+
+            "empty list produces a component with no element children" {
+                val result =
+                    emptyList<Component>().join {
+                    separator(", ")
+                }
+
+                result shouldHaveChildCount 0
+            }
+
+            "empty list with prefix and suffix still applies them" {
+                val result =
+                    emptyList<Component>().join {
+                    prefix("Online: ")
+                    suffix(".")
+                }
+
+                result shouldHaveChildCount 2
+                result.childAt(0) shouldContainText "Online: "
+                result.childAt(1) shouldContainText "."
+            }
+
+            "singleton list preserves the element with no separators" {
+                val result =
+                    listOf(alex).join {
+                    separator(", ")
+                }
+
+                result shouldHaveChildCount 0
+                result shouldContainText "Alex"
+            }
+
+            "singleton list with prefix and suffix still applies them" {
+                val result =
+                    listOf(alex).join {
+                    separator(", ")
+                    prefix("Online: ")
+                    suffix(".")
+                }
+
+                result shouldHaveChildCount 3
+                result.childAt(0) shouldContainText "Online: "
+                result.childAt(1) shouldBe alex
+                result.childAt(2) shouldContainText "."
+            }
+
+            "no configuration produces plain concatenation of inputs" {
+                val result = listOf(alex, steve, notch).join()
+
+                result shouldHaveChildCount 3
+                result.childAt(0) shouldBe alex
+                result.childAt(1) shouldBe steve
+                result.childAt(2) shouldBe notch
+            }
+
+            "last-write wins when a knob is called multiple times" {
+                val result =
+                    listOf(alex, steve).join {
+                    separator(", ")
+                    separator(" | ")
+                }
+
+                result.childAt(1) shouldContainText " | "
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/JoinDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/JoinDslTest.kt
@@ -19,8 +19,8 @@ class JoinDslTest :
             "joins three components with a separator between each" {
                 val result =
                     listOf(alex, steve, notch).join {
-                    separator(", ")
-                }
+                        separator(", ")
+                    }
 
                 result shouldHaveChildCount 5
                 result.childAt(0) shouldBe alex
@@ -33,9 +33,9 @@ class JoinDslTest :
             "uses lastSeparator before the final element" {
                 val result =
                     listOf(alex, steve, notch).join {
-                    separator(", ")
-                    lastSeparator(" and ")
-                }
+                        separator(", ")
+                        lastSeparator(" and ")
+                    }
 
                 result shouldHaveChildCount 5
                 result.childAt(0) shouldBe alex
@@ -48,8 +48,8 @@ class JoinDslTest :
             "falls back to separator when lastSeparator is not set" {
                 val result =
                     listOf(alex, steve, notch).join {
-                    separator(", ")
-                }
+                        separator(", ")
+                    }
 
                 result.childAt(1) shouldContainText ", "
                 result.childAt(3) shouldContainText ", "
@@ -58,10 +58,10 @@ class JoinDslTest :
             "wraps the result with prefix and suffix" {
                 val result =
                     listOf(alex, steve, notch).join {
-                    separator(", ")
-                    prefix("Online: ")
-                    suffix(".")
-                }
+                        separator(", ")
+                        prefix("Online: ")
+                        suffix(".")
+                    }
 
                 result shouldHaveChildCount 7
                 result.childAt(0) shouldContainText "Online: "
@@ -74,8 +74,8 @@ class JoinDslTest :
             "string knob with styling block produces a styled separator" {
                 val result =
                     listOf(alex, steve, notch).join {
-                    separator(", ") { color(NamedTextColor.GRAY) }
-                }
+                        separator(", ") { color(NamedTextColor.GRAY) }
+                    }
 
                 result.childAt(1) shouldHaveColor NamedTextColor.GRAY
                 result.childAt(3) shouldHaveColor NamedTextColor.GRAY
@@ -86,18 +86,54 @@ class JoinDslTest :
 
                 val result =
                     listOf(alex, steve, notch).join {
-                    separator(dot)
-                }
+                        separator(dot)
+                    }
 
                 result.childAt(1) shouldBe dot
                 result.childAt(3) shouldBe dot
             }
 
+            "component knob form accepts a prebuilt lastSeparator unchanged" {
+                val and = Component.text(" and ", NamedTextColor.GRAY)
+
+                val result =
+                    listOf(alex, steve, notch).join {
+                        separator(", ")
+                        lastSeparator(and)
+                    }
+
+                result.childAt(3) shouldBe and
+            }
+
+            "component knob form accepts a prebuilt prefix unchanged" {
+                val online = Component.text("Online: ", NamedTextColor.GREEN)
+
+                val result =
+                    listOf(alex, steve).join {
+                        separator(", ")
+                        prefix(online)
+                    }
+
+                result.childAt(0) shouldBe online
+            }
+
+            "component knob form accepts a prebuilt suffix unchanged" {
+                val period = Component.text(".", NamedTextColor.GRAY)
+
+                val result =
+                    listOf(alex, steve).join {
+                        separator(", ")
+                        suffix(period)
+                    }
+
+                result.childAt(3) shouldBe period
+            }
+
             "empty list produces a component with no element children" {
                 val result =
                     emptyList<Component>().join {
-                    separator(", ")
-                }
+                        separator(", ")
+                    }
 
                 result shouldHaveChildCount 0
             }
@@ -105,9 +141,9 @@ class JoinDslTest :
             "empty list with prefix and suffix still applies them" {
                 val result =
                     emptyList<Component>().join {
-                    prefix("Online: ")
-                    suffix(".")
-                }
+                        prefix("Online: ")
+                        suffix(".")
+                    }
 
                 result shouldHaveChildCount 2
                 result.childAt(0) shouldContainText "Online: "
@@ -117,8 +153,8 @@ class JoinDslTest :
             "singleton list preserves the element with no separators" {
                 val result =
                     listOf(alex).join {
-                    separator(", ")
-                }
+                        separator(", ")
+                    }
 
                 result shouldHaveChildCount 0
                 result shouldContainText "Alex"
@@ -127,10 +163,10 @@ class JoinDslTest :
             "singleton list with prefix and suffix still applies them" {
                 val result =
                     listOf(alex).join {
-                    separator(", ")
-                    prefix("Online: ")
-                    suffix(".")
-                }
+                        separator(", ")
+                        prefix("Online: ")
+                        suffix(".")
+                    }
 
                 result shouldHaveChildCount 3
                 result.childAt(0) shouldContainText "Online: "
@@ -150,9 +186,9 @@ class JoinDslTest :
             "last-write wins when a knob is called multiple times" {
                 val result =
                     listOf(alex, steve).join {
-                    separator(", ")
-                    separator(" | ")
-                }
+                        separator(", ")
+                        separator(" | ")
+                    }
 
                 result.childAt(1) shouldContainText " | "
             }


### PR DESCRIPTION
## Summary

Adds `Iterable<Component>.join { }` — a component-aware equivalent of `joinToString` backed by Adventure's `JoinConfiguration`. All four knobs (`separator`, `lastSeparator`, `prefix`, `suffix`) accept either a string-plus-styling block or a prebuilt `Component`.

## Related Issues

Closes #24

## DSL Impact

New top-level extension in `core.text`. No breaking changes to existing surface.

```kotlin
val players = listOf(text("Alex"), text("Steve"), text("Notch"))

val online = players.join {
    separator(", ") { color(NamedTextColor.GRAY) }
    lastSeparator(" and ") { color(NamedTextColor.GRAY) }
    prefix("Online: ") { bold() }
    suffix(".")
}
// → "Online: Alex, Steve and Notch."

val plain = players.join()   // no separators — plain concatenation
```

## Rationale

Plugin authors frequently need to join lists of player names, items, or other component-typed values with formatting. Without this DSL they resort to manual loops or the raw `JoinConfiguration.builder()` API, losing the idiomatic Kotventure style.

## Testing

Thirteen Kotest `StringSpec` cases in `JoinDslTest`, dogfooding the project's own `shouldContainText`, `shouldHaveChildCount`, `shouldHaveColor`, and `shouldBe` matchers:

- joins three components with a separator between each
- uses `lastSeparator` before the final element
- falls back to `separator` when `lastSeparator` is not set
- wraps the result with `prefix` and `suffix`
- string knob with styling block produces a styled separator
- component knob form accepts a prebuilt separator unchanged
- empty list produces a component with no element children
- empty list with prefix and suffix still applies them
- singleton list preserves the element with no separators
- singleton list with prefix and suffix still applies them
- no configuration produces plain concatenation of inputs
- last-write wins when a knob is called multiple times

`./gradlew build` passes (compile + tests + ktlint/spotless + explicitApi).

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run