### PR TITLE
chore(build): align release-please pre-1.0 bumps with roadmap

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -14,6 +14,18 @@ Prefer `RELEASE_PLEASE_TOKEN` for normal releases because PRs, tags, and release
 `GITHUB_TOKEN` do not trigger follow-up workflows. Use a fine-grained PAT or GitHub App token for the GitHub Actions bot
 with repository access and the ability to write contents, issues, and pull requests.
 
+## Version Policy
+
+Release automation follows the roadmap version ranges literally:
+
+- `0.0.x` is reserved for the pre-alpha spike.
+- The first feature release after `0.0.x` is `0.1.0`, which marks the start of the alpha line.
+- Before `1.0.0`, `feat(...)` and breaking changes bump the minor version; patch releases remain available for
+  non-feature follow-up work on the current minor line.
+
+When adjusting release automation, verify the policy still matches [ROADMAP.md](./ROADMAP.md) and the phase ranges in
+[DESIGN.md](./DESIGN.md).
+
 ## Branch Protection
 
 Keep `master` protected and release through the Release PR. Branch protection must allow the GitHub Actions bot or the

--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -185,8 +185,8 @@ tasks.register('verifyReleasePleaseConfiguration') {
                 'release-please-config.json must set bump-minor-pre-major for 0.x releases.'
         )
         requireReleaseAutomationValue(
-                releaseConfig['bump-patch-for-minor-pre-major'] == true,
-                'release-please-config.json must set bump-patch-for-minor-pre-major for 0.x releases.'
+                releaseConfig['bump-patch-for-minor-pre-major'] == false,
+                'release-please-config.json must disable bump-patch-for-minor-pre-major so pre-1.0 feature releases follow the roadmap and bump the minor version.'
         )
         requireReleaseAutomationValue(
                 releaseConfig['include-v-in-tag'] == false,

--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -262,6 +262,8 @@ tasks.register('verifyReleasePleaseConfiguration') {
 
         def releaseDocs = requireReleaseAutomationFile('docs/RELEASING.md').text
         requireReleaseAutomationText(releaseDocs, 'RELEASE_PLEASE_TOKEN', 'release documentation must describe the bot token secret')
+        requireReleaseAutomationText(releaseDocs, '`0.0.x` is reserved for the pre-alpha spike.', 'release documentation must reserve 0.0.x for the pre-alpha phase.')
+        requireReleaseAutomationText(releaseDocs, '`0.1.0`, which marks the start of the alpha line.', 'release documentation must describe 0.1.0 as the first alpha feature release.')
         requireReleaseAutomationText(releaseDocs, 'branch protection', 'release documentation must cover branch protection')
         requireReleaseAutomationText(releaseDocs, 'GitHub Actions bot', 'release documentation must cover bot permissions')
         requireReleaseAutomationText(releaseDocs, 'Maven Central', 'release documentation must keep publishing coordination explicit')

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
   "include-component-in-tag": false,
   "include-v-in-tag": false,
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
   "changelog-path": "CHANGELOG.md",
   "changelog-sections": [
     {


### PR DESCRIPTION
## Summary

Align release-please's pre-1.0 bump policy with the roadmap so feature releases leave the `0.0.x` pre-alpha line and start Phase 1 at `0.1.0`.

## Related Issues

Closes #139

## Scope

- [x] Build tooling
- [ ] GitHub Actions workflow
- [ ] Dependency bump
- [x] Repo config (labels, CODEOWNERS, etc.)

## Notes for Reviewers

- `release-please-config.json` now keeps `bump-minor-pre-major` enabled and disables `bump-patch-for-minor-pre-major`.
- `verifyReleasePleaseConfiguration` now enforces the roadmap-aligned policy.
- `docs/RELEASING.md` now documents the literal phase/version mapping and expected pre-1.0 bump behavior.
- Verified with `./gradlew build` and a local `release-please release-pr --dry-run` against this branch, which predicts `0.1.0` instead of `0.0.12`.

## Checklist

- [x] Linked related issue
- [x] Verified build/test pass after change
