### PR TITLE
feat(minimessage): add typed reusable message templates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,6 +45,7 @@ ktlint_standard_indent = disabled
 ktlint_standard_no-wildcard-imports = enabled
 ktlint_standard_filename = enabled
 ktlint_standard_string-template-indent = disabled
+ktlint_standard_context-receiver-list-wrapping = disabled
 ij_kotlin_align_in_columns_case_branch = false
 ij_kotlin_align_multiline_binary_operation = false
 ij_kotlin_align_multiline_extends_list = false

--- a/README.md
+++ b/README.md
@@ -280,29 +280,35 @@ val nested = component {
 ```
 
 For messages that are rendered many times with different values, declare a typed template once and reuse it. Each
-placeholder is a compile-checked `val` whose name drives the MiniMessage tag; value types are enforced at the call site;
-and missing bindings fail with a helpful message listing what was omitted:
+placeholder is a compile-checked `val`; the string argument passed to `placeholder(...)` defines the MiniMessage tag,
+the `val` gives scoped typed access for `bind(placeholder, value)`, and missing bindings fail with a helpful message
+listing what was omitted:
 
 ```kotlin
+import io.github.lmliam.kotventure.minimessage.MiniTemplate
+import io.github.lmliam.kotventure.minimessage.bind
+import io.github.lmliam.kotventure.minimessage.invoke
+import net.kyori.adventure.text.Component
+
 object WelcomeTemplate : MiniTemplate("<gold>Welcome <player>, <count> new messages") {
     val player = placeholder<Component>("player")
     val count = placeholder<Int>("count")
 }
 
 val forAlex = WelcomeTemplate {
-    bind(WelcomeTemplate.player, Component.text("Alex"))
-    bind(WelcomeTemplate.count, 3)
+    bind(player, Component.text("Alex"))
+    bind(count, 3)
 }
 val forSam = WelcomeTemplate {
-    bind(WelcomeTemplate.player, Component.text("Sam"))
-    bind(WelcomeTemplate.count, 0)
+    bind(player, Component.text("Sam"))
+    bind(count, 0)
 }
 
 // Compile error — wrong value type:
-//   WelcomeTemplate { bind(WelcomeTemplate.count, "three") }   // String is not Int
+//   WelcomeTemplate { bind(count, "three") }   // String is not Int
 
 // Use-time error — forgot a placeholder:
-//   WelcomeTemplate { bind(WelcomeTemplate.player, Component.text("Alex")) }
+//   WelcomeTemplate { bind(player, Component.text("Alex")) }
 //   → IllegalArgumentException: Template is missing required placeholder(s): [count].
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ The current build enables the first lazy modules:
 
 - `kotventure-core` — the plain component builder and explicit startup registry
 - `kotventure-minimessage` — `mini(...)` parsing plus typed placeholders via `placeholder<T>(name)` and
-  `resolve(placeholder, value)`, alongside the `parsed`, `unparsed`, and `component` resolvers
+  `resolve(placeholder, value)`, alongside the `parsed`, `unparsed`, and `component` resolvers; typed reusable
+  templates via `MiniTemplate` with compile-checked `bind(placeholder, value)` at the call site
 - `kotventure-serializer` — `Component.toMiniMessage()` and `Component.toPlainText()` wrappers around Adventure
   serializers
 - `kotventure-test` — Kotest component matchers consumed test-scoped by library modules
@@ -276,6 +277,33 @@ val nested = component {
         resolve(player, alex)
     }
 }
+```
+
+For messages that are rendered many times with different values, declare a typed template once and reuse it. Each
+placeholder is a compile-checked `val` whose name drives the MiniMessage tag; value types are enforced at the call site;
+and missing bindings fail with a helpful message listing what was omitted:
+
+```kotlin
+object WelcomeTemplate : MiniTemplate("<gold>Welcome <player>, <count> new messages") {
+    val player = placeholder<Component>("player")
+    val count = placeholder<Int>("count")
+}
+
+val forAlex = WelcomeTemplate {
+    bind(player, Component.text("Alex"))
+    bind(count, 3)
+}
+val forSam = WelcomeTemplate {
+    bind(player, Component.text("Sam"))
+    bind(count, 0)
+}
+
+// Compile error — wrong value type:
+//   WelcomeTemplate { bind(count, "three") }   // String is not Int
+
+// Use-time error — forgot a placeholder:
+//   WelcomeTemplate { bind(player, Component.text("Alex")) }
+//   → IllegalArgumentException: Template is missing required placeholder(s): [count].
 ```
 
 Join a list of components using `Iterable<Component>.join { }`, with optional separator, `lastSeparator`, `prefix`, and

--- a/README.md
+++ b/README.md
@@ -290,19 +290,19 @@ object WelcomeTemplate : MiniTemplate("<gold>Welcome <player>, <count> new messa
 }
 
 val forAlex = WelcomeTemplate {
-    bind(player, Component.text("Alex"))
-    bind(count, 3)
+    bind(WelcomeTemplate.player, Component.text("Alex"))
+    bind(WelcomeTemplate.count, 3)
 }
 val forSam = WelcomeTemplate {
-    bind(player, Component.text("Sam"))
-    bind(count, 0)
+    bind(WelcomeTemplate.player, Component.text("Sam"))
+    bind(WelcomeTemplate.count, 0)
 }
 
 // Compile error — wrong value type:
-//   WelcomeTemplate { bind(count, "three") }   // String is not Int
+//   WelcomeTemplate { bind(WelcomeTemplate.count, "three") }   // String is not Int
 
 // Use-time error — forgot a placeholder:
-//   WelcomeTemplate { bind(player, Component.text("Alex")) }
+//   WelcomeTemplate { bind(WelcomeTemplate.player, Component.text("Alex")) }
 //   → IllegalArgumentException: Template is missing required placeholder(s): [count].
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ kotest = "6.1.11"
 kotestPlugin = "6.1.11"
 kotlin = "2.4.0"
 spotless = "8.6.0"
-spotlessKtlint = "1.5.0"
+spotlessKtlint = "1.7.0"
 
 [libraries]
 adventure-api = { module = "net.kyori:adventure-api", version.ref = "adventureApi" }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
@@ -3,8 +3,8 @@ package io.github.lmliam.kotventure.minimessage
 import net.kyori.adventure.text.ComponentLike
 import kotlin.jvm.javaObjectType
 
-// Mirrors Adventure's TagPattern.TAG_NAME_REGEX so invalid names fail at declaration instead of first render.
-private val TAG_NAME_REGEX = Regex("[!?#]?[a-z0-9_-]*")
+// Reject invalid or blank names at declaration instead of first render.
+private val TAG_NAME_REGEX = Regex("[!?#]?[a-z0-9_-]+")
 
 /**
  * A typed MiniMessage placeholder descriptor.

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
@@ -1,0 +1,147 @@
+package io.github.lmliam.kotventure.minimessage
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.MiniMessage
+
+/**
+ * Base class for typed, reusable MiniMessage templates.
+ *
+ * Subclass as an `object` to declare a template with compile-checked typed placeholder properties:
+ *
+ * ```kotlin
+ * object WelcomeTemplate : MiniTemplate("<gold>Welcome <player>, <count> new messages") {
+ *     val player = placeholder<Component>("player")
+ *     val count = placeholder<Int>("count")
+ * }
+ *
+ * val forAlex = WelcomeTemplate {
+ *     bind(player, Component.text("Alex"))
+ *     bind(count, 3)
+ * }
+ * ```
+ *
+ * The [MiniMessage] instance and the template's declared-placeholder metadata and markup string are
+ * created once per template instance and reused on every render; each [invoke] call returns a fresh,
+ * independent [Component].
+ *
+ * @param markup the MiniMessage markup string this template renders; must not be blank.
+ * @throws IllegalArgumentException when [markup] is blank.
+ */
+public abstract class MiniTemplate(
+    private val markup: String,
+) {
+    init {
+        require(markup.isNotBlank()) { "MiniMessage template markup must not be blank." }
+    }
+
+    /**
+     * Ordered map of placeholder name to descriptor, populated at object-construction time by calls
+     * to [placeholder]. [LinkedHashMap] preserves declaration order so error messages list missing
+     * placeholder names in the order they were declared.
+     *
+     * `@PublishedApi internal` because the `inline reified` [placeholder] member is inlined into
+     * subclass call sites, which means it cannot touch a `private` field.
+     */
+    @PublishedApi
+    internal val placeholders: LinkedHashMap<String, MiniMessagePlaceholder<*>> = LinkedHashMap()
+
+    /** Cached MiniMessage instance, reused across every render of this template. */
+    private val miniMessage: MiniMessage = MiniMessage.miniMessage()
+
+    /**
+     * Declares a required placeholder on this template. Call at object-construction time:
+     * `val x = placeholder<T>("x")`.
+     *
+     * Returns the descriptor unchanged so it can be stored as a `val` and referenced at render time.
+     * `inline reified` so it can delegate to the public top-level [placeholder] factory from #26,
+     * forwarding the reified type without requiring a `Class` or `KClass` argument. The member is
+     * non-`open`, satisfying the Kotlin requirement that `inline` members are not virtual.
+     *
+     * @param T the value type that must be supplied when binding this placeholder; must belong to
+     *   one of the supported families: [net.kyori.adventure.text.ComponentLike], [String],
+     *   [Number], or [Boolean].
+     * @param name the MiniMessage tag name that this placeholder resolves in the markup.
+     * @return the registered [MiniMessagePlaceholder] descriptor.
+     * @throws IllegalArgumentException when [name] is already declared on this template, when [T]
+     *   is outside the supported value families, or when [name] is not a valid MiniMessage tag name.
+     */
+    protected inline fun <reified T : Any> placeholder(name: String): MiniMessagePlaceholder<T> =
+        // Fully-qualified call to the public top-level factory avoids the unqualified call resolving
+        // back to this member inside a subclass body (members win over top-level functions in scope).
+        register(
+            io.github.lmliam.kotventure.minimessage
+            .placeholder<T>(name),
+                )
+
+    /**
+     * Records [descriptor] in the declared-placeholder set, rejecting duplicate names. Non-inline
+     * so the mutation and duplicate check stay encapsulated behind a single call site in the inline
+     * [placeholder] hook.
+     *
+     * @param descriptor the placeholder to register.
+     * @return [descriptor] unchanged.
+     * @throws IllegalArgumentException when a placeholder with the same name is already declared.
+     */
+    @PublishedApi
+    internal fun <T : Any> register(descriptor: MiniMessagePlaceholder<T>): MiniMessagePlaceholder<T> {
+        require(placeholders.put(descriptor.name, descriptor) == null) {
+            "Duplicate placeholder '${descriptor.name}' in template."
+        }
+        return descriptor
+    }
+
+    /**
+     * Renders this template by binding every required placeholder via [bind], then deserializing the
+     * markup with the built [net.kyori.adventure.text.minimessage.tag.resolver.TagResolver].
+     *
+     * Validates that every declared placeholder was bound before rendering; throws
+     * [IllegalArgumentException] listing the missing name(s). Also rejects binding a placeholder not
+     * declared on this template.
+     *
+     * Double-binding the same placeholder within one call follows first-wins semantics — the natural
+     * default of [net.kyori.adventure.text.minimessage.tag.resolver.TagResolver.resolver].
+     *
+     * @param bind lambda that receives a [MiniTemplateBindingScope] to supply placeholder values.
+     * @return a fresh [Component] for this render call; independent of all prior and future renders.
+     * @throws IllegalArgumentException when any declared placeholder is not bound, or when [bind]
+     *   attempts to bind a placeholder not declared on this template.
+     */
+    public operator fun invoke(bind: MiniTemplateBindingScope.() -> Unit): Component {
+        val builder = MiniMessageResolverBuilder()
+        val boundNames = mutableSetOf<String>()
+
+        val scope =
+            object : MiniTemplateBindingScope {
+            override fun <T : Any> bind(
+                placeholder: MiniMessagePlaceholder<T>,
+                value: T,
+            ) {
+                require(placeholders.containsKey(placeholder.name)) {
+                    "Placeholder '${placeholder.name}' is not declared on this template. " +
+                        "Declared placeholders: ${placeholders.keys}."
+                }
+                // Record first-bind only; double-bind is first-wins via TagResolver.resolver(list).
+                if (boundNames.add(placeholder.name)) {
+                    builder.resolve(placeholder, value)
+                }
+            }
+        }
+
+        scope.bind()
+
+        val missing = placeholders.keys - boundNames
+        require(missing.isEmpty()) {
+            "Template is missing required placeholder(s): $missing."
+        }
+
+        return miniMessage.deserialize(markup, builder.build())
+    }
+
+    /**
+     * The names of every placeholder this template declares, in declaration order.
+     *
+     * Useful for introspection or for generating helpful error messages in higher-level utilities.
+     */
+    public val requiredPlaceholders: Set<String>
+        get() = placeholders.keys.toSet()
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
@@ -2,6 +2,8 @@ package io.github.lmliam.kotventure.minimessage
 
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+import io.github.lmliam.kotventure.minimessage.placeholder as createPlaceholder
 
 /**
  * Base class for typed, reusable MiniMessage templates.
@@ -9,14 +11,19 @@ import net.kyori.adventure.text.minimessage.MiniMessage
  * Subclass as an `object` to declare a template with compile-checked typed placeholder properties:
  *
  * ```kotlin
+ * import io.github.lmliam.kotventure.minimessage.MiniTemplate
+ * import io.github.lmliam.kotventure.minimessage.bind
+ * import io.github.lmliam.kotventure.minimessage.invoke
+ * import net.kyori.adventure.text.Component
+ *
  * object WelcomeTemplate : MiniTemplate("<gold>Welcome <player>, <count> new messages") {
  *     val player = placeholder<Component>("player")
  *     val count = placeholder<Int>("count")
  * }
  *
  * val forAlex = WelcomeTemplate {
- *     bind(WelcomeTemplate.player, Component.text("Alex"))
- *     bind(WelcomeTemplate.count, 3)
+ *     bind(player, Component.text("Alex"))
+ *     bind(count, 3)
  * }
  * ```
  *
@@ -53,25 +60,25 @@ public abstract class MiniTemplate(
      * `val x = placeholder<T>("x")`.
      *
      * Returns the descriptor unchanged so it can be stored as a `val` and referenced at render time.
-     * `inline reified` so it can delegate to the public top-level [placeholder] factory from #26,
+     * `inline reified` so it can delegate to the top-level [createPlaceholder] factory from #26,
      * forwarding the reified type without requiring a `Class` or `KClass` argument. The member is
      * non-`open`, satisfying the Kotlin requirement that `inline` members are not virtual.
      *
      * @param T the value type that must be supplied when binding this placeholder; must belong to
      *   one of the supported families: [net.kyori.adventure.text.ComponentLike], [String],
      *   [Number], or [Boolean].
-     * @param name the MiniMessage tag name that this placeholder resolves in the markup.
+     * @param name the string argument that defines both the MiniMessage tag resolved in the markup
+     *   and the name by which the descriptor is tracked; the returned `val` gives compile-checked
+     *   scoped access to the descriptor.
      * @return the registered [MiniMessagePlaceholder] descriptor.
      * @throws IllegalArgumentException when [name] is already declared on this template, when [T]
      *   is outside the supported value families, or when [name] is not a valid MiniMessage tag name.
      */
     protected inline fun <reified T : Any> placeholder(name: String): MiniMessagePlaceholder<T> =
-        // Fully-qualified call to the public top-level factory avoids the unqualified call resolving
-        // back to this member inside a subclass body (members win over top-level functions in scope).
-        register(
-            io.github.lmliam.kotventure.minimessage
-                .placeholder<T>(name),
-        )
+        // Import alias `createPlaceholder` refers to the public top-level factory; avoids the
+        // unqualified call resolving back to this member inside a subclass body (members win over
+        // top-level functions in scope).
+        register(createPlaceholder<T>(name))
 
     /**
      * Records [descriptor] in the declared-placeholder set, rejecting duplicate names. Non-inline
@@ -91,32 +98,73 @@ public abstract class MiniTemplate(
     }
 
     /**
-     * Renders this template by binding every required placeholder via [bind], then deserializing the
-     * markup with the built [net.kyori.adventure.text.minimessage.tag.resolver.TagResolver].
+     * Deserializes [markup] with [resolver] and returns a fresh [Component].
      *
-     * Validates that every declared placeholder was bound before rendering; throws
-     * [IllegalArgumentException] listing the missing name(s). Also rejects binding a placeholder not
-     * declared on this template.
-     *
-     * Double-binding the same placeholder within one call follows first-wins semantics — the natural
-     * default of [net.kyori.adventure.text.minimessage.tag.resolver.TagResolver.resolver].
-     *
-     * @param bind lambda that receives a [MiniTemplateBindingScope] to supply placeholder values.
-     * @return a fresh [Component] for this render call; independent of all prior and future renders.
-     * @throws IllegalArgumentException when any declared placeholder is not bound, or when [bind]
-     *   attempts to bind a placeholder not declared on this template.
+     * Called by the top-level [invoke] extension after validating all bindings. The method is
+     * `internal` rather than `private` so the extension function can reach it without reflection,
+     * while keeping the low-level deserialization detail out of the public surface.
      */
-    public operator fun invoke(bind: MiniTemplateBindingScope.() -> Unit): Component {
-        val builder = MiniMessageResolverBuilder()
-        val boundNames = mutableSetOf<String>()
+    internal fun deserialize(resolver: TagResolver): Component = miniMessage.deserialize(markup, resolver)
 
-        val scope =
-            object : MiniTemplateBindingScope {
-            override fun <T : Any> bind(
-                placeholder: MiniMessagePlaceholder<T>,
-                value: T,
+    /**
+     * The names of every placeholder this template declares, in declaration order.
+     *
+     * Useful for introspection or for generating helpful error messages in higher-level utilities.
+     */
+    public val requiredPlaceholders: Set<String>
+        get() = placeholders.keys.toSet()
+}
+
+/**
+ * Binds [value] to [placeholder] inside a [MiniTemplate] render lambda.
+ *
+ * The concrete template is the extension receiver, which keeps template placeholder properties in
+ * scope, while the context parameter supplies the per-render state used by
+ * [MiniTemplateBindingScope.bind].
+ *
+ * @param placeholder a descriptor declared on this template.
+ * @param value the value to substitute for [placeholder].
+ */
+context(_: MiniTemplateBindingScope) public fun <T : Any> MiniTemplate.bind(
+    placeholder: MiniMessagePlaceholder<T>,
+    value: T,
+): Unit = contextOf<MiniTemplateBindingScope>().bind(placeholder, value)
+
+/**
+ * Renders this template by binding every required placeholder via [bind], then deserializing the
+ * markup with the built [TagResolver].
+ *
+ * The render lambda uses the concrete template as its receiver and carries a
+ * [MiniTemplateBindingScope] context parameter, so placeholder descriptors declared on the template
+ * (e.g. `player`, `count`) are accessible unqualified while [bind] is available in the same block.
+ *
+ * Per-render state (the resolver builder and bound-name set) is created fresh on each call and
+ * never touches the shared template object, preserving thread-safety and declare-once semantics.
+ *
+ * Validates that every declared placeholder was bound before rendering; throws
+ * [IllegalArgumentException] listing the missing name(s). Also rejects binding a placeholder not
+ * declared on this template, or a descriptor from a different template that happens to share a name.
+ *
+ * Double-binding the same placeholder within one call follows first-wins semantics — the natural
+ * default of [TagResolver.resolver].
+ *
+ * @param block lambda that receives the template [T] as receiver and a [MiniTemplateBindingScope]
+ *   as context.
+ * @return a fresh [Component] for this render call; independent of all prior and future renders.
+ * @throws IllegalArgumentException when any declared placeholder is not bound, or when [block]
+ *   attempts to bind a placeholder not declared on this template (checked by descriptor identity).
+ */
+public operator fun <T : MiniTemplate> T.invoke(block: context(MiniTemplateBindingScope) T.() -> Unit): Component {
+    val builder = MiniMessageResolverBuilder()
+    val boundNames = mutableSetOf<String>()
+
+    val scope =
+        object : MiniTemplateBindingScope {
+            override fun <V : Any> bind(
+                placeholder: MiniMessagePlaceholder<V>,
+                value: V,
             ) {
-                require(placeholders.containsKey(placeholder.name)) {
+                require(placeholders[placeholder.name] === placeholder) {
                     "Placeholder '${placeholder.name}' is not declared on this template. " +
                         "Declared placeholders: ${placeholders.keys}."
                 }
@@ -127,21 +175,12 @@ public abstract class MiniTemplate(
             }
         }
 
-        scope.bind()
+    context(scope) { block() }
 
-        val missing = placeholders.keys - boundNames
-        require(missing.isEmpty()) {
-            "Template is missing required placeholder(s): $missing."
-        }
-
-        return miniMessage.deserialize(markup, builder.build())
+    val missing = placeholders.keys - boundNames
+    require(missing.isEmpty()) {
+        "Template is missing required placeholder(s): $missing."
     }
 
-    /**
-     * The names of every placeholder this template declares, in declaration order.
-     *
-     * Useful for introspection or for generating helpful error messages in higher-level utilities.
-     */
-    public val requiredPlaceholders: Set<String>
-        get() = placeholders.keys.toSet()
+    return deserialize(builder.build())
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
@@ -75,9 +75,7 @@ public abstract class MiniTemplate(
      *   is outside the supported value families, or when [name] is not a valid MiniMessage tag name.
      */
     protected inline fun <reified T : Any> placeholder(name: String): MiniMessagePlaceholder<T> =
-        // Import alias `createPlaceholder` refers to the public top-level factory; avoids the
-        // unqualified call resolving back to this member inside a subclass body (members win over
-        // top-level functions in scope).
+        // Delegates to the top-level factory via import alias to avoid shadowing.
         register(createPlaceholder<T>(name))
 
     /**

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
@@ -109,7 +109,7 @@ public abstract class MiniTemplate(
      *
      * Useful for introspection or for generating helpful error messages in higher-level utilities.
      */
-    public val requiredPlaceholders: Set<String>
+    public val declaredPlaceholders: Set<String>
         get() = placeholders.keys.toSet()
 }
 
@@ -129,7 +129,7 @@ context(_: MiniTemplateBindingScope) public fun <T : Any> MiniTemplate.bind(
 ): Unit = contextOf<MiniTemplateBindingScope>().bind(placeholder, value)
 
 /**
- * Renders this template by binding every required placeholder via [bind], then deserializing the
+ * Renders this template by binding every declared placeholder via [bind], then deserializing the
  * markup with the built [TagResolver].
  *
  * The render lambda uses the concrete template as its receiver and carries a
@@ -143,14 +143,12 @@ context(_: MiniTemplateBindingScope) public fun <T : Any> MiniTemplate.bind(
  * [IllegalArgumentException] listing the missing name(s). Also rejects binding a placeholder not
  * declared on this template, or a descriptor from a different template that happens to share a name.
  *
- * Double-binding the same placeholder within one call follows first-wins semantics — the natural
- * default of [TagResolver.resolver].
- *
  * @param block lambda that receives the template [T] as receiver and a [MiniTemplateBindingScope]
  *   as context.
  * @return a fresh [Component] for this render call; independent of all prior and future renders.
  * @throws IllegalArgumentException when any declared placeholder is not bound, or when [block]
- *   attempts to bind a placeholder not declared on this template (checked by descriptor identity).
+ *   attempts to bind a placeholder not declared on this template (checked by descriptor identity),
+ *   or when the same placeholder is bound more than once in a single render.
  */
 public operator fun <T : MiniTemplate> T.invoke(block: context(MiniTemplateBindingScope) T.() -> Unit): Component {
     val builder = MiniMessageResolverBuilder()
@@ -166,10 +164,10 @@ public operator fun <T : MiniTemplate> T.invoke(block: context(MiniTemplateBindi
                     "Placeholder '${placeholder.name}' is not declared on this template. " +
                         "Declared placeholders: ${placeholders.keys}."
                 }
-                // Record first-bind only; double-bind is first-wins via TagResolver.resolver(list).
-                if (boundNames.add(placeholder.name)) {
-                    builder.resolve(placeholder, value)
+                require(boundNames.add(placeholder.name)) {
+                    "Placeholder '${placeholder.name}' is already bound in this template render."
                 }
+                builder.resolve(placeholder, value)
             }
         }
 

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
@@ -15,8 +15,8 @@ import net.kyori.adventure.text.minimessage.MiniMessage
  * }
  *
  * val forAlex = WelcomeTemplate {
- *     bind(player, Component.text("Alex"))
- *     bind(count, 3)
+ *     bind(WelcomeTemplate.player, Component.text("Alex"))
+ *     bind(WelcomeTemplate.count, 3)
  * }
  * ```
  *
@@ -70,8 +70,8 @@ public abstract class MiniTemplate(
         // back to this member inside a subclass body (members win over top-level functions in scope).
         register(
             io.github.lmliam.kotventure.minimessage
-            .placeholder<T>(name),
-                )
+                .placeholder<T>(name),
+        )
 
     /**
      * Records [descriptor] in the declared-placeholder set, rejecting duplicate names. Non-inline

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateBindingScope.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateBindingScope.kt
@@ -1,0 +1,27 @@
+package io.github.lmliam.kotventure.minimessage
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+
+/**
+ * Receiver for the [MiniTemplate.invoke] lambda that binds values to declared placeholders.
+ *
+ * Each call to [bind] records the typed value for one placeholder; the value type is enforced at
+ * compile time by the generic constraint on [MiniMessagePlaceholder]. After the lambda completes,
+ * [MiniTemplate.invoke] validates that every required placeholder was bound before rendering.
+ */
+@KotventureDslMarker
+public interface MiniTemplateBindingScope {
+    /**
+     * Binds [value] to [placeholder].
+     *
+     * The value type is compile-checked against the placeholder's declared type parameter, inheriting
+     * the typing guarantee from [MiniMessageResolverScope.resolve].
+     *
+     * @param placeholder a descriptor declared on the owning template.
+     * @param value the value to substitute for this placeholder's tag in the markup.
+     */
+    public fun <T : Any> bind(
+        placeholder: MiniMessagePlaceholder<T>,
+        value: T,
+    )
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateBindingScope.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateBindingScope.kt
@@ -7,7 +7,7 @@ import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
  *
  * Each call to [bind] records the typed value for one placeholder; the value type is enforced at
  * compile time by the generic constraint on [MiniMessagePlaceholder]. After the lambda completes,
- * [MiniTemplate.invoke] validates that every required placeholder was bound before rendering.
+ * [MiniTemplate.invoke] validates that every declared placeholder was bound before rendering.
  */
 @KotventureDslMarker
 public interface MiniTemplateBindingScope {
@@ -15,7 +15,8 @@ public interface MiniTemplateBindingScope {
      * Binds [value] to [placeholder].
      *
      * The value type is compile-checked against the placeholder's declared type parameter, inheriting
-     * the typing guarantee from [MiniMessageResolverScope.resolve].
+     * the typing guarantee from [MiniMessageResolverScope.resolve]. A placeholder may be bound at
+     * most once per render.
      *
      * @param placeholder a descriptor declared on the owning template.
      * @param value the value to substitute for this placeholder's tag in the markup.

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateTest.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.kotventure.minimessage
 
 import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
+import io.github.lmliam.kotventure.test.text.shouldContainComponent
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldNotContainText
@@ -28,6 +29,16 @@ private object SparseTemplate : MiniTemplate("<gold>Hello <name>") {
     val unused = placeholder<Int>("unused")
 }
 
+// Cross-template fixture: declares a "player" placeholder of a DIFFERENT type than WelcomeTemplate.
+private object AltTemplate : MiniTemplate("<red>Alt <player>") {
+    val player = placeholder<String>("player")
+}
+
+// Cross-template fixture: declares a structurally equal "player" descriptor to WelcomeTemplate.
+private object SameTypeAltTemplate : MiniTemplate("<red>Alt <player>") {
+    val player = placeholder<Component>("player")
+}
+
 class MiniTemplateTest :
     StringSpec(
         {
@@ -39,7 +50,7 @@ class MiniTemplateTest :
                 val error =
                     shouldThrow<IllegalArgumentException> {
                         WelcomeTemplate {
-                            bind(WelcomeTemplate.player, Component.text("Alex"))
+                            bind(player, Component.text("Alex"))
                             // count intentionally omitted
                         }
                     }
@@ -63,8 +74,8 @@ class MiniTemplateTest :
                 val error =
                     shouldThrow<IllegalArgumentException> {
                         WelcomeTemplate {
-                            bind(WelcomeTemplate.player, Component.text("Alex"))
-                            bind(WelcomeTemplate.count, 1)
+                            bind(player, Component.text("Alex"))
+                            bind(count, 1)
                             @Suppress("UNCHECKED_CAST")
                             bind(outsider as MiniMessagePlaceholder<Component>, Component.text("x"))
                         }
@@ -74,20 +85,55 @@ class MiniTemplateTest :
             }
 
             // ---------------------------------------------------------------
+            // Priority 2 — Descriptor identity: same name, different template
+            // ---------------------------------------------------------------
+
+            "throws IllegalArgumentException when binding another template's same-named descriptor" {
+                // WelcomeTemplate.player is placeholder<Component>("player")
+                // AltTemplate.player     is placeholder<String>("player")
+                // Binding AltTemplate.player inside WelcomeTemplate must be rejected by identity,
+                // even though the names match, because they are different descriptor objects.
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        WelcomeTemplate {
+                            @Suppress("UNCHECKED_CAST")
+                            bind(AltTemplate.player as MiniMessagePlaceholder<Component>, Component.text("Alex"))
+                            bind(count, 1)
+                        }
+                    }
+
+                error.message shouldContain "player"
+                error.message shouldContain "not declared on this template"
+            }
+
+            "throws IllegalArgumentException when binding another template's structurally equal descriptor" {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        WelcomeTemplate {
+                            bind(SameTypeAltTemplate.player, Component.text("Alex"))
+                            bind(count, 1)
+                        }
+                    }
+
+                error.message shouldContain "player"
+                error.message shouldContain "not declared on this template"
+            }
+
+            // ---------------------------------------------------------------
             // AC2 — Reuse correctness: two independent, correct components
             // ---------------------------------------------------------------
 
             "renders correct component for each of two independent invocations" {
                 val forAlex =
                     WelcomeTemplate {
-                        bind(WelcomeTemplate.player, Component.text("Alex", NamedTextColor.GREEN))
-                        bind(WelcomeTemplate.count, 3)
+                        bind(player, Component.text("Alex", NamedTextColor.GREEN))
+                        bind(count, 3)
                     }
 
                 val forSam =
                     WelcomeTemplate {
-                        bind(WelcomeTemplate.player, Component.text("Sam", NamedTextColor.RED))
-                        bind(WelcomeTemplate.count, 0)
+                        bind(player, Component.text("Sam", NamedTextColor.RED))
+                        bind(count, 0)
                     }
 
                 // Gold color is applied to the root component by the <gold> tag.
@@ -109,18 +155,14 @@ class MiniTemplateTest :
 
                 val rendered =
                     WelcomeTemplate {
-                        bind(WelcomeTemplate.player, alex)
-                        bind(WelcomeTemplate.count, 5)
+                        bind(player, alex)
+                        bind(count, 5)
                     }
 
-                // The bound component appears as a direct child within the rendered tree.
+                // The bound component appears as a node in the rendered tree (structural equality).
                 rendered shouldContainText "Alex"
                 rendered shouldHaveColor NamedTextColor.GOLD
-
-                // Locate the child that IS the bound component and verify its color.
-                val childrenFlat = buildList { collectChildren(rendered, this) }
-                val alexChild = childrenFlat.firstOrNull { it == alex }
-                alexChild shouldBe alex
+                rendered shouldContainComponent alex
             }
 
             // ---------------------------------------------------------------
@@ -129,8 +171,6 @@ class MiniTemplateTest :
 
             "does not compile when an Int placeholder is bound with a String value" {
                 // Test the type safety of MiniTemplateBindingScope.bind via the public interface.
-                // Using placeholder<T>() top-level (matching the existing compile-fail test pattern)
-                // to avoid calling the protected inline member inside a subclass body in the snippet.
                 assertDoesNotCompile(
                     fileName = "TemplateIntStringMismatch.kt",
                     source =
@@ -166,6 +206,33 @@ class MiniTemplateTest :
                     "Argument type mismatch",
                     "Int",
                     "Component",
+                )
+            }
+
+            // ---------------------------------------------------------------
+            // AC3 — Scope safety: placeholder() is NOT callable inside the render lambda
+            // ---------------------------------------------------------------
+
+            "does not compile when placeholder() is called inside the render lambda" {
+                // The protected placeholder() member must be inaccessible at the render site.
+                // User code in the render lambda is NOT inside a subclass body, so `protected`
+                // blocks the call even though the template type is a context receiver.
+                assertDoesNotCompile(
+                    fileName = "TemplatePlaceholderAtRenderSite.kt",
+                    source =
+                        """
+                        import io.github.lmliam.kotventure.minimessage.MiniTemplate
+                        import io.github.lmliam.kotventure.minimessage.invoke
+
+                        private object ScopeTestTemplate : MiniTemplate("<gold><name>") { }
+
+                        fun test() {
+                            ScopeTestTemplate {
+                                placeholder<Int>("x")
+                            }
+                        }
+                        """.trimIndent(),
+                    "Cannot access",
                 )
             }
 
@@ -208,10 +275,10 @@ class MiniTemplateTest :
             "uses the first bound value when the same placeholder is bound twice" {
                 val firstWins =
                     WelcomeTemplate {
-                        bind(WelcomeTemplate.player, Component.text("First", NamedTextColor.GREEN))
-                        bind(WelcomeTemplate.count, 1)
+                        bind(player, Component.text("First", NamedTextColor.GREEN))
+                        bind(count, 1)
                         // Second bind for player — should be silently ignored (first-wins).
-                        bind(WelcomeTemplate.player, Component.text("Second", NamedTextColor.RED))
+                        bind(player, Component.text("Second", NamedTextColor.RED))
                     }
 
                 firstWins shouldContainText "First"
@@ -228,7 +295,7 @@ class MiniTemplateTest :
                 val error =
                     shouldThrow<IllegalArgumentException> {
                         WelcomeTemplate {
-                            bind(WelcomeTemplate.count, 99)
+                            bind(count, 99)
                             // player intentionally omitted
                         }
                     }
@@ -245,8 +312,8 @@ class MiniTemplateTest :
                 // SparseTemplate declares 'unused' which does not appear in "<gold>Hello <name>".
                 val rendered =
                     SparseTemplate {
-                        bind(SparseTemplate.name, "Alex")
-                        bind(SparseTemplate.unused, 99)
+                        bind(name, "Alex")
+                        bind(unused, 99)
                     }
 
                 rendered shouldContainText "Alex"
@@ -262,14 +329,14 @@ class MiniTemplateTest :
             }
 
             // ---------------------------------------------------------------
-            // Child structure assertion helper (inline, no logic in test body)
+            // Child structure assertion
             // ---------------------------------------------------------------
 
             "renders a multi-segment component with the player and count inline" {
                 val rendered =
                     WelcomeTemplate {
-                        bind(WelcomeTemplate.player, Component.text("Alex"))
-                        bind(WelcomeTemplate.count, 7)
+                        bind(player, Component.text("Alex"))
+                        bind(count, 7)
                     }
 
                 // Root carries the <gold> colour; text is contained across the tree.
@@ -280,16 +347,3 @@ class MiniTemplateTest :
             }
         },
     )
-
-// ---------------------------------------------------------------------------
-// Private helper — collects all components in the tree (root + descendants).
-// Used only in the "children with bound component placeholder" test above.
-// ---------------------------------------------------------------------------
-
-private fun collectChildren(
-    component: Component,
-    into: MutableList<Component>,
-) {
-    into += component
-    component.children().forEach { collectChildren(it, into) }
-}

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateTest.kt
@@ -3,10 +3,12 @@ package io.github.lmliam.kotventure.minimessage
 import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldNotContainText
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 
@@ -213,6 +215,26 @@ class MiniTemplateTest :
                     }
 
                 firstWins shouldContainText "First"
+                firstWins shouldNotContainText "Second"
+            }
+
+            // ---------------------------------------------------------------
+            // Declaration-order: missing error names only the first-omitted placeholder
+            // ---------------------------------------------------------------
+
+            "error message names only the first-declared placeholder when only the second is bound" {
+                // WelcomeTemplate declares 'player' then 'count' (LinkedHashMap preserves order).
+                // Binding only 'count' should produce an error that names 'player' but not 'count'.
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        WelcomeTemplate {
+                            bind(WelcomeTemplate.count, 99)
+                            // player intentionally omitted
+                        }
+                    }
+
+                error.message shouldContain "player"
+                error.message shouldNotContain "count"
             }
 
             // ---------------------------------------------------------------

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateTest.kt
@@ -4,7 +4,6 @@ import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
 import io.github.lmliam.kotventure.test.text.shouldContainComponent
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
-import io.github.lmliam.kotventure.test.text.shouldNotContainText
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -269,20 +268,49 @@ class MiniTemplateTest :
             }
 
             // ---------------------------------------------------------------
-            // Double-bind first-wins
+            // Blank placeholder names
             // ---------------------------------------------------------------
 
-            "uses the first bound value when the same placeholder is bound twice" {
-                val firstWins =
-                    WelcomeTemplate {
-                        bind(player, Component.text("First", NamedTextColor.GREEN))
-                        bind(count, 1)
-                        // Second bind for player — should be silently ignored (first-wins).
-                        bind(player, Component.text("Second", NamedTextColor.RED))
+            "throws IllegalArgumentException when placeholder name is empty" {
+                shouldThrow<IllegalArgumentException> {
+                    placeholder<String>("")
+                }.message shouldContain "MiniMessage placeholder names must match"
+            }
+
+            // ---------------------------------------------------------------
+            // Duplicate render-time binding
+            // ---------------------------------------------------------------
+
+            "throws IllegalArgumentException when the same placeholder is bound twice" {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        WelcomeTemplate {
+                            bind(player, Component.text("First", NamedTextColor.GREEN))
+                            bind(count, 1)
+                            bind(player, Component.text("Second", NamedTextColor.RED))
+                        }
                     }
 
-                firstWins shouldContainText "First"
-                firstWins shouldNotContainText "Second"
+                error.message shouldContain "player"
+                error.message shouldContain "already bound"
+            }
+
+            "throws IllegalArgumentException when same-name placeholders are bound twice before missing validation" {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        object : MiniTemplate("<name>") {
+                            val name = placeholder<String>("name")
+                            val unused = placeholder<Int>("unused")
+                        }.run {
+                            this {
+                                bind(name, "Alex")
+                                bind(name, "Sam")
+                            }
+                        }
+                    }
+
+                error.message shouldContain "name"
+                error.message shouldContain "already bound"
             }
 
             // ---------------------------------------------------------------
@@ -321,11 +349,11 @@ class MiniTemplateTest :
             }
 
             // ---------------------------------------------------------------
-            // requiredPlaceholders surface
+            // declaredPlaceholders surface
             // ---------------------------------------------------------------
 
-            "requiredPlaceholders returns the names of all declared placeholders" {
-                WelcomeTemplate.requiredPlaceholders shouldBe setOf("player", "count")
+            "declaredPlaceholders returns the names of all declared placeholders" {
+                WelcomeTemplate.declaredPlaceholders shouldBe setOf("player", "count")
             }
 
             // ---------------------------------------------------------------

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateTest.kt
@@ -1,0 +1,273 @@
+package io.github.lmliam.kotventure.minimessage
+
+import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+
+// ---------------------------------------------------------------------------
+// Fixture templates — declared at file scope so they exercise the object-init
+// path and are reused across tests without per-test construction cost.
+// ---------------------------------------------------------------------------
+
+private object WelcomeTemplate : MiniTemplate("<gold>Welcome <player>, <count> new messages") {
+    val player = placeholder<Component>("player")
+    val count = placeholder<Int>("count")
+}
+
+// Template with a declared placeholder absent from the markup (AC: lenient unused).
+private object SparseTemplate : MiniTemplate("<gold>Hello <name>") {
+    val name = placeholder<String>("name")
+    val unused = placeholder<Int>("unused")
+}
+
+class MiniTemplateTest :
+    StringSpec(
+        {
+            // ---------------------------------------------------------------
+            // AC1 — Required-placeholder enforcement
+            // ---------------------------------------------------------------
+
+            "throws IllegalArgumentException listing missing placeholder when one binding is omitted" {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        WelcomeTemplate {
+                            bind(WelcomeTemplate.player, Component.text("Alex"))
+                            // count intentionally omitted
+                        }
+                    }
+
+                error.message shouldContain "count"
+            }
+
+            "throws IllegalArgumentException listing all missing placeholders when all bindings are omitted" {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        WelcomeTemplate { }
+                    }
+
+                error.message shouldContain "player"
+                error.message shouldContain "count"
+            }
+
+            "throws IllegalArgumentException when binding a placeholder not declared on this template" {
+                val outsider = placeholder<String>("outsider")
+
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        WelcomeTemplate {
+                            bind(WelcomeTemplate.player, Component.text("Alex"))
+                            bind(WelcomeTemplate.count, 1)
+                            @Suppress("UNCHECKED_CAST")
+                            bind(outsider as MiniMessagePlaceholder<Component>, Component.text("x"))
+                        }
+                    }
+
+                error.message shouldContain "outsider"
+            }
+
+            // ---------------------------------------------------------------
+            // AC2 — Reuse correctness: two independent, correct components
+            // ---------------------------------------------------------------
+
+            "renders correct component for each of two independent invocations" {
+                val forAlex =
+                    WelcomeTemplate {
+                        bind(WelcomeTemplate.player, Component.text("Alex", NamedTextColor.GREEN))
+                        bind(WelcomeTemplate.count, 3)
+                    }
+
+                val forSam =
+                    WelcomeTemplate {
+                        bind(WelcomeTemplate.player, Component.text("Sam", NamedTextColor.RED))
+                        bind(WelcomeTemplate.count, 0)
+                    }
+
+                // Gold color is applied to the root component by the <gold> tag.
+                forAlex shouldHaveColor NamedTextColor.GOLD
+                forAlex shouldContainText "Alex"
+                forAlex shouldContainText "3"
+
+                forSam shouldHaveColor NamedTextColor.GOLD
+                forSam shouldContainText "Sam"
+                forSam shouldContainText "0"
+
+                // The two components are independent — Alex's render did not leak into Sam's.
+                forAlex shouldContainText "Alex"
+                forSam shouldContainText "Sam"
+            }
+
+            "renders children with the bound component placeholder inline" {
+                val alex = Component.text("Alex", NamedTextColor.AQUA)
+
+                val rendered =
+                    WelcomeTemplate {
+                        bind(WelcomeTemplate.player, alex)
+                        bind(WelcomeTemplate.count, 5)
+                    }
+
+                // The bound component appears as a direct child within the rendered tree.
+                rendered shouldContainText "Alex"
+                rendered shouldHaveColor NamedTextColor.GOLD
+
+                // Locate the child that IS the bound component and verify its color.
+                val childrenFlat = buildList { collectChildren(rendered, this) }
+                val alexChild = childrenFlat.firstOrNull { it == alex }
+                alexChild shouldBe alex
+            }
+
+            // ---------------------------------------------------------------
+            // AC3 — Type safety: assertDoesNotCompile
+            // ---------------------------------------------------------------
+
+            "does not compile when an Int placeholder is bound with a String value" {
+                // Test the type safety of MiniTemplateBindingScope.bind via the public interface.
+                // Using placeholder<T>() top-level (matching the existing compile-fail test pattern)
+                // to avoid calling the protected inline member inside a subclass body in the snippet.
+                assertDoesNotCompile(
+                    fileName = "TemplateIntStringMismatch.kt",
+                    source =
+                        """
+                        import io.github.lmliam.kotventure.minimessage.MiniTemplateBindingScope
+                        import io.github.lmliam.kotventure.minimessage.placeholder
+
+                        fun test(scope: MiniTemplateBindingScope) {
+                            val count = placeholder<Int>("count")
+                            scope.bind(count, "three")
+                        }
+                        """.trimIndent(),
+                    "Argument type mismatch",
+                    "String",
+                    "Int",
+                )
+            }
+
+            "does not compile when a Component placeholder is bound with an Int value" {
+                assertDoesNotCompile(
+                    fileName = "TemplateComponentIntMismatch.kt",
+                    source =
+                        """
+                        import io.github.lmliam.kotventure.minimessage.MiniTemplateBindingScope
+                        import io.github.lmliam.kotventure.minimessage.placeholder
+                        import net.kyori.adventure.text.Component
+
+                        fun test(scope: MiniTemplateBindingScope) {
+                            val player = placeholder<Component>("player")
+                            scope.bind(player, 42)
+                        }
+                        """.trimIndent(),
+                    "Argument type mismatch",
+                    "Int",
+                    "Component",
+                )
+            }
+
+            // ---------------------------------------------------------------
+            // Duplicate placeholder name → fails at object init
+            // ---------------------------------------------------------------
+
+            "throws IllegalArgumentException at template construction when two placeholders share a name" {
+                shouldThrow<IllegalArgumentException> {
+                    object : MiniTemplate("<a>") {
+                        @Suppress("unused")
+                        val first = placeholder<String>("a")
+
+                        @Suppress("unused")
+                        val second = placeholder<Int>("a")
+                    }
+                }.message shouldContain "Duplicate placeholder 'a'"
+            }
+
+            // ---------------------------------------------------------------
+            // Empty / blank markup → throws at construction
+            // ---------------------------------------------------------------
+
+            "throws IllegalArgumentException when markup is empty" {
+                shouldThrow<IllegalArgumentException> {
+                    object : MiniTemplate("") { }
+                }
+            }
+
+            "throws IllegalArgumentException when markup is blank" {
+                shouldThrow<IllegalArgumentException> {
+                    object : MiniTemplate("   ") { }
+                }
+            }
+
+            // ---------------------------------------------------------------
+            // Double-bind first-wins
+            // ---------------------------------------------------------------
+
+            "uses the first bound value when the same placeholder is bound twice" {
+                val firstWins =
+                    WelcomeTemplate {
+                        bind(WelcomeTemplate.player, Component.text("First", NamedTextColor.GREEN))
+                        bind(WelcomeTemplate.count, 1)
+                        // Second bind for player — should be silently ignored (first-wins).
+                        bind(WelcomeTemplate.player, Component.text("Second", NamedTextColor.RED))
+                    }
+
+                firstWins shouldContainText "First"
+            }
+
+            // ---------------------------------------------------------------
+            // Declared-but-unused placeholder → renders fine
+            // ---------------------------------------------------------------
+
+            "renders successfully when a declared placeholder is absent from the markup" {
+                // SparseTemplate declares 'unused' which does not appear in "<gold>Hello <name>".
+                val rendered =
+                    SparseTemplate {
+                        bind(SparseTemplate.name, "Alex")
+                        bind(SparseTemplate.unused, 99)
+                    }
+
+                rendered shouldContainText "Alex"
+                rendered shouldHaveColor NamedTextColor.GOLD
+            }
+
+            // ---------------------------------------------------------------
+            // requiredPlaceholders surface
+            // ---------------------------------------------------------------
+
+            "requiredPlaceholders returns the names of all declared placeholders" {
+                WelcomeTemplate.requiredPlaceholders shouldBe setOf("player", "count")
+            }
+
+            // ---------------------------------------------------------------
+            // Child structure assertion helper (inline, no logic in test body)
+            // ---------------------------------------------------------------
+
+            "renders a multi-segment component with the player and count inline" {
+                val rendered =
+                    WelcomeTemplate {
+                        bind(WelcomeTemplate.player, Component.text("Alex"))
+                        bind(WelcomeTemplate.count, 7)
+                    }
+
+                // Root carries the <gold> colour; text is contained across the tree.
+                rendered shouldHaveColor NamedTextColor.GOLD
+                rendered shouldContainText "Welcome"
+                rendered shouldContainText "Alex"
+                rendered shouldContainText "7"
+            }
+        },
+    )
+
+// ---------------------------------------------------------------------------
+// Private helper — collects all components in the tree (root + descendants).
+// Used only in the "children with bound component placeholder" test above.
+// ---------------------------------------------------------------------------
+
+private fun collectChildren(
+    component: Component,
+    into: MutableList<Component>,
+) {
+    into += component
+    component.children().forEach { collectChildren(it, into) }
+}

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/external/MiniTemplateExternalDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/external/MiniTemplateExternalDslTest.kt
@@ -1,0 +1,29 @@
+package io.github.lmliam.kotventure.minimessage.external
+
+import io.github.lmliam.kotventure.minimessage.MiniTemplate
+import io.github.lmliam.kotventure.minimessage.bind
+import io.github.lmliam.kotventure.minimessage.invoke
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.kotest.core.spec.style.StringSpec
+import net.kyori.adventure.text.Component
+
+private object ExternalWelcomeTemplate : MiniTemplate("<gold>Welcome <player>, <count> new messages") {
+    val player = placeholder<Component>("player")
+    val count = placeholder<Int>("count")
+}
+
+class MiniTemplateExternalDslTest :
+    StringSpec(
+        {
+            "renders with unqualified placeholders from another package" {
+                val rendered =
+                    ExternalWelcomeTemplate {
+                        bind(player, Component.text("Alex"))
+                        bind(count, 3)
+                    }
+
+                rendered shouldContainText "Alex"
+                rendered shouldContainText "3"
+            }
+        },
+    )

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -3,6 +3,7 @@ package io.github.lmliam.kotventure.test.text
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.BlockNBTComponent
 import net.kyori.adventure.text.Component
@@ -29,6 +30,14 @@ import net.kyori.adventure.text.`object`.ObjectContents
 public infix fun Component.shouldContainText(expected: String): Component =
     apply {
         this should haveTextContent(expected)
+    }
+
+/**
+ * Asserts that this component tree does NOT contain [expected] in its text content.
+ */
+public infix fun Component.shouldNotContainText(expected: String): Component =
+    apply {
+        this shouldNot haveTextContent(expected)
     }
 
 /**


### PR DESCRIPTION
## Summary

Adds typed, reusable MiniMessage templates via a `MiniTemplate` base class.

- Declare a template once as an `object : MiniTemplate("…")` with typed `val` placeholder properties
- Render with a compile-checked `bind` DSL block; each property carries its type at the call site
- Use-time validation ensures all declared placeholders are bound exactly once before a `Component` is returned
- Declare-once/reuse-correctly semantics: `MiniMessage` instance and placeholder metadata are built once per template object; each `invoke` call produces an independent `Component`

## Related Issues

Closes #27. Builds on the typed placeholder support introduced in #26 (PR #142).

## DSL Impact

New public surface:
- `MiniTemplate` — abstract base class; subclass as an `object` to declare a template
- `MiniTemplateBindingScope` — `@KotventureDslMarker`-annotated scope that exposes `bind(placeholder, value)`
- `MiniTemplate.declaredPlaceholders` — declaration-order names for template introspection

API shape follows the idiomatic-Kotlin-DSL resolution ladder: object/property API chosen over a builder-lambda because compile-time value typing is already inherited from #26 typed placeholders; use-time completeness validation is the right trade-off given codegen is out of scope.

## Rationale

Plugin authors often send the same message in multiple places (join, chat, command output). Without `MiniTemplate` the markup string and its placeholder names must be repeated at every call site, which drifts. A reusable, typed factory eliminates that duplication and surfaces missing-placeholder, duplicate-binding, and cross-template placeholder mistakes at runtime before a `Component` ever leaves the scope.

## Testing

`./gradlew :minimessage:test` — 38 MiniMessage tests, all green:
- Happy-path rendering (single and multi-placeholder templates)
- External-package test covering the README-style unqualified `bind(player, ...)` render block
- `assertDoesNotCompile` guards verifying that binding the wrong type is a compile error
- Negative-path: blank markup rejected, blank placeholder names rejected, missing declared placeholder throws, duplicate bind throws, cross-template placeholder binding throws
- `./gradlew ktlintFormat spotlessApply build ktlintCheck spotlessCheck` passes

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run
