### PR TITLE
feat(minimessage): add mini() passthrough and a tag-resolver DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 
 ### Added
 
+- MiniMessage passthrough parsing via `kotventure-minimessage`, including `mini(...)`, placeholder resolvers for parsed,
+  unparsed, and component values, and `ComponentScope.mini(...)` integration for use inside the core DSL.
 - Text DSL composition helpers: `append(Component)`, `newline()`, and inline `style { }` blocks for the current
   component.
 - Translatable component DSL support for translation keys, fallback text, component arguments, boolean arguments, numeric

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ See [`docs/DESIGN.md`](docs/DESIGN.md) for the full design and the [Roadmap](doc
 The current build enables the first lazy modules:
 
 - `kotventure-core` — the plain component builder and explicit startup registry
+- `kotventure-minimessage` — `mini(...)` parsing plus parsed, unparsed, and component placeholder resolvers
 - `kotventure-serializer` — `Component.toMiniMessage()` and `Component.toPlainText()` wrappers around Adventure
   serializers
 - `kotventure-test` — Kotest component matchers consumed test-scoped by library modules
@@ -236,6 +237,30 @@ val storedTitle = storageNbt(key("kotventure", "messages"), "welcome.title") {
 val stoneIcon = display(sprite(key("minecraft", "block/stone"))) {
     fallback {
         text("[stone]")
+    }
+}
+```
+
+MiniMessage passthrough parsing is available as an opt-in module so `core` stays free of MiniMessage dependencies:
+
+```kotlin
+val announcement = mini("<gold>[Server]</gold> <player> joined") {
+    unparsed("player", "Alex")
+}
+
+val rich = mini("<prefix> <badge>") {
+    parsed("prefix", "<gray>[chat]</gray>")
+    component("badge") {
+        text("VIP") {
+            color(NamedTextColor.AQUA)
+        }
+    }
+}
+
+val nested = component {
+    text("Notice: ")
+    mini("<gold><player></gold> joined") {
+        unparsed("player", "Alex")
     }
 }
 ```

--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -44,6 +44,7 @@ repositories {
 
 def bomConsumerModules = [
         'core',
+        'minimessage',
         'serializer',
         'test'
 ]

--- a/modules/bom/build.gradle
+++ b/modules/bom/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 
     constraints {
         api project(':core')
+        api project(':minimessage')
         api project(':serializer')
         api project(':test')
 

--- a/modules/minimessage/build.gradle
+++ b/modules/minimessage/build.gradle
@@ -1,0 +1,10 @@
+description = 'Adventure MiniMessage parsing helpers and placeholder DSL.'
+
+dependencies {
+    api project(':core')
+
+    implementation kotventureDependencies."adventure-text-minimessage"
+
+    testImplementation project(':core')
+    testImplementation project(':test')
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/ComponentScopeMiniMessage.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/ComponentScopeMiniMessage.kt
@@ -1,0 +1,20 @@
+package io.github.lmliam.kotventure.minimessage
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+
+/**
+ * Parses [input] as MiniMessage and appends the resulting component to this scope.
+ */
+public fun ComponentScope.mini(input: String) {
+    append(parseMiniMessage(input))
+}
+
+/**
+ * Parses [input] as MiniMessage with placeholder resolvers configured by [init], then appends the result to this scope.
+ */
+public fun ComponentScope.mini(
+    input: String,
+    init: MiniMessageResolverScope.() -> Unit,
+) {
+    append(parseMiniMessage(input, init))
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
@@ -1,0 +1,24 @@
+package io.github.lmliam.kotventure.minimessage
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.MiniMessage
+
+/**
+ * Parses [input] with Adventure's default MiniMessage parser.
+ */
+public fun mini(input: String): Component = parseMiniMessage(input)
+
+/**
+ * Parses [input] with Adventure's default MiniMessage parser after configuring placeholder resolvers with [init].
+ */
+public fun mini(
+    input: String,
+    init: MiniMessageResolverScope.() -> Unit,
+): Component = parseMiniMessage(input, init)
+
+internal fun parseMiniMessage(input: String): Component = MiniMessage.miniMessage().deserialize(input)
+
+internal fun parseMiniMessage(
+    input: String,
+    init: MiniMessageResolverScope.() -> Unit,
+): Component = MiniMessage.miniMessage().deserialize(input, MiniMessageResolverBuilder().apply(init).build())

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageResolverBuilder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageResolverBuilder.kt
@@ -1,0 +1,41 @@
+package io.github.lmliam.kotventure.minimessage
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.text.component
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+
+internal class MiniMessageResolverBuilder : MiniMessageResolverScope {
+    private val resolvers: MutableList<TagResolver> = mutableListOf()
+
+    override fun parsed(
+        name: String,
+        value: String,
+    ) {
+        resolvers += Placeholder.parsed(name, value)
+    }
+
+    override fun unparsed(
+        name: String,
+        value: String,
+    ) {
+        resolvers += Placeholder.unparsed(name, value)
+    }
+
+    override fun component(
+        name: String,
+        value: ComponentLike,
+    ) {
+        resolvers += Placeholder.component(name, value)
+    }
+
+    override fun component(
+        name: String,
+        init: ComponentScope.() -> Unit,
+    ) {
+        component(name, component(init))
+    }
+
+    internal fun build(): TagResolver = TagResolver.resolver(resolvers)
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageResolverScope.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageResolverScope.kt
@@ -1,0 +1,43 @@
+package io.github.lmliam.kotventure.minimessage
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Configures placeholder resolvers applied while parsing MiniMessage markup.
+ */
+@KotventureDslMarker
+public interface MiniMessageResolverScope {
+    /**
+     * Inserts [value] as parsed MiniMessage markup for the placeholder named [name].
+     */
+    public fun parsed(
+        name: String,
+        value: String,
+    ): Unit
+
+    /**
+     * Inserts [value] as literal text for the placeholder named [name].
+     */
+    public fun unparsed(
+        name: String,
+        value: String,
+    ): Unit
+
+    /**
+     * Inserts [value] as a self-closing component placeholder for the placeholder named [name].
+     */
+    public fun component(
+        name: String,
+        value: ComponentLike,
+    ): Unit
+
+    /**
+     * Builds a component placeholder named [name] from a Kotventure component DSL block.
+     */
+    public fun component(
+        name: String,
+        init: ComponentScope.() -> Unit,
+    ): Unit
+}

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
@@ -1,0 +1,93 @@
+package io.github.lmliam.kotventure.minimessage
+
+import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldNotHaveColor
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+
+class MiniMessageDslTest :
+    StringSpec(
+        {
+            "parses MiniMessage markup to an Adventure component" {
+                val parsed = mini("<red>hi")
+
+                parsed shouldContainText "hi"
+                parsed shouldHaveColor NamedTextColor.RED
+            }
+
+            "applies parsed placeholders through the resolver DSL" {
+                val parsed =
+                    mini("<name>") {
+                        parsed("name", "<gold>Alex</gold>")
+                    }
+
+                parsed shouldContainText "Alex"
+                parsed shouldHaveColor NamedTextColor.GOLD
+            }
+
+            "applies unparsed placeholders without interpreting nested markup" {
+                val parsed =
+                    mini("<name>") {
+                        unparsed("name", "<red>Alex")
+                    }
+
+                parsed shouldContainText "<red>Alex"
+                parsed.shouldNotHaveColor()
+            }
+
+            "applies component placeholders from existing Adventure components" {
+                val badge = Component.text("VIP", NamedTextColor.AQUA)
+                val parsed =
+                    mini("<badge> joined") {
+                        component("badge", badge)
+                    }
+
+                parsed shouldHaveChildCount 2
+                parsed.childAt(0) shouldBe badge
+                parsed.childAt(1) shouldContainText " joined"
+                parsed.childAt(1).shouldNotHaveColor()
+            }
+
+            "builds component placeholders from the Kotventure component DSL" {
+                val parsed =
+                    mini("<badge> joined") {
+                        component("badge") {
+                            text("VIP") {
+                                color(NamedTextColor.AQUA)
+                            }
+                        }
+                    }
+
+                parsed shouldHaveChildCount 2
+                parsed.childAt(0) shouldContainText "VIP"
+                parsed.childAt(0) shouldHaveColor NamedTextColor.AQUA
+                parsed.childAt(1) shouldContainText " joined"
+                parsed.childAt(1).shouldNotHaveColor()
+            }
+
+            "appends parsed MiniMessage components inside the component DSL" {
+                val message =
+                    component {
+                        text("Notice: ")
+                        mini("<gold><player></gold> joined") {
+                            unparsed("player", "Alex")
+                        }
+                    }
+
+                message shouldHaveChildCount 2
+                message.childAt(0) shouldContainText "Notice: "
+                message.childAt(1) shouldContainText "Alex joined"
+                message.childAt(1) shouldHaveChildCount 2
+                message.childAt(1).childAt(0) shouldContainText "Alex"
+                message.childAt(1).childAt(0) shouldHaveColor NamedTextColor.GOLD
+                message.childAt(1).childAt(1) shouldContainText " joined"
+                message.childAt(1).childAt(1).shouldNotHaveColor()
+            }
+        },
+    )

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,10 +14,12 @@ rootProject.name = 'Kotventure'
 // Modules are introduced lazily, one phase at a time (see docs/DESIGN.md §4 and issue #7).
 // Each module lives under modules/<name>; enable only modules that have landed.
 include 'core'
+include 'minimessage'
 include 'serializer'
 include 'test'
 include 'bom'
 project(':core').projectDir = file('modules/core')
+project(':minimessage').projectDir = file('modules/minimessage')
 project(':serializer').projectDir = file('modules/serializer')
 project(':test').projectDir = file('modules/test')
 project(':bom').projectDir = file('modules/bom')


### PR DESCRIPTION
## Summary

Add the first `kotventure-minimessage` slice: top-level `mini(...)` parsing, a resolver DSL for parsed/unparsed/component placeholders, and `ComponentScope.mini(...)` integration.

## Related Issues

Closes #25

## DSL Impact

Users can now parse MiniMessage directly into Adventure components, supply placeholder resolvers with a Kotventure receiver DSL, and append parsed MiniMessage inside `component { ... }` blocks without adding MiniMessage to `core`.

## Rationale

This establishes the MiniMessage entry point described in the design without widening scope into typed templates, validation, or conversion work that belongs to follow-up issues.

## Testing

- Added `MiniMessageDslTest` coverage for plain parsing, parsed/unparsed/component placeholders, and `ComponentScope.mini(...)` integration.
- Ran `./gradlew build ktlintCheck spotlessCheck`.

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [ ] Verified examples build and run
