### PR TITLE
feat(minimessage): add typed placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 
 ### Added
 
+- Typed MiniMessage placeholders via `placeholder<T>(name)` and `resolve(...)`, covering component, string, numeric,
+  and boolean values.
 - MiniMessage passthrough parsing via `kotventure-minimessage`, including `mini(...)`, placeholder resolvers for parsed,
   unparsed, and component values, and `ComponentScope.mini(...)` integration for use inside the core DSL.
 - Text DSL composition helpers: `append(Component)`, `newline()`, and inline `style { }` blocks for the current

--- a/README.md
+++ b/README.md
@@ -249,18 +249,39 @@ val count = placeholder<Int>("count")
 val channel = placeholder<String>("channel")
 
 val announcement = mini("<gold>[Server]</gold> <player> joined") {
-    resolve(player, Component.text("Alex", NamedTextColor.AQUA))
+    resolve(
+        player,
+        component {
+            text("Alex") {
+                color(NamedTextColor.AQUA)
+            }
+        },
+    )
 }
 
 val invites = mini("<gray>[<channel>]</gray> <player> has <count> invites") {
     resolve(channel, "chat")
-    resolve(player, Component.text("Alex", NamedTextColor.AQUA))
+    resolve(
+        player,
+        component {
+            text("Alex") {
+                color(NamedTextColor.AQUA)
+            }
+        },
+    )
     resolve(count, 3)
 }
 
 val rich = mini("<prefix> <player>") {
     parsed("prefix", "<gray>[chat]</gray>") // explicit bridge for markup-bearing strings
-    resolve(player, Component.text("Alex", NamedTextColor.AQUA))
+    resolve(
+        player,
+        component {
+            text("Alex") {
+                color(NamedTextColor.AQUA)
+            }
+        },
+    )
 }
 
 val nested = component {

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The current build enables the first lazy modules:
 
 - `kotventure-core` — the plain component builder and explicit startup registry
 - `kotventure-minimessage` — `mini(...)` parsing plus typed placeholders via `placeholder<T>(name)` and
-  `resolve(placeholder, value)`
+  `resolve(placeholder, value)`, alongside the `parsed`, `unparsed`, and `component` resolvers
 - `kotventure-serializer` — `Component.toMiniMessage()` and `Component.toPlainText()` wrappers around Adventure
   serializers
 - `kotventure-test` — Kotest component matchers consumed test-scoped by library modules
@@ -249,51 +249,31 @@ val player = placeholder<Component>("player")
 val count = placeholder<Int>("count")
 val channel = placeholder<String>("channel")
 
+val alex = component {
+    text("Alex") {
+        color(NamedTextColor.AQUA)
+    }
+}
+
 val announcement = mini("<gold>[Server]</gold> <player> joined") {
-    resolve(
-        player,
-        component {
-            text("Alex") {
-                color(NamedTextColor.AQUA)
-            }
-        },
-    )
+    resolve(player, alex)
 }
 
 val invites = mini("<gray>[<channel>]</gray> <player> has <count> invites") {
     resolve(channel, "chat")
-    resolve(
-        player,
-        component {
-            text("Alex") {
-                color(NamedTextColor.AQUA)
-            }
-        },
-    )
+    resolve(player, alex)
     resolve(count, 3)
 }
 
 val rich = mini("<prefix> <player>") {
     parsed("prefix", "<gray>[chat]</gray>") // explicit bridge for markup-bearing strings
-    resolve(
-        player,
-        component {
-            text("Alex") {
-                color(NamedTextColor.AQUA)
-            }
-        },
-    )
+    resolve(player, alex)
 }
 
 val nested = component {
     text("Notice: ")
     mini("<gold><player></gold> joined") {
-        resolve(
-            player,
-            component {
-                text("Alex")
-            },
-        )
+        resolve(player, alex)
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ See [`docs/DESIGN.md`](docs/DESIGN.md) for the full design and the [Roadmap](doc
 The current build enables the first lazy modules:
 
 - `kotventure-core` — the plain component builder and explicit startup registry
-- `kotventure-minimessage` — `mini(...)` parsing plus typed, parsed, unparsed, and component placeholder resolvers
+- `kotventure-minimessage` — `mini(...)` parsing plus typed placeholders via `placeholder<T>(name)` and
+  `resolve(placeholder, value)`
 - `kotventure-serializer` — `Component.toMiniMessage()` and `Component.toPlainText()` wrappers around Adventure
   serializers
 - `kotventure-test` — Kotest component matchers consumed test-scoped by library modules

--- a/README.md
+++ b/README.md
@@ -287,7 +287,12 @@ val rich = mini("<prefix> <player>") {
 val nested = component {
     text("Notice: ")
     mini("<gold><player></gold> joined") {
-        resolve(player, Component.text("Alex"))
+        resolve(
+            player,
+            component {
+                text("Alex")
+            },
+        )
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See [`docs/DESIGN.md`](docs/DESIGN.md) for the full design and the [Roadmap](doc
 The current build enables the first lazy modules:
 
 - `kotventure-core` — the plain component builder and explicit startup registry
-- `kotventure-minimessage` — `mini(...)` parsing plus parsed, unparsed, and component placeholder resolvers
+- `kotventure-minimessage` — `mini(...)` parsing plus typed, parsed, unparsed, and component placeholder resolvers
 - `kotventure-serializer` — `Component.toMiniMessage()` and `Component.toPlainText()` wrappers around Adventure
   serializers
 - `kotventure-test` — Kotest component matchers consumed test-scoped by library modules
@@ -244,23 +244,29 @@ val stoneIcon = display(sprite(key("minecraft", "block/stone"))) {
 MiniMessage passthrough parsing is available as an opt-in module so `core` stays free of MiniMessage dependencies:
 
 ```kotlin
+val player = placeholder<Component>("player")
+val count = placeholder<Int>("count")
+val channel = placeholder<String>("channel")
+
 val announcement = mini("<gold>[Server]</gold> <player> joined") {
-    unparsed("player", "Alex")
+    resolve(player, Component.text("Alex", NamedTextColor.AQUA))
 }
 
-val rich = mini("<prefix> <badge>") {
-    parsed("prefix", "<gray>[chat]</gray>")
-    component("badge") {
-        text("VIP") {
-            color(NamedTextColor.AQUA)
-        }
-    }
+val invites = mini("<gray>[<channel>]</gray> <player> has <count> invites") {
+    resolve(channel, "chat")
+    resolve(player, Component.text("Alex", NamedTextColor.AQUA))
+    resolve(count, 3)
+}
+
+val rich = mini("<prefix> <player>") {
+    parsed("prefix", "<gray>[chat]</gray>") // explicit bridge for markup-bearing strings
+    resolve(player, Component.text("Alex", NamedTextColor.AQUA))
 }
 
 val nested = component {
     text("Notice: ")
     mini("<gold><player></gold> joined") {
-        unparsed("player", "Alex")
+        resolve(player, Component.text("Alex"))
     }
 }
 ```

--- a/modules/core/build.gradle
+++ b/modules/core/build.gradle
@@ -7,5 +7,4 @@ dependencies {
     api kotventureDependencies."adventure-api"
 
     testImplementation project(':test')
-    testImplementation kotventureDependencies."kctfork-core"
 }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/ClickEventDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/ClickEventDslTest.kt
@@ -1,10 +1,9 @@
 package io.github.lmliam.kotventure.core.event
 
-import com.tschuchort.compiletesting.KotlinCompilation
-import com.tschuchort.compiletesting.SourceFile
 import io.github.lmliam.kotventure.core.key.key
 import io.github.lmliam.kotventure.core.style.style
 import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
 import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldHaveClickAction
 import io.github.lmliam.kotventure.test.text.shouldHaveClickEvent
@@ -19,12 +18,10 @@ import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.event.ClickCallback
 import net.kyori.adventure.text.event.ClickEvent
-import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import java.nio.file.Path
 import kotlin.time.Duration.Companion.minutes
 import java.time.Duration as JavaDuration
 
-@OptIn(ExperimentalCompilerApi::class)
 class ClickEventDslTest :
     StringSpec(
         {
@@ -457,23 +454,3 @@ private data class CompileFailureCase(
     val source: String,
     val expectedMessage: String,
 )
-
-@OptIn(ExperimentalCompilerApi::class)
-private fun assertDoesNotCompile(
-    fileName: String,
-    source: String,
-    expectedMessage: String? = null,
-) {
-    val compilation =
-        KotlinCompilation().apply {
-            inheritClassPath = true
-            sources = listOf(SourceFile.kotlin(fileName, source))
-        }
-
-    val result = compilation.compile()
-
-    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-    if (expectedMessage != null) {
-        result.messages shouldContain expectedMessage
-    }
-}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
@@ -1,8 +1,7 @@
 package io.github.lmliam.kotventure.core.text
 
-import com.tschuchort.compiletesting.KotlinCompilation
-import com.tschuchort.compiletesting.SourceFile
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
 import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldBeBlockNbtComponent
 import io.github.lmliam.kotventure.test.text.shouldBeEntityNbtComponent
@@ -28,16 +27,13 @@ import io.github.lmliam.kotventure.test.text.shouldHaveTranslationKey
 import io.github.lmliam.kotventure.test.text.shouldNotHaveDecoration
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.BlockNBTComponent
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextDecoration
-import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
-@OptIn(ExperimentalCompilerApi::class)
 class ComponentDslTest :
     StringSpec(
         {
@@ -315,94 +311,73 @@ class ComponentDslTest :
             }
 
             "prevents implicit outer scope access in Kotventure-marked DSL blocks" {
-                val source =
-                    """
-                    import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
-                    import io.github.lmliam.kotventure.core.text.component
+                assertDoesNotCompile(
+                    fileName = "DslMarkerScopeTest.kt",
+                    source =
+                        """
+                        import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+                        import io.github.lmliam.kotventure.core.text.component
 
-                    @KotventureDslMarker
-                    class OuterScope {
-                        fun outerOnly() {
-                        }
-                    }
-
-                    fun outer(init: OuterScope.() -> Unit) {
-                        OuterScope().init()
-                    }
-
-                    fun shouldNotCompile() {
-                        outer {
-                            component {
-                                outerOnly()
+                        @KotventureDslMarker
+                        class OuterScope {
+                            fun outerOnly() {
                             }
                         }
-                    }
-                    """.trimIndent()
 
-                val compilation =
-                    KotlinCompilation().apply {
-                        inheritClassPath = true
-                        sources = listOf(SourceFile.kotlin("DslMarkerScopeTest.kt", source))
-                    }
-
-                val result = compilation.compile()
-
-                result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-                result.messages shouldContain "implicit receiver"
-            }
-
-            "prevents text content access from the generic component root" {
-                val source =
-                    """
-                    import io.github.lmliam.kotventure.core.text.component
-
-                    fun shouldNotCompile() {
-                        component {
-                            content("root text")
+                        fun outer(init: OuterScope.() -> Unit) {
+                            OuterScope().init()
                         }
-                    }
-                    """.trimIndent()
 
-                val compilation =
-                    KotlinCompilation().apply {
-                        inheritClassPath = true
-                        sources = listOf(SourceFile.kotlin("ComponentRootScopeTest.kt", source))
-                    }
-
-                val result = compilation.compile()
-
-                result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-                result.messages shouldContain "Unresolved reference 'content'"
-            }
-
-            "prevents text scope access inside style blocks" {
-                val source =
-                    """
-                    import io.github.lmliam.kotventure.core.text.component
-                    import net.kyori.adventure.text.format.NamedTextColor
-
-                    fun shouldNotCompile() {
-                        component {
-                            text {
-                                style {
-                                    color(NamedTextColor.GOLD)
-                                    content("leaked")
+                        fun shouldNotCompile() {
+                            outer {
+                                component {
+                                    outerOnly()
                                 }
                             }
                         }
-                    }
-                    """.trimIndent()
+                        """.trimIndent(),
+                    "implicit receiver",
+                )
+            }
 
-                val compilation =
-                    KotlinCompilation().apply {
-                        inheritClassPath = true
-                        sources = listOf(SourceFile.kotlin("StyleScopeLeakTest.kt", source))
-                    }
+            "prevents text content access from the generic component root" {
+                assertDoesNotCompile(
+                    fileName = "ComponentRootScopeTest.kt",
+                    source =
+                        """
+                        import io.github.lmliam.kotventure.core.text.component
 
-                val result = compilation.compile()
+                        fun shouldNotCompile() {
+                            component {
+                                content("root text")
+                            }
+                        }
+                        """.trimIndent(),
+                    "Unresolved reference 'content'",
+                )
+            }
 
-                result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-                result.messages shouldContain "implicit receiver"
+            "prevents text scope access inside style blocks" {
+                assertDoesNotCompile(
+                    fileName = "StyleScopeLeakTest.kt",
+                    source =
+                        """
+                        import io.github.lmliam.kotventure.core.text.component
+                        import net.kyori.adventure.text.format.NamedTextColor
+
+                        fun shouldNotCompile() {
+                            component {
+                                text {
+                                    style {
+                                        color(NamedTextColor.GOLD)
+                                        content("leaked")
+                                    }
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    "implicit receiver",
+                )
             }
 
             "builds a component tree when nested scopes stay explicit" {

--- a/modules/minimessage/build.gradle
+++ b/modules/minimessage/build.gradle
@@ -7,5 +7,4 @@ dependencies {
 
     testImplementation project(':core')
     testImplementation project(':test')
-    testImplementation kotventureDependencies."kctfork-core"
 }

--- a/modules/minimessage/build.gradle
+++ b/modules/minimessage/build.gradle
@@ -7,4 +7,5 @@ dependencies {
 
     testImplementation project(':core')
     testImplementation project(':test')
+    testImplementation kotventureDependencies."kctfork-core"
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
@@ -1,25 +1,37 @@
 package io.github.lmliam.kotventure.minimessage
 
 import net.kyori.adventure.text.ComponentLike
+import kotlin.jvm.javaObjectType
+
+// Mirrors Adventure's TagPattern.TAG_NAME_REGEX so invalid names fail at declaration instead of first render.
+private val TAG_NAME_REGEX = Regex("[!?#]?[a-z0-9_-]*")
 
 /**
  * A typed MiniMessage placeholder descriptor.
  *
- * The type parameter controls which values can be bound with [MiniMessageResolverScope.resolve].
+ * The type parameter controls which values can be bound with [MiniMessageResolverScope.resolve]. Two descriptors are
+ * equal when they share both name and value type.
  */
 public class MiniMessagePlaceholder<T : Any>
     @PublishedApi
     internal constructor(
         public val name: String,
+        internal val type: Class<T>,
         internal val strategy: MiniMessagePlaceholderStrategy,
     ) {
+        init {
+            require(TAG_NAME_REGEX.matches(name)) {
+                "MiniMessage placeholder names must match ${TAG_NAME_REGEX.pattern}; received '$name'."
+            }
+        }
+
         override fun equals(other: Any?): Boolean =
             this === other ||
                 other is MiniMessagePlaceholder<*> &&
                 name == other.name &&
-                strategy == other.strategy
+                type == other.type
 
-        override fun hashCode(): Int = 31 * name.hashCode() + strategy.hashCode()
+        override fun hashCode(): Int = 31 * name.hashCode() + type.hashCode()
     }
 
 /**
@@ -28,7 +40,9 @@ public class MiniMessagePlaceholder<T : Any>
  * Supported value families are [ComponentLike], [String], [Number], and [Boolean]. String, number, and boolean
  * placeholders bind as literal text; use [MiniMessageResolverScope.parsed] for markup-bearing string substitutions.
  *
- * @throws IllegalArgumentException when [T] is outside the supported value families.
+ * @throws IllegalArgumentException when [T] is outside the supported value families or [name] is not a valid
+ *   MiniMessage tag name.
  */
 public inline fun <reified T : Any> placeholder(name: String): MiniMessagePlaceholder<T> =
-    MiniMessagePlaceholder(name, miniMessagePlaceholderStrategy<T>())
+    // Box Kotlin primitive types so Int/Double/Boolean compare equal across creation sites.
+    MiniMessagePlaceholder(name, T::class.javaObjectType, miniMessagePlaceholderStrategy<T>())

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
@@ -13,7 +13,17 @@ public class MiniMessagePlaceholder<T : Any>
     internal constructor(
         public val name: String,
         internal val strategy: MiniMessagePlaceholderStrategy,
-    )
+    ) {
+        override fun equals(other: Any?): Boolean =
+            this === other ||
+                other is MiniMessagePlaceholder<*> &&
+                name == other.name &&
+                strategy == other.strategy
+
+        override fun hashCode(): Int = 31 * name.hashCode() + strategy.hashCode()
+
+        override fun toString(): String = "MiniMessagePlaceholder(name=$name)"
+    }
 
 /**
  * Creates a typed MiniMessage placeholder descriptor named [name].

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
@@ -1,7 +1,6 @@
 package io.github.lmliam.kotventure.minimessage
 
 import net.kyori.adventure.text.ComponentLike
-import kotlin.jvm.javaObjectType
 
 /**
  * A typed MiniMessage placeholder descriptor.
@@ -33,25 +32,3 @@ public class MiniMessagePlaceholder<T : Any>
  */
 public inline fun <reified T : Any> placeholder(name: String): MiniMessagePlaceholder<T> =
     MiniMessagePlaceholder(name, miniMessagePlaceholderStrategy<T>())
-
-@PublishedApi
-internal enum class MiniMessagePlaceholderStrategy {
-    COMPONENT,
-    LITERAL,
-}
-
-@PublishedApi
-internal inline fun <reified T : Any> miniMessagePlaceholderStrategy(): MiniMessagePlaceholderStrategy =
-    when {
-        ComponentLike::class.java.isAssignableFrom(T::class.javaObjectType) -> MiniMessagePlaceholderStrategy.COMPONENT
-        String::class.java.isAssignableFrom(T::class.javaObjectType) -> MiniMessagePlaceholderStrategy.LITERAL
-        Number::class.java.isAssignableFrom(T::class.javaObjectType) -> MiniMessagePlaceholderStrategy.LITERAL
-        Boolean::class.javaObjectType.isAssignableFrom(
-            T::class.javaObjectType,
-        ) -> MiniMessagePlaceholderStrategy.LITERAL
-        else ->
-            error(
-                "Supported MiniMessage placeholder types are ComponentLike, String, Number, and Boolean; " +
-                    "received ${T::class.qualifiedName}.",
-            )
-    }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
@@ -1,0 +1,47 @@
+package io.github.lmliam.kotventure.minimessage
+
+import net.kyori.adventure.text.ComponentLike
+import kotlin.jvm.javaObjectType
+
+/**
+ * A typed MiniMessage placeholder descriptor.
+ *
+ * The type parameter controls which values can be bound with [MiniMessageResolverScope.resolve].
+ */
+public class MiniMessagePlaceholder<T : Any>
+    @PublishedApi
+    internal constructor(
+        public val name: String,
+        internal val strategy: MiniMessagePlaceholderStrategy,
+    )
+
+/**
+ * Creates a typed MiniMessage placeholder descriptor named [name].
+ *
+ * Supported value families are [ComponentLike], [String], [Number], and [Boolean]. String, number, and boolean
+ * placeholders bind as literal text; use [MiniMessageResolverScope.parsed] for markup-bearing string substitutions.
+ */
+public inline fun <reified T : Any> placeholder(name: String): MiniMessagePlaceholder<T> =
+    MiniMessagePlaceholder(name, miniMessagePlaceholderStrategy<T>())
+
+@PublishedApi
+internal enum class MiniMessagePlaceholderStrategy {
+    COMPONENT,
+    LITERAL,
+}
+
+@PublishedApi
+internal inline fun <reified T : Any> miniMessagePlaceholderStrategy(): MiniMessagePlaceholderStrategy =
+    when {
+        ComponentLike::class.java.isAssignableFrom(T::class.javaObjectType) -> MiniMessagePlaceholderStrategy.COMPONENT
+        String::class.java.isAssignableFrom(T::class.javaObjectType) -> MiniMessagePlaceholderStrategy.LITERAL
+        Number::class.java.isAssignableFrom(T::class.javaObjectType) -> MiniMessagePlaceholderStrategy.LITERAL
+        Boolean::class.javaObjectType.isAssignableFrom(
+            T::class.javaObjectType,
+        ) -> MiniMessagePlaceholderStrategy.LITERAL
+        else ->
+            error(
+                "Supported MiniMessage placeholder types are ComponentLike, String, Number, and Boolean; " +
+                    "received ${T::class.qualifiedName}.",
+            )
+    }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
@@ -20,8 +20,6 @@ public class MiniMessagePlaceholder<T : Any>
                 strategy == other.strategy
 
         override fun hashCode(): Int = 31 * name.hashCode() + strategy.hashCode()
-
-        override fun toString(): String = "MiniMessagePlaceholder(name=$name)"
     }
 
 /**

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
@@ -27,6 +27,8 @@ public class MiniMessagePlaceholder<T : Any>
  *
  * Supported value families are [ComponentLike], [String], [Number], and [Boolean]. String, number, and boolean
  * placeholders bind as literal text; use [MiniMessageResolverScope.parsed] for markup-bearing string substitutions.
+ *
+ * @throws IllegalArgumentException when [T] is outside the supported value families.
  */
 public inline fun <reified T : Any> placeholder(name: String): MiniMessagePlaceholder<T> =
     MiniMessagePlaceholder(name, miniMessagePlaceholderStrategy<T>())

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholderStrategy.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholderStrategy.kt
@@ -20,7 +20,7 @@ internal inline fun <reified T : Any> miniMessagePlaceholderStrategy(): MiniMess
         Number::class.java.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.LITERAL
         Boolean::class.javaObjectType.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.LITERAL
         else ->
-            error(
+            throw IllegalArgumentException(
                 "Supported MiniMessage placeholder types are ComponentLike, String, Number, and Boolean; " +
                     "received ${T::class.qualifiedName}.",
             )

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholderStrategy.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholderStrategy.kt
@@ -1,0 +1,28 @@
+package io.github.lmliam.kotventure.minimessage
+
+import net.kyori.adventure.text.ComponentLike
+import kotlin.jvm.javaObjectType
+
+@PublishedApi
+internal enum class MiniMessagePlaceholderStrategy {
+    COMPONENT,
+    LITERAL,
+}
+
+@PublishedApi
+internal inline fun <reified T : Any> miniMessagePlaceholderStrategy(): MiniMessagePlaceholderStrategy {
+    // Box Kotlin primitive types so Int/Double/Boolean classify with their JVM wrapper families.
+    val valueType = T::class.javaObjectType
+
+    return when {
+        ComponentLike::class.java.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.COMPONENT
+        String::class.java.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.LITERAL
+        Number::class.java.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.LITERAL
+        Boolean::class.javaObjectType.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.LITERAL
+        else ->
+            error(
+                "Supported MiniMessage placeholder types are ComponentLike, String, Number, and Boolean; " +
+                    "received ${T::class.qualifiedName}.",
+            )
+    }
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholderStrategy.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholderStrategy.kt
@@ -15,9 +15,9 @@ internal inline fun <reified T : Any> miniMessagePlaceholderStrategy(): MiniMess
     val valueType = T::class.javaObjectType
 
     return when {
-        ComponentLike::class.java.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.COMPONENT
-        String::class.java.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.LITERAL
-        Number::class.java.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.LITERAL
+        ComponentLike::class.javaObjectType.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.COMPONENT
+        String::class.javaObjectType.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.LITERAL
+        Number::class.javaObjectType.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.LITERAL
         Boolean::class.javaObjectType.isAssignableFrom(valueType) -> MiniMessagePlaceholderStrategy.LITERAL
         else ->
             throw IllegalArgumentException(

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageResolverBuilder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageResolverBuilder.kt
@@ -37,5 +37,15 @@ internal class MiniMessageResolverBuilder : MiniMessageResolverScope {
         component(name, component(init))
     }
 
+    override fun <T : Any> resolve(
+        placeholder: MiniMessagePlaceholder<T>,
+        value: T,
+    ) {
+        when (placeholder.strategy) {
+            MiniMessagePlaceholderStrategy.COMPONENT -> component(placeholder.name, value as ComponentLike)
+            MiniMessagePlaceholderStrategy.LITERAL -> unparsed(placeholder.name, value.toString())
+        }
+    }
+
     internal fun build(): TagResolver = TagResolver.resolver(resolvers)
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageResolverBuilder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageResolverBuilder.kt
@@ -42,7 +42,15 @@ internal class MiniMessageResolverBuilder : MiniMessageResolverScope {
         value: T,
     ) {
         when (placeholder.strategy) {
-            MiniMessagePlaceholderStrategy.COMPONENT -> component(placeholder.name, value as ComponentLike)
+            MiniMessagePlaceholderStrategy.COMPONENT -> {
+                val componentValue =
+                    value as? ComponentLike
+                        ?: throw IllegalArgumentException(
+                            "Placeholder '${placeholder.name}' expects a ComponentLike value.",
+                        )
+
+                component(placeholder.name, componentValue)
+            }
             MiniMessagePlaceholderStrategy.LITERAL -> unparsed(placeholder.name, value.toString())
         }
     }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageResolverScope.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageResolverScope.kt
@@ -40,4 +40,15 @@ public interface MiniMessageResolverScope {
         name: String,
         init: ComponentScope.() -> Unit,
     ): Unit
+
+    /**
+     * Resolves [placeholder] to [value] using the placeholder's typed binding strategy.
+     *
+     * [String], [Number], and [Boolean] values are inserted as literal text. [ComponentLike] values are inserted as
+     * component placeholders.
+     */
+    public fun <T : Any> resolve(
+        placeholder: MiniMessagePlaceholder<T>,
+        value: T,
+    ): Unit
 }

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
@@ -12,6 +12,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
@@ -192,6 +193,23 @@ class MiniMessageDslTest :
 
                 first shouldBe second
                 setOf(first, second) shouldHaveSize 1
+            }
+
+            "distinguishes typed placeholders with different value types" {
+                val count = placeholder<Int>("count")
+                val label = placeholder<String>("count")
+
+                count shouldNotBe label
+                setOf(count, label) shouldHaveSize 2
+            }
+
+            "rejects invalid placeholder names" {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        placeholder<String>("BadName")
+                    }
+
+                error.message shouldContain "placeholder names must match"
             }
 
             "does not compile when a typed placeholder is resolved with the wrong value type" {

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
@@ -1,5 +1,7 @@
 package io.github.lmliam.kotventure.minimessage
 
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
 import io.github.lmliam.kotventure.core.text.component
 import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldContainText
@@ -8,8 +10,10 @@ import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldNotHaveColor
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
 class MiniMessageDslTest :
     StringSpec(
@@ -89,5 +93,151 @@ class MiniMessageDslTest :
                 message.childAt(1).childAt(1) shouldContainText " joined"
                 message.childAt(1).childAt(1).shouldNotHaveColor()
             }
+
+            "resolves component typed placeholders" {
+                val badge = placeholder<Component>("badge")
+                val parsed =
+                    mini("<badge> joined") {
+                        resolve(badge, Component.text("VIP", NamedTextColor.AQUA))
+                    }
+
+                parsed shouldHaveChildCount 2
+                parsed.childAt(0) shouldContainText "VIP"
+                parsed.childAt(0) shouldHaveColor NamedTextColor.AQUA
+                parsed.childAt(1) shouldContainText " joined"
+            }
+
+            "resolves string typed placeholders as literal text" {
+                val name = placeholder<String>("name")
+                val parsed =
+                    mini("<name>") {
+                        resolve(name, "<red>Alex")
+                    }
+
+                parsed shouldContainText "<red>Alex"
+                parsed.shouldNotHaveColor()
+            }
+
+            "resolves numeric and boolean typed placeholders as literal text" {
+                val count = placeholder<Int>("count")
+                val ratio = placeholder<Double>("ratio")
+                val online = placeholder<Boolean>("online")
+                val parsed =
+                    mini("<count> / <ratio> / <online>") {
+                        resolve(count, 3)
+                        resolve(ratio, 1.5)
+                        resolve(online, true)
+                    }
+
+                parsed shouldContainText "3 / 1.5 / true"
+            }
+
+            "resolves mixed typed placeholders in one message" {
+                val channel = placeholder<String>("channel")
+                val player = placeholder<Component>("player")
+                val count = placeholder<Long>("count")
+                val playerComponent = Component.text("Alex", NamedTextColor.AQUA)
+                val parsed =
+                    mini("<gray>[<channel>]</gray> <gold><player></gold> has <count> invites") {
+                        resolve(channel, "chat")
+                        resolve(player, playerComponent)
+                        resolve(count, 2L)
+                    }
+
+                parsed shouldContainText "[chat] Alex has 2 invites"
+                parsed.children().contains(playerComponent) shouldBe true
+            }
+
+            "supports typed placeholders inside the component DSL" {
+                val player = placeholder<String>("player")
+                val message =
+                    component {
+                        text("Notice: ")
+                        mini("<gold><player></gold> joined") {
+                            resolve(player, "Alex")
+                        }
+                    }
+
+                message shouldHaveChildCount 2
+                message.childAt(1) shouldContainText "Alex joined"
+                message.childAt(1).childAt(0) shouldHaveColor NamedTextColor.GOLD
+            }
+
+            "keeps parsed string bridge available for markup-aware substitutions" {
+                val parsed =
+                    mini("<prefix> <name>") {
+                        parsed("prefix", "<gray>[chat]</gray>")
+                        resolve(placeholder<String>("name"), "Alex")
+                    }
+
+                parsed shouldContainText "[chat] Alex"
+                parsed.childAt(0) shouldHaveColor NamedTextColor.GRAY
+            }
+
+            "rejects unsupported placeholder value families" {
+                val error =
+                    runCatching {
+                        placeholder<List<String>>("items")
+                    }.exceptionOrNull()
+
+                error?.message shouldContain "Supported MiniMessage placeholder types"
+            }
+
+            "does not compile when a typed placeholder is resolved with the wrong value type" {
+                assertDoesNotCompile(
+                    fileName = "TypedPlaceholderMismatchTest.kt",
+                    source =
+                        """
+                        import io.github.lmliam.kotventure.minimessage.mini
+                        import io.github.lmliam.kotventure.minimessage.placeholder
+
+                        fun shouldNotCompile() {
+                            val count = placeholder<Int>("count")
+
+                            mini("<count>") {
+                                resolve(count, "three")
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedMessage = "Argument type mismatch",
+                )
+
+                assertDoesNotCompile(
+                    fileName = "ComponentPlaceholderMismatchTest.kt",
+                    source =
+                        """
+                        import io.github.lmliam.kotventure.minimessage.mini
+                        import io.github.lmliam.kotventure.minimessage.placeholder
+                        import net.kyori.adventure.text.Component
+
+                        fun shouldNotCompile() {
+                            val player = placeholder<Component>("player")
+
+                            mini("<player>") {
+                                resolve(player, 3)
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedMessage = "Argument type mismatch",
+                )
+            }
         },
     )
+
+@OptIn(ExperimentalCompilerApi::class)
+private fun assertDoesNotCompile(
+    fileName: String,
+    source: String,
+    expectedMessage: String,
+) {
+    val compilation =
+        KotlinCompilation().apply {
+            inheritClassPath = true
+            sources = listOf(SourceFile.kotlin(fileName, source))
+        }
+
+    val result = compilation.compile()
+
+    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+    result.messages shouldContain expectedMessage
+}

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
@@ -8,6 +8,7 @@ import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldNotHaveColor
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -146,7 +147,7 @@ class MiniMessageDslTest :
                     }
 
                 parsed shouldContainText "[chat] Alex has 2 invites"
-                parsed.children().contains(playerComponent) shouldBe true
+                parsed.containsComponent(playerComponent) shouldBe true
             }
 
             "supports typed placeholders inside the component DSL" {
@@ -177,11 +178,11 @@ class MiniMessageDslTest :
 
             "rejects unsupported placeholder value families" {
                 val error =
-                    runCatching {
+                    shouldThrow<IllegalArgumentException> {
                         placeholder<List<String>>("items")
-                    }.exceptionOrNull()
+                    }
 
-                error?.message shouldContain "Supported MiniMessage placeholder types"
+                error.message shouldContain "Supported MiniMessage placeholder types"
             }
 
             "treats equivalent typed placeholders as equal values" {
@@ -250,3 +251,6 @@ private fun assertDoesNotCompile(
     result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
     result.messages shouldContain expectedMessage
 }
+
+private fun Component.containsComponent(expected: Component): Boolean =
+    this == expected || children().any { child -> child.containsComponent(expected) }

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
@@ -1,9 +1,9 @@
 package io.github.lmliam.kotventure.minimessage
 
-import com.tschuchort.compiletesting.KotlinCompilation
-import com.tschuchort.compiletesting.SourceFile
 import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
 import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainComponent
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
@@ -16,7 +16,6 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
-import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
 class MiniMessageDslTest :
     StringSpec(
@@ -149,7 +148,7 @@ class MiniMessageDslTest :
                     }
 
                 parsed shouldContainText "[chat] Alex has 2 invites"
-                parsed.containsComponent(playerComponent) shouldBe true
+                parsed shouldContainComponent playerComponent
             }
 
             "supports typed placeholders inside the component DSL" {
@@ -256,26 +255,3 @@ class MiniMessageDslTest :
             }
         },
     )
-
-@OptIn(ExperimentalCompilerApi::class)
-private fun assertDoesNotCompile(
-    fileName: String,
-    source: String,
-    vararg expectedMessages: String,
-) {
-    val compilation =
-        KotlinCompilation().apply {
-            inheritClassPath = true
-            sources = listOf(SourceFile.kotlin(fileName, source))
-        }
-
-    val result = compilation.compile()
-
-    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-    expectedMessages.forEach { expectedMessage ->
-        result.messages shouldContain expectedMessage
-    }
-}
-
-private fun Component.containsComponent(expected: Component): Boolean =
-    this == expected || children().any { child -> child.containsComponent(expected) }

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
@@ -9,6 +9,7 @@ import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldNotHaveColor
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import net.kyori.adventure.text.Component
@@ -181,6 +182,14 @@ class MiniMessageDslTest :
                     }.exceptionOrNull()
 
                 error?.message shouldContain "Supported MiniMessage placeholder types"
+            }
+
+            "treats equivalent typed placeholders as equal values" {
+                val first = placeholder<String>("name")
+                val second = placeholder<String>("name")
+
+                first shouldBe second
+                setOf(first, second) shouldHaveSize 1
             }
 
             "does not compile when a typed placeholder is resolved with the wrong value type" {

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDslTest.kt
@@ -107,6 +107,7 @@ class MiniMessageDslTest :
                 parsed.childAt(0) shouldContainText "VIP"
                 parsed.childAt(0) shouldHaveColor NamedTextColor.AQUA
                 parsed.childAt(1) shouldContainText " joined"
+                parsed.childAt(1).shouldNotHaveColor()
             }
 
             "resolves string typed placeholders as literal text" {
@@ -209,7 +210,9 @@ class MiniMessageDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedMessage = "Argument type mismatch",
+                    "Argument type mismatch",
+                    "String",
+                    "Int",
                 )
 
                 assertDoesNotCompile(
@@ -228,7 +231,9 @@ class MiniMessageDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedMessage = "Argument type mismatch",
+                    "Argument type mismatch",
+                    "Int",
+                    "Component",
                 )
             }
         },
@@ -238,7 +243,7 @@ class MiniMessageDslTest :
 private fun assertDoesNotCompile(
     fileName: String,
     source: String,
-    expectedMessage: String,
+    vararg expectedMessages: String,
 ) {
     val compilation =
         KotlinCompilation().apply {
@@ -249,7 +254,9 @@ private fun assertDoesNotCompile(
     val result = compilation.compile()
 
     result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-    result.messages shouldContain expectedMessage
+    expectedMessages.forEach { expectedMessage ->
+        result.messages shouldContain expectedMessage
+    }
 }
 
 private fun Component.containsComponent(expected: Component): Boolean =

--- a/modules/test/build.gradle
+++ b/modules/test/build.gradle
@@ -6,4 +6,5 @@ description = 'Kotest matchers and testing utilities for Kotventure components.'
 dependencies {
     api project(':core')
     api kotventureDependencies."kotest-assertions-core"
+    implementation kotventureDependencies."kctfork-core"
 }

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/compilation/Assertions.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/compilation/Assertions.kt
@@ -1,0 +1,31 @@
+package io.github.lmliam.kotventure.test.compilation
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+/**
+ * Asserts that [source] fails to compile, optionally verifying that each of the [expectedMessages] appears in the
+ * compiler output.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+public fun assertDoesNotCompile(
+    fileName: String,
+    source: String,
+    vararg expectedMessages: String,
+) {
+    val compilation =
+        KotlinCompilation().apply {
+            inheritClassPath = true
+            sources = listOf(SourceFile.kotlin(fileName, source))
+        }
+
+    val result = compilation.compile()
+
+    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+    expectedMessages.forEach { expectedMessage ->
+        result.messages shouldContain expectedMessage
+    }
+}

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -163,6 +163,26 @@ public infix fun Component.shouldHaveChildCount(expected: Int): Component =
     }
 
 /**
+ * Asserts that this component's tree contains [expected] (by structural equality).
+ */
+public infix fun Component.shouldContainComponent(expected: Component): Component =
+    apply {
+        this should containComponent(expected)
+    }
+
+private fun containComponent(expected: Component): Matcher<Component> =
+    Matcher { actual ->
+        MatcherResult(
+            actual.containsComponent(expected),
+            { "Expected component tree to contain $expected" },
+            { "Expected component tree not to contain $expected" },
+        )
+    }
+
+private fun Component.containsComponent(expected: Component): Boolean =
+    this == expected || children().any { it.containsComponent(expected) }
+
+/**
  * Asserts that this component is translatable and has [expected] as its translation key.
  */
 public infix fun Component.shouldHaveTranslationKey(expected: String): Component =


### PR DESCRIPTION
## Summary

Adds typed MiniMessage placeholders with `placeholder<T>(name)` descriptors and `resolve(...)` bindings for component, string, numeric, and boolean values.

## Related Issues

Closes #26

## DSL Impact

Kotlin callers can declare typed placeholders once and bind only matching values inside `mini(...)` resolver scopes. Strings, numbers, and booleans bind as literal text by default; `parsed(...)` remains the explicit bridge for markup-bearing strings.

## Rationale

MiniMessage placeholder names often come from markup/config strings, so a typed descriptor keeps the dynamic placeholder name while moving wrong value bindings to compile-time type errors where Kotlin can enforce them.

## Testing

- `./gradlew build`
- Added MiniMessage DSL tests for component, string, numeric, boolean, mixed, and nested component-scope typed placeholders.
- Added compile-fail tests for wrong typed placeholder/value pairings.

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run
