### PR TITLE
feat(minimessage): validate markup and placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,17 +328,17 @@ import net.kyori.adventure.text.Component
 val player = placeholder<Component>("player")
 val count = placeholder<Int>("count")
 
-// Success — well-formed markup, all placeholders present, standard tags closed
+// Success — well-formed input, all placeholders present, standard tags closed
 val result = validate(
-    markup = "<gold>Welcome <player></gold>, you have <count> messages",
-    spec = listOf(player, count),
+    input = "<gold>Welcome <player></gold>, you have <count> messages",
+    placeholders = listOf(player, count),
 )
 // result == ValidationResult.Success
 
-// MissingPlaceholder — 'count' declared in spec but absent from markup
+// MissingPlaceholder — 'count' declared in placeholders but absent from input
 val missingResult = validate(
-    markup = "<gold>Welcome <player></gold>",
-    spec = listOf(player, count),
+    input = "<gold>Welcome <player></gold>",
+    placeholders = listOf(player, count),
 )
 // missingResult == ValidationResult.Failure(
 //   diagnostics = [MissingPlaceholder("count")]
@@ -346,38 +346,36 @@ val missingResult = validate(
 
 // MalformedTag — '<gold>' opened but not closed (strict mode)
 val malformedResult = validate(
-    markup = "<gold>Hello world",
-    spec = listOf(player),
+    input = "<gold>Hello world",
+    placeholders = listOf(player),
 )
 // malformedResult == ValidationResult.Failure(
 //   diagnostics = [
 //     MalformedTag("...", startIndex, endIndex),  // unclosed <gold>
-//     MissingPlaceholder("player"),               // declared but absent from markup
+//     MissingPlaceholder("player"),               // declared but absent from input
 //   ]
 // )
 
-// ExtraPlaceholder — '<mystery>' tag in markup has no spec entry
+// ExtraPlaceholder — '<mystery>' tag in input has no placeholder entry
 val extraResult = validate(
-    markup = "<gold>Hello <player></gold> <mystery>",
-    spec = listOf(player),
+    input = "<gold>Hello <player></gold> <mystery>",
+    placeholders = listOf(player),
 )
 // extraResult == ValidationResult.Failure(
 //   diagnostics = [ExtraPlaceholder("mystery")]
 // )
 
-// Inspect diagnostics with an exhaustive when
-when (val r = missingResult) {
-    is ValidationResult.Success -> println("All good!")
-    is ValidationResult.Failure -> {
-        for (diag in r.diagnostics) {
-            when (diag) {
-                is MiniMessageDiagnostic.MalformedTag ->
-                    println("Malformed tag at [${diag.startIndex}–${diag.endIndex}]: ${diag.message}")
-                is MiniMessageDiagnostic.MissingPlaceholder ->
-                    println("Missing placeholder: <${diag.name}>")
-                is MiniMessageDiagnostic.ExtraPlaceholder ->
-                    println("Extra placeholder: <${diag.name}>")
-            }
+// Inspect diagnostics exhaustively
+val diagnosticMessages = when (val r = missingResult) {
+    is ValidationResult.Success -> emptyList()
+    is ValidationResult.Failure -> r.diagnostics.map { diag ->
+        when (diag) {
+            is MiniMessageDiagnostic.MalformedTag ->
+                "Malformed tag at [${diag.startIndex}–${diag.endIndex}]: ${diag.message}"
+            is MiniMessageDiagnostic.MissingPlaceholder ->
+                "Missing placeholder: <${diag.name}>"
+            is MiniMessageDiagnostic.ExtraPlaceholder ->
+                "Extra placeholder: <${diag.name}>"
         }
     }
 }
@@ -402,8 +400,8 @@ val templateResult = WelcomeTemplate.validate()
 ```
 
 Diagnostic ordering in `ValidationResult.Failure.diagnostics`: malformed-tag diagnostics appear first, then missing
-placeholders in spec declaration order, then extra placeholders in the order they were encountered in the markup.
-`result.isSuccess` and `result.isFailure` are available as extension properties for concise checks.
+placeholders in declaration order, then extra placeholders in the order they were encountered in the input.
+`result.isSuccess` and `result.isFailure` are available as concise boolean checks.
 
 Join a list of components using `Iterable<Component>.join { }`, with optional separator, `lastSeparator`, `prefix`, and
 `suffix` knobs that each accept a string-plus-styling block or a prebuilt component:

--- a/README.md
+++ b/README.md
@@ -312,11 +312,11 @@ val forSam = WelcomeTemplate {
 //   → IllegalArgumentException: Template is missing required placeholder(s): [count].
 ```
 
-`validate(markup, spec)` checks a MiniMessage string against a declared placeholder spec and returns a structured
-`ValidationResult` — no exception escapes to the caller. It runs two passes: a strict-mode parse that catches malformed
-or unclosed tags, and a recording parse that cross-checks which placeholder tags appear in the markup. Note that strict
-mode requires all standard child-allowing tags (such as `<gold>`) to be explicitly closed; an unclosed standard tag is
-reported as a `MalformedTag` diagnostic.
+`validate(input, placeholders)` checks a MiniMessage string against a declared set of placeholders and returns a
+structured `ValidationResult` — no exception escapes to the caller. It runs two passes: a strict-mode parse that catches
+malformed or unclosed tags, and a recording parse that cross-checks which placeholder tags appear in the input. Note that
+strict mode requires all standard child-allowing tags (such as `<gold>`) to be explicitly closed; an unclosed standard
+tag is reported as a `MalformedTag` diagnostic.
 
 ```kotlin
 import io.github.lmliam.kotventure.minimessage.placeholder
@@ -381,8 +381,8 @@ val diagnosticMessages = when (val r = missingResult) {
 }
 ```
 
-`MiniTemplate.validate()` is a convenience extension that validates a template's own markup against its declared
-placeholders without needing to pass the spec manually:
+`MiniTemplate.validate()` is a convenience extension that validates a template's own MiniMessage string against its
+declared placeholders without needing to pass them manually:
 
 ```kotlin
 import io.github.lmliam.kotventure.minimessage.MiniTemplate

--- a/README.md
+++ b/README.md
@@ -312,6 +312,99 @@ val forSam = WelcomeTemplate {
 //   → IllegalArgumentException: Template is missing required placeholder(s): [count].
 ```
 
+`validate(markup, spec)` checks a MiniMessage string against a declared placeholder spec and returns a structured
+`ValidationResult` — no exception escapes to the caller. It runs two passes: a strict-mode parse that catches malformed
+or unclosed tags, and a recording parse that cross-checks which placeholder tags appear in the markup. Note that strict
+mode requires all standard child-allowing tags (such as `<gold>`) to be explicitly closed; an unclosed standard tag is
+reported as a `MalformedTag` diagnostic.
+
+```kotlin
+import io.github.lmliam.kotventure.minimessage.placeholder
+import io.github.lmliam.kotventure.minimessage.validate
+import io.github.lmliam.kotventure.minimessage.validation.MiniMessageDiagnostic
+import io.github.lmliam.kotventure.minimessage.validation.ValidationResult
+import net.kyori.adventure.text.Component
+
+val player = placeholder<Component>("player")
+val count = placeholder<Int>("count")
+
+// Success — well-formed markup, all placeholders present, standard tags closed
+val result = validate(
+    markup = "<gold>Welcome <player></gold>, you have <count> messages",
+    spec = listOf(player, count),
+)
+// result == ValidationResult.Success
+
+// MissingPlaceholder — 'count' declared in spec but absent from markup
+val missingResult = validate(
+    markup = "<gold>Welcome <player></gold>",
+    spec = listOf(player, count),
+)
+// missingResult == ValidationResult.Failure(
+//   diagnostics = [MissingPlaceholder("count")]
+// )
+
+// MalformedTag — '<gold>' opened but not closed (strict mode)
+val malformedResult = validate(
+    markup = "<gold>Hello world",
+    spec = listOf(player),
+)
+// malformedResult == ValidationResult.Failure(
+//   diagnostics = [
+//     MalformedTag("...", startIndex, endIndex),  // unclosed <gold>
+//     MissingPlaceholder("player"),               // declared but absent from markup
+//   ]
+// )
+
+// ExtraPlaceholder — '<mystery>' tag in markup has no spec entry
+val extraResult = validate(
+    markup = "<gold>Hello <player></gold> <mystery>",
+    spec = listOf(player),
+)
+// extraResult == ValidationResult.Failure(
+//   diagnostics = [ExtraPlaceholder("mystery")]
+// )
+
+// Inspect diagnostics with an exhaustive when
+when (val r = missingResult) {
+    is ValidationResult.Success -> println("All good!")
+    is ValidationResult.Failure -> {
+        for (diag in r.diagnostics) {
+            when (diag) {
+                is MiniMessageDiagnostic.MalformedTag ->
+                    println("Malformed tag at [${diag.startIndex}–${diag.endIndex}]: ${diag.message}")
+                is MiniMessageDiagnostic.MissingPlaceholder ->
+                    println("Missing placeholder: <${diag.name}>")
+                is MiniMessageDiagnostic.ExtraPlaceholder ->
+                    println("Extra placeholder: <${diag.name}>")
+            }
+        }
+    }
+}
+```
+
+`MiniTemplate.validate()` is a convenience extension that validates a template's own markup against its declared
+placeholders without needing to pass the spec manually:
+
+```kotlin
+import io.github.lmliam.kotventure.minimessage.MiniTemplate
+import io.github.lmliam.kotventure.minimessage.placeholder
+import io.github.lmliam.kotventure.minimessage.validate
+import net.kyori.adventure.text.Component
+
+object WelcomeTemplate : MiniTemplate("<gold>Welcome <player>, <count> new messages</gold>") {
+    val player = placeholder<Component>("player")
+    val count = placeholder<Int>("count")
+}
+
+val templateResult = WelcomeTemplate.validate()
+// templateResult == ValidationResult.Success
+```
+
+Diagnostic ordering in `ValidationResult.Failure.diagnostics`: malformed-tag diagnostics appear first, then missing
+placeholders in spec declaration order, then extra placeholders in the order they were encountered in the markup.
+`result.isSuccess` and `result.isFailure` are available as extension properties for concise checks.
+
 Join a list of components using `Iterable<Component>.join { }`, with optional separator, `lastSeparator`, `prefix`, and
 `suffix` knobs that each accept a string-plus-styling block or a prebuilt component:
 

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidation.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidation.kt
@@ -66,6 +66,10 @@ public fun MiniTemplate.validate(): ValidationResult = validate(markup, placehol
  * Spec names are resolved as self-closing tags so they never trigger a false "unclosed tag"
  * diagnostic under strict mode. Returns at most one [MiniMessageDiagnostic.MalformedTag]
  * because Adventure's strict parser throws on the first violation.
+ *
+ * [ParsingException] is the expected signal for strict-mode violations. Other [RuntimeException]
+ * subclasses can be thrown by Adventure's parser internals on severely malformed inputs; they
+ * are caught to preserve the no-throw contract of [validate].
  */
 private fun detectMalformedTags(
     markup: String,
@@ -85,15 +89,22 @@ private fun detectMalformedTags(
                 endIndex = e.endIndex(),
             ),
         )
+    } catch (_: RuntimeException) {
+        // Adventure parser bug on edge-case malformed input — no position info available.
+        emptyList()
     }
 }
 
 /**
  * Pass 2: lenient parse with a recording resolver to enumerate tags referenced in the markup.
  *
- * Records every non-standard tag name (i.e. names for which [TagResolver.standard] returns
- * `false` from [TagResolver.has]) encountered by the recording resolver. Non-standard names
- * are exactly the placeholder-like tags; standard Adventure formatting tags are excluded.
+ * Records a tag name when it is either non-standard (i.e. [TagResolver.standard] does not
+ * claim it) **or** present in the spec. The second condition handles the edge case where a
+ * spec placeholder shares its name with a standard Adventure tag (e.g. `"gold"`): without it,
+ * the recording resolver would silently skip `<gold>` and produce a false `MissingPlaceholder`.
+ *
+ * Standard tags whose names are NOT in the spec are still excluded, preserving the existing
+ * behaviour that prevents ordinary formatting tags from showing up as extra placeholders.
  *
  * Returns a pair of (missing diagnostics, extra diagnostics):
  * - missing: spec names absent from the recorded tags (in spec declaration order).
@@ -103,12 +114,20 @@ private fun detectPlaceholderMismatches(
     markup: String,
     spec: List<MiniMessagePlaceholder<*>>,
 ): Pair<List<MiniMessageDiagnostic.MissingPlaceholder>, List<MiniMessageDiagnostic.ExtraPlaceholder>> {
-    val recorder = RecordingTagResolver()
+    val specNames = spec.map { it.name }.toSet()
+    val recorder = RecordingTagResolver(specNames)
     val combined = TagResolver.resolver(TagResolver.standard(), recorder)
-    MiniMessage.miniMessage().deserialize(markup, combined)
+    // The lenient parser is designed not to throw ParsingException, but Adventure's internals
+    // can still throw RuntimeException (e.g. StringIndexOutOfBoundsException) on certain
+    // edge-case malformed inputs (PaperMC/adventure#1011). Catch it so validate() never
+    // propagates an exception; the recording side-effects gathered so far remain usable.
+    try {
+        MiniMessage.miniMessage().deserialize(markup, combined)
+    } catch (_: RuntimeException) {
+        // Proceed with whatever the recorder captured before the throw.
+    }
 
     val tagsInMarkup = recorder.encounteredNames
-    val specNames = spec.map { it.name }.toSet()
 
     val missing =
         spec
@@ -137,16 +156,27 @@ private fun buildSpecNameResolver(spec: List<MiniMessagePlaceholder<*>>): TagRes
 }
 
 /**
- * A [TagResolver] that records the names of every non-standard tag it is asked to resolve.
+ * A [TagResolver] that records the names of tags it is asked to resolve.
  *
  * [has] returns `true` for all names so that Adventure calls [resolve] for every `<tag>` in
- * the markup. [resolve] records the name only when [TagResolver.standard] does not claim it,
- * preventing standard Adventure formatting tags from appearing in the recorded set.
+ * the markup. [resolve] records the name when either:
+ * - [TagResolver.standard] does not claim it (it's a custom/unknown tag), or
+ * - it appears in [specNames] (a spec placeholder whose name collides with a standard tag).
+ *
+ * This dual condition prevents standard formatting tags (e.g. `<red>`, `<bold>`) from polluting
+ * the recorded set, while still recording spec-named placeholders that share a standard tag
+ * name (e.g. a placeholder declared as `"gold"`).
+ *
  * [resolve] returns `null` so the lenient parser silently skips each tag.
  *
  * Tags are recorded in encounter order (the order [resolve] is first called for each name).
+ *
+ * @param specNames the set of placeholder names declared in the spec; used to force-record
+ *   names that would otherwise be filtered by the standard-tag check.
  */
-private class RecordingTagResolver : TagResolver {
+private class RecordingTagResolver(
+    private val specNames: Set<String>,
+) : TagResolver {
     /** Tag names encountered in the markup, in the order they were first seen. */
     val encounteredNames: LinkedHashSet<String> = LinkedHashSet()
 
@@ -155,7 +185,7 @@ private class RecordingTagResolver : TagResolver {
         arguments: ArgumentQueue,
         ctx: Context,
     ): Tag? {
-        if (!TagResolver.standard().has(name)) {
+        if (name in specNames || !TagResolver.standard().has(name)) {
             encounteredNames.add(name)
         }
         return null

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidation.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidation.kt
@@ -1,195 +1,49 @@
 package io.github.lmliam.kotventure.minimessage
 
-import io.github.lmliam.kotventure.minimessage.validation.MiniMessageDiagnostic
 import io.github.lmliam.kotventure.minimessage.validation.ValidationResult
-import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.minimessage.Context
-import net.kyori.adventure.text.minimessage.MiniMessage
-import net.kyori.adventure.text.minimessage.ParsingException
-import net.kyori.adventure.text.minimessage.tag.Tag
-import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue
-import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+import io.github.lmliam.kotventure.minimessage.validation.runValidation
 
 /**
- * Validates [markup] against the declared [spec] placeholders.
+ * Validates [input] against the declared [placeholders].
  *
  * Two independent passes are run and their diagnostics are merged into a single list:
  *
- * - **Pass 1 (malformed tags):** The markup is parsed with `strict(true)` mode. Every spec name
- *   is resolved as a self-closing tag so spec-name placeholders do not produce false positives. A
- *   [ParsingException] is caught and emitted as [MiniMessageDiagnostic.MalformedTag]. Only the
- *   first exception per parse is reported — fixing it may reveal more.
+ * - **Pass 1 (malformed tags):** The input is parsed with `strict(true)` mode. Every placeholder
+ *   name is resolved as a self-closing tag so placeholder-name tags do not produce false positives.
+ *   A [net.kyori.adventure.text.minimessage.ParsingException] is caught and emitted as a
+ *   [io.github.lmliam.kotventure.minimessage.validation.MiniMessageDiagnostic.MalformedTag]. Only
+ *   the first exception per parse is reported — fixing it may reveal more.
  *
- * - **Pass 2 (placeholder presence):** A recording [TagResolver] records every non-standard tag
- *   name encountered during a lenient parse. Names in [spec] but absent from the markup produce
- *   [MiniMessageDiagnostic.MissingPlaceholder]; names in the markup but absent from [spec] produce
- *   [MiniMessageDiagnostic.ExtraPlaceholder].
+ * - **Pass 2 (placeholder presence):** A recording
+ *   [net.kyori.adventure.text.minimessage.tag.resolver.TagResolver] records every non-standard tag
+ *   name encountered during a lenient parse. Names in [placeholders] but absent from the input
+ *   produce [io.github.lmliam.kotventure.minimessage.validation.MiniMessageDiagnostic.MissingPlaceholder];
+ *   names in the input but absent from [placeholders] produce
+ *   [io.github.lmliam.kotventure.minimessage.validation.MiniMessageDiagnostic.ExtraPlaceholder].
  *
  * Diagnostic ordering in [ValidationResult.Failure.diagnostics]: malformed tags first, then
- * missing placeholders in spec declaration order, then extra placeholders in markup-encounter order.
+ * missing placeholders in [placeholders] declaration order, then extra placeholders in
+ * input-encounter order.
  *
- * @param markup the MiniMessage markup string to validate.
- * @param spec the declared placeholders the markup is expected to use; order determines the order
- *   of [MiniMessageDiagnostic.MissingPlaceholder] entries in the result.
- * @return [ValidationResult.Success] when no issues were found, or
- *   [ValidationResult.Failure] with a non-empty list of diagnostics.
+ * @param input the MiniMessage markup string to validate.
+ * @param placeholders the declared placeholders the input is expected to use; order determines the
+ *   order of [io.github.lmliam.kotventure.minimessage.validation.MiniMessageDiagnostic.MissingPlaceholder]
+ *   entries in the result.
+ * @return [ValidationResult.Success] when no issues were found, or [ValidationResult.Failure] with
+ *   a non-empty list of diagnostics.
  */
 public fun validate(
-    markup: String,
-    spec: Iterable<MiniMessagePlaceholder<*>>,
-): ValidationResult {
-    val specList = spec.toList()
-    val malformed = detectMalformedTags(markup, specList)
-    val (missing, extra) = detectPlaceholderMismatches(markup, specList)
-    val diagnostics = malformed + missing + extra
-    return if (diagnostics.isEmpty()) ValidationResult.Success else ValidationResult.Failure(diagnostics)
-}
+    input: String,
+    placeholders: Iterable<MiniMessagePlaceholder<*>>,
+): ValidationResult = runValidation(input, placeholders.toList())
 
 /**
  * Validates this template's markup against its own declared placeholders.
  *
- * Convenience wrapper over [validate] that extracts the spec from the template's
+ * Convenience wrapper over [validate] that extracts the placeholder list from the template's
  * `@PublishedApi internal` [MiniTemplate.placeholders] map without exposing a new public surface.
  *
  * @return [ValidationResult.Success] when the markup is well-formed and every declared placeholder
  *   has a corresponding tag (and vice versa); [ValidationResult.Failure] otherwise.
  */
 public fun MiniTemplate.validate(): ValidationResult = validate(markup, placeholders.values)
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Pass 1: strict-mode parse to detect malformed or unclosed tags.
- *
- * Spec names are resolved as self-closing tags so they never trigger a false "unclosed tag"
- * diagnostic under strict mode. Returns at most one [MiniMessageDiagnostic.MalformedTag]
- * because Adventure's strict parser throws on the first violation.
- *
- * [ParsingException] is the expected signal for strict-mode violations. Other [RuntimeException]
- * subclasses can be thrown by Adventure's parser internals on severely malformed inputs; they
- * are caught to preserve the no-throw contract of [validate].
- */
-private fun detectMalformedTags(
-    markup: String,
-    spec: List<MiniMessagePlaceholder<*>>,
-): List<MiniMessageDiagnostic.MalformedTag> {
-    val strictParser = MiniMessage.builder().strict(true).build()
-    val specResolver = buildSpecNameResolver(spec)
-    val combined = TagResolver.resolver(TagResolver.standard(), specResolver)
-    return try {
-        strictParser.deserialize(markup, combined)
-        emptyList()
-    } catch (e: ParsingException) {
-        listOf(
-            MiniMessageDiagnostic.MalformedTag(
-                message = e.detailMessage() ?: e.message ?: "",
-                startIndex = e.startIndex(),
-                endIndex = e.endIndex(),
-            ),
-        )
-    } catch (_: RuntimeException) {
-        // Adventure parser bug on edge-case malformed input — no position info available.
-        emptyList()
-    }
-}
-
-/**
- * Pass 2: lenient parse with a recording resolver to enumerate tags referenced in the markup.
- *
- * Records a tag name when it is either non-standard (i.e. [TagResolver.standard] does not
- * claim it) **or** present in the spec. The second condition handles the edge case where a
- * spec placeholder shares its name with a standard Adventure tag (e.g. `"gold"`): without it,
- * the recording resolver would silently skip `<gold>` and produce a false `MissingPlaceholder`.
- *
- * Standard tags whose names are NOT in the spec are still excluded, preserving the existing
- * behaviour that prevents ordinary formatting tags from showing up as extra placeholders.
- *
- * Returns a pair of (missing diagnostics, extra diagnostics):
- * - missing: spec names absent from the recorded tags (in spec declaration order).
- * - extra: recorded names absent from the spec (in markup-encounter order).
- */
-private fun detectPlaceholderMismatches(
-    markup: String,
-    spec: List<MiniMessagePlaceholder<*>>,
-): Pair<List<MiniMessageDiagnostic.MissingPlaceholder>, List<MiniMessageDiagnostic.ExtraPlaceholder>> {
-    val specNames = spec.map { it.name }.toSet()
-    val recorder = RecordingTagResolver(specNames)
-    val combined = TagResolver.resolver(TagResolver.standard(), recorder)
-    // The lenient parser is designed not to throw ParsingException, but Adventure's parser
-    // internals can still throw RuntimeException (e.g. StringIndexOutOfBoundsException) on
-    // edge-case malformed inputs. Guard defensively so validate() never propagates an exception;
-    // the recording side-effects gathered so far remain usable.
-    try {
-        MiniMessage.miniMessage().deserialize(markup, combined)
-    } catch (_: RuntimeException) {
-        // Proceed with whatever the recorder captured before the throw.
-    }
-
-    val tagsInMarkup = recorder.encounteredNames
-
-    val missing =
-        spec
-        .filter { it.name !in tagsInMarkup }
-        .map { MiniMessageDiagnostic.MissingPlaceholder(it.name) }
-
-    val extra =
-        tagsInMarkup
-        .filter { it !in specNames }
-        .map { MiniMessageDiagnostic.ExtraPlaceholder(it) }
-
-    return missing to extra
-}
-
-/**
- * Builds a [TagResolver] that resolves each spec name as a self-closing inserting tag.
- *
- * Self-closing tags are never required to be explicitly closed, so they do not produce
- * false-positive "unclosed tag" diagnostics under strict mode.
- */
-private fun buildSpecNameResolver(spec: List<MiniMessagePlaceholder<*>>): TagResolver {
-    if (spec.isEmpty()) return TagResolver.empty()
-    val selfClosingTag = Tag.selfClosingInserting(Component.empty())
-    val resolvers = spec.map { TagResolver.resolver(it.name, selfClosingTag) }
-    return TagResolver.resolver(*resolvers.toTypedArray())
-}
-
-/**
- * A [TagResolver] that records the names of tags it is asked to resolve.
- *
- * [has] returns `true` for all names so that Adventure calls [resolve] for every `<tag>` in
- * the markup. [resolve] records the name when either:
- * - [TagResolver.standard] does not claim it (it's a custom/unknown tag), or
- * - it appears in [specNames] (a spec placeholder whose name collides with a standard tag).
- *
- * This dual condition prevents standard formatting tags (e.g. `<red>`, `<bold>`) from polluting
- * the recorded set, while still recording spec-named placeholders that share a standard tag
- * name (e.g. a placeholder declared as `"gold"`).
- *
- * [resolve] returns `null` so the lenient parser silently skips each tag.
- *
- * Tags are recorded in encounter order (the order [resolve] is first called for each name).
- *
- * @param specNames the set of placeholder names declared in the spec; used to force-record
- *   names that would otherwise be filtered by the standard-tag check.
- */
-private class RecordingTagResolver(
-    private val specNames: Set<String>,
-) : TagResolver {
-    /** Tag names encountered in the markup, in the order they were first seen. */
-    val encounteredNames: LinkedHashSet<String> = LinkedHashSet()
-
-    override fun resolve(
-        name: String,
-        arguments: ArgumentQueue,
-        ctx: Context,
-    ): Tag? {
-        if (name in specNames || !TagResolver.standard().has(name)) {
-            encounteredNames.add(name)
-        }
-        return null
-    }
-
-    override fun has(name: String): Boolean = true
-}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidation.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidation.kt
@@ -1,0 +1,165 @@
+package io.github.lmliam.kotventure.minimessage
+
+import io.github.lmliam.kotventure.minimessage.validation.MiniMessageDiagnostic
+import io.github.lmliam.kotventure.minimessage.validation.ValidationResult
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.Context
+import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.minimessage.ParsingException
+import net.kyori.adventure.text.minimessage.tag.Tag
+import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+
+/**
+ * Validates [markup] against the declared [spec] placeholders.
+ *
+ * Two independent passes are run and their diagnostics are merged into a single list:
+ *
+ * - **Pass 1 (malformed tags):** The markup is parsed with `strict(true)` mode. Every spec name
+ *   is resolved as a self-closing tag so spec-name placeholders do not produce false positives. A
+ *   [ParsingException] is caught and emitted as [MiniMessageDiagnostic.MalformedTag]. Only the
+ *   first exception per parse is reported — fixing it may reveal more.
+ *
+ * - **Pass 2 (placeholder presence):** A recording [TagResolver] records every non-standard tag
+ *   name encountered during a lenient parse. Names in [spec] but absent from the markup produce
+ *   [MiniMessageDiagnostic.MissingPlaceholder]; names in the markup but absent from [spec] produce
+ *   [MiniMessageDiagnostic.ExtraPlaceholder].
+ *
+ * Diagnostic ordering in [ValidationResult.Failure.diagnostics]: malformed tags first, then
+ * missing placeholders in spec declaration order, then extra placeholders in markup-encounter order.
+ *
+ * @param markup the MiniMessage markup string to validate.
+ * @param spec the declared placeholders the markup is expected to use; order determines the order
+ *   of [MiniMessageDiagnostic.MissingPlaceholder] entries in the result.
+ * @return [ValidationResult.Success] when no issues were found, or
+ *   [ValidationResult.Failure] with a non-empty list of diagnostics.
+ */
+public fun validate(
+    markup: String,
+    spec: Iterable<MiniMessagePlaceholder<*>>,
+): ValidationResult {
+    val specList = spec.toList()
+    val malformed = detectMalformedTags(markup, specList)
+    val (missing, extra) = detectPlaceholderMismatches(markup, specList)
+    val diagnostics = malformed + missing + extra
+    return if (diagnostics.isEmpty()) ValidationResult.Success else ValidationResult.Failure(diagnostics)
+}
+
+/**
+ * Validates this template's markup against its own declared placeholders.
+ *
+ * Convenience wrapper over [validate] that extracts the spec from the template's
+ * `@PublishedApi internal` [MiniTemplate.placeholders] map without exposing a new public surface.
+ *
+ * @return [ValidationResult.Success] when the markup is well-formed and every declared placeholder
+ *   has a corresponding tag (and vice versa); [ValidationResult.Failure] otherwise.
+ */
+public fun MiniTemplate.validate(): ValidationResult = validate(markup, placeholders.values)
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Pass 1: strict-mode parse to detect malformed or unclosed tags.
+ *
+ * Spec names are resolved as self-closing tags so they never trigger a false "unclosed tag"
+ * diagnostic under strict mode. Returns at most one [MiniMessageDiagnostic.MalformedTag]
+ * because Adventure's strict parser throws on the first violation.
+ */
+private fun detectMalformedTags(
+    markup: String,
+    spec: List<MiniMessagePlaceholder<*>>,
+): List<MiniMessageDiagnostic.MalformedTag> {
+    val strictParser = MiniMessage.builder().strict(true).build()
+    val specResolver = buildSpecNameResolver(spec)
+    val combined = TagResolver.resolver(TagResolver.standard(), specResolver)
+    return try {
+        strictParser.deserialize(markup, combined)
+        emptyList()
+    } catch (e: ParsingException) {
+        listOf(
+            MiniMessageDiagnostic.MalformedTag(
+                message = e.detailMessage() ?: e.message ?: "",
+                startIndex = e.startIndex(),
+                endIndex = e.endIndex(),
+            ),
+        )
+    }
+}
+
+/**
+ * Pass 2: lenient parse with a recording resolver to enumerate tags referenced in the markup.
+ *
+ * Records every non-standard tag name (i.e. names for which [TagResolver.standard] returns
+ * `false` from [TagResolver.has]) encountered by the recording resolver. Non-standard names
+ * are exactly the placeholder-like tags; standard Adventure formatting tags are excluded.
+ *
+ * Returns a pair of (missing diagnostics, extra diagnostics):
+ * - missing: spec names absent from the recorded tags (in spec declaration order).
+ * - extra: recorded names absent from the spec (in markup-encounter order).
+ */
+private fun detectPlaceholderMismatches(
+    markup: String,
+    spec: List<MiniMessagePlaceholder<*>>,
+): Pair<List<MiniMessageDiagnostic.MissingPlaceholder>, List<MiniMessageDiagnostic.ExtraPlaceholder>> {
+    val recorder = RecordingTagResolver()
+    val combined = TagResolver.resolver(TagResolver.standard(), recorder)
+    MiniMessage.miniMessage().deserialize(markup, combined)
+
+    val tagsInMarkup = recorder.encounteredNames
+    val specNames = spec.map { it.name }.toSet()
+
+    val missing =
+        spec
+        .filter { it.name !in tagsInMarkup }
+        .map { MiniMessageDiagnostic.MissingPlaceholder(it.name) }
+
+    val extra =
+        tagsInMarkup
+        .filter { it !in specNames }
+        .map { MiniMessageDiagnostic.ExtraPlaceholder(it) }
+
+    return missing to extra
+}
+
+/**
+ * Builds a [TagResolver] that resolves each spec name as a self-closing inserting tag.
+ *
+ * Self-closing tags are never required to be explicitly closed, so they do not produce
+ * false-positive "unclosed tag" diagnostics under strict mode.
+ */
+private fun buildSpecNameResolver(spec: List<MiniMessagePlaceholder<*>>): TagResolver {
+    if (spec.isEmpty()) return TagResolver.empty()
+    val selfClosingTag = Tag.selfClosingInserting(Component.empty())
+    val resolvers = spec.map { TagResolver.resolver(it.name, selfClosingTag) }
+    return TagResolver.resolver(*resolvers.toTypedArray())
+}
+
+/**
+ * A [TagResolver] that records the names of every non-standard tag it is asked to resolve.
+ *
+ * [has] returns `true` for all names so that Adventure calls [resolve] for every `<tag>` in
+ * the markup. [resolve] records the name only when [TagResolver.standard] does not claim it,
+ * preventing standard Adventure formatting tags from appearing in the recorded set.
+ * [resolve] returns `null` so the lenient parser silently skips each tag.
+ *
+ * Tags are recorded in encounter order (the order [resolve] is first called for each name).
+ */
+private class RecordingTagResolver : TagResolver {
+    /** Tag names encountered in the markup, in the order they were first seen. */
+    val encounteredNames: LinkedHashSet<String> = LinkedHashSet()
+
+    override fun resolve(
+        name: String,
+        arguments: ArgumentQueue,
+        ctx: Context,
+    ): Tag? {
+        if (!TagResolver.standard().has(name)) {
+            encounteredNames.add(name)
+        }
+        return null
+    }
+
+    override fun has(name: String): Boolean = true
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidation.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidation.kt
@@ -117,10 +117,10 @@ private fun detectPlaceholderMismatches(
     val specNames = spec.map { it.name }.toSet()
     val recorder = RecordingTagResolver(specNames)
     val combined = TagResolver.resolver(TagResolver.standard(), recorder)
-    // The lenient parser is designed not to throw ParsingException, but Adventure's internals
-    // can still throw RuntimeException (e.g. StringIndexOutOfBoundsException) on certain
-    // edge-case malformed inputs (PaperMC/adventure#1011). Catch it so validate() never
-    // propagates an exception; the recording side-effects gathered so far remain usable.
+    // The lenient parser is designed not to throw ParsingException, but Adventure's parser
+    // internals can still throw RuntimeException (e.g. StringIndexOutOfBoundsException) on
+    // edge-case malformed inputs. Guard defensively so validate() never propagates an exception;
+    // the recording side-effects gathered so far remain usable.
     try {
         MiniMessage.miniMessage().deserialize(markup, combined)
     } catch (_: RuntimeException) {

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
@@ -35,7 +35,7 @@ import io.github.lmliam.kotventure.minimessage.placeholder as createPlaceholder
  * @throws IllegalArgumentException when [markup] is blank.
  */
 public abstract class MiniTemplate(
-    private val markup: String,
+    internal val markup: String,
 ) {
     init {
         require(markup.isNotBlank()) { "MiniMessage template markup must not be blank." }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/MiniMessageDiagnostic.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/MiniMessageDiagnostic.kt
@@ -3,27 +3,27 @@ package io.github.lmliam.kotventure.minimessage.validation
 import net.kyori.adventure.text.minimessage.ParsingException
 
 /**
- * A single diagnostic produced by [io.github.lmliam.kotventure.minimessage.validate].
+ * A single diagnostic produced by [validate].
  *
  * Sealed so callers can exhaustively handle every diagnostic kind.
  */
-public sealed class MiniMessageDiagnostic {
+public sealed interface MiniMessageDiagnostic {
     /**
-     * A tag in the markup is malformed or was not explicitly closed when strict parsing requires it.
+     * A tag in the input is malformed or was not explicitly closed when strict parsing requires it.
      *
      * @property message Human-readable description from Adventure's parser. Prefers
      *   [ParsingException.detailMessage] (no location noise); falls back to
      *   [ParsingException.getMessage] if `detailMessage` is null.
-     * @property startIndex Start index into the original markup string, or [LOCATION_UNKNOWN] when
+     * @property startIndex Start index into the original input string, or [LOCATION_UNKNOWN] when
      *   Adventure did not report a source position.
-     * @property endIndex End index into the original markup string, or [LOCATION_UNKNOWN] when
+     * @property endIndex End index into the original input string, or [LOCATION_UNKNOWN] when
      *   Adventure did not report a source position.
      */
     public data class MalformedTag(
         public val message: String,
         public val startIndex: Int,
         public val endIndex: Int,
-    ) : MiniMessageDiagnostic() {
+    ) : MiniMessageDiagnostic {
         public companion object {
             /**
              * Sentinel used when Adventure did not report a source position for the malformed tag.
@@ -36,20 +36,20 @@ public sealed class MiniMessageDiagnostic {
     }
 
     /**
-     * A placeholder declared in the spec has no corresponding tag in the markup.
+     * A placeholder declared in the placeholders list has no corresponding tag in the input.
      *
-     * @property name The placeholder's tag name as declared in the spec.
+     * @property name The placeholder's tag name as declared in the placeholders list.
      */
     public data class MissingPlaceholder(
         public val name: String,
-    ) : MiniMessageDiagnostic()
+    ) : MiniMessageDiagnostic
 
     /**
-     * A placeholder tag appears in the markup but has no entry in the spec.
+     * A placeholder tag appears in the input but has no entry in the placeholders list.
      *
-     * @property name The tag name found in the markup.
+     * @property name The tag name found in the input.
      */
     public data class ExtraPlaceholder(
         public val name: String,
-    ) : MiniMessageDiagnostic()
+    ) : MiniMessageDiagnostic
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/MiniMessageDiagnostic.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/MiniMessageDiagnostic.kt
@@ -1,0 +1,55 @@
+package io.github.lmliam.kotventure.minimessage.validation
+
+import net.kyori.adventure.text.minimessage.ParsingException
+
+/**
+ * A single diagnostic produced by [io.github.lmliam.kotventure.minimessage.validate].
+ *
+ * Sealed so callers can exhaustively handle every diagnostic kind.
+ */
+public sealed class MiniMessageDiagnostic {
+    /**
+     * A tag in the markup is malformed or was not explicitly closed when strict parsing requires it.
+     *
+     * @property message Human-readable description from Adventure's parser. Prefers
+     *   [ParsingException.detailMessage] (no location noise); falls back to
+     *   [ParsingException.getMessage] if `detailMessage` is null.
+     * @property startIndex Start index into the original markup string, or [LOCATION_UNKNOWN] when
+     *   Adventure did not report a source position.
+     * @property endIndex End index into the original markup string, or [LOCATION_UNKNOWN] when
+     *   Adventure did not report a source position.
+     */
+    public data class MalformedTag(
+        public val message: String,
+        public val startIndex: Int,
+        public val endIndex: Int,
+    ) : MiniMessageDiagnostic() {
+        public companion object {
+            /**
+             * Sentinel used when Adventure did not report a source position for the malformed tag.
+             *
+             * Mirrors [ParsingException.LOCATION_UNKNOWN] directly so the value is always
+             * Adventure-derived. Do not hardcode `-1`; read this constant instead.
+             */
+            public val LOCATION_UNKNOWN: Int = ParsingException.LOCATION_UNKNOWN
+        }
+    }
+
+    /**
+     * A placeholder declared in the spec has no corresponding tag in the markup.
+     *
+     * @property name The placeholder's tag name as declared in the spec.
+     */
+    public data class MissingPlaceholder(
+        public val name: String,
+    ) : MiniMessageDiagnostic()
+
+    /**
+     * A placeholder tag appears in the markup but has no entry in the spec.
+     *
+     * @property name The tag name found in the markup.
+     */
+    public data class ExtraPlaceholder(
+        public val name: String,
+    ) : MiniMessageDiagnostic()
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/MiniMessageValidator.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/MiniMessageValidator.kt
@@ -16,9 +16,10 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
  * Diagnostic ordering: malformed tags first, then missing placeholders in [placeholders]
  * declaration order, then extra placeholders in input-encounter order.
  *
- * [ParsingException] is the expected signal for strict-mode violations. Other [RuntimeException]
- * subclasses can be thrown by Adventure's parser internals on severely malformed inputs; they are
- * caught to preserve the no-throw contract.
+ * [ParsingException] is the documented signal for strict-mode violations and is reported as a
+ * malformed-tag diagnostic. The lenient parser is not contractually guaranteed exception-free for
+ * every input, so any other [RuntimeException] is turned into a diagnostic rather than propagated —
+ * `validate` never throws for the caller.
  *
  * @param input the MiniMessage input string to validate.
  * @param placeholders the declared placeholders the input is expected to use.
@@ -43,9 +44,9 @@ internal fun runValidation(
  * [MiniMessageDiagnostic.MalformedTag] because Adventure's strict parser throws on the first
  * violation.
  *
- * [ParsingException] is the expected signal for strict-mode violations. Other [RuntimeException]
- * subclasses can be thrown by Adventure's parser internals on severely malformed inputs; they are
- * caught to preserve the no-throw contract of the public entry point.
+ * [ParsingException] is the documented signal for strict-mode violations. Any other
+ * [RuntimeException] from the parser is also reported as a malformed-tag diagnostic (with an unknown
+ * position) so a crash-inducing input is never silently treated as valid and `validate` never throws.
  */
 private fun detectMalformedTags(
     input: String,
@@ -65,9 +66,16 @@ private fun detectMalformedTags(
                 endIndex = e.endIndex(),
             ),
         )
-    } catch (_: RuntimeException) {
-        // Adventure parser bug on edge-case malformed input — no position info available.
-        emptyList()
+    } catch (e: RuntimeException) {
+        // The parser rejected the input outside the documented ParsingException path (no position
+        // info available). Report it as malformed so it is never silently treated as valid.
+        listOf(
+            MiniMessageDiagnostic.MalformedTag(
+                message = e.message ?: "Input rejected by the MiniMessage parser.",
+                startIndex = MiniMessageDiagnostic.MalformedTag.LOCATION_UNKNOWN,
+                endIndex = MiniMessageDiagnostic.MalformedTag.LOCATION_UNKNOWN,
+            ),
+        )
     }
 }
 
@@ -93,10 +101,9 @@ private fun detectPlaceholderMismatches(
     val specNames = placeholders.map { it.name }.toSet()
     val recorder = RecordingTagResolver(specNames)
     val combined = TagResolver.resolver(TagResolver.standard(), recorder)
-    // The lenient parser is designed not to throw ParsingException, but Adventure's parser
-    // internals can still throw RuntimeException (e.g. StringIndexOutOfBoundsException) on
-    // edge-case malformed inputs. Guard defensively so validate() never propagates an exception;
-    // the recording side-effects gathered so far remain usable.
+    // The lenient parser is not contractually guaranteed exception-free for every input. Guard so
+    // validate() never propagates an exception; any input that crashes the parser is already
+    // reported as malformed by the strict pass, and the recorder's side-effects so far remain usable.
     try {
         MiniMessage.miniMessage().deserialize(input, combined)
     } catch (_: RuntimeException) {

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/MiniMessageValidator.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/MiniMessageValidator.kt
@@ -1,0 +1,132 @@
+package io.github.lmliam.kotventure.minimessage.validation
+
+import io.github.lmliam.kotventure.minimessage.MiniMessagePlaceholder
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.minimessage.ParsingException
+import net.kyori.adventure.text.minimessage.tag.Tag
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+
+/**
+ * Runs the two-pass validation algorithm and returns the merged [ValidationResult].
+ *
+ * - **Pass 1** detects malformed or unclosed tags via a strict-mode parse.
+ * - **Pass 2** detects placeholder mismatches via a recording lenient parse.
+ *
+ * Diagnostic ordering: malformed tags first, then missing placeholders in [placeholders]
+ * declaration order, then extra placeholders in input-encounter order.
+ *
+ * [ParsingException] is the expected signal for strict-mode violations. Other [RuntimeException]
+ * subclasses can be thrown by Adventure's parser internals on severely malformed inputs; they are
+ * caught to preserve the no-throw contract.
+ *
+ * @param input the MiniMessage input string to validate.
+ * @param placeholders the declared placeholders the input is expected to use.
+ * @return [ValidationResult.Success] when no issues were found, or [ValidationResult.Failure]
+ *   with a non-empty list of diagnostics.
+ */
+internal fun runValidation(
+    input: String,
+    placeholders: List<MiniMessagePlaceholder<*>>,
+): ValidationResult {
+    val malformed = detectMalformedTags(input, placeholders)
+    val (missing, extra) = detectPlaceholderMismatches(input, placeholders)
+    val diagnostics = malformed + missing + extra
+    return if (diagnostics.isEmpty()) ValidationResult.Success else ValidationResult.Failure(diagnostics)
+}
+
+/**
+ * Pass 1: strict-mode parse to detect malformed or unclosed tags.
+ *
+ * Placeholder names are resolved as self-closing tags so they never trigger a false
+ * "unclosed tag" diagnostic under strict mode. Returns at most one
+ * [MiniMessageDiagnostic.MalformedTag] because Adventure's strict parser throws on the first
+ * violation.
+ *
+ * [ParsingException] is the expected signal for strict-mode violations. Other [RuntimeException]
+ * subclasses can be thrown by Adventure's parser internals on severely malformed inputs; they are
+ * caught to preserve the no-throw contract of the public entry point.
+ */
+private fun detectMalformedTags(
+    input: String,
+    placeholders: List<MiniMessagePlaceholder<*>>,
+): List<MiniMessageDiagnostic.MalformedTag> {
+    val strictParser = MiniMessage.builder().strict(true).build()
+    val placeholderResolver = buildPlaceholderNameResolver(placeholders)
+    val combined = TagResolver.resolver(TagResolver.standard(), placeholderResolver)
+    return try {
+        strictParser.deserialize(input, combined)
+        emptyList()
+    } catch (e: ParsingException) {
+        listOf(
+            MiniMessageDiagnostic.MalformedTag(
+                message = e.detailMessage() ?: e.message ?: "",
+                startIndex = e.startIndex(),
+                endIndex = e.endIndex(),
+            ),
+        )
+    } catch (_: RuntimeException) {
+        // Adventure parser bug on edge-case malformed input — no position info available.
+        emptyList()
+    }
+}
+
+/**
+ * Pass 2: lenient parse with a recording resolver to enumerate tags referenced in the input.
+ *
+ * Records a tag name when it is either non-standard (i.e. [TagResolver.standard] does not
+ * claim it) **or** present in the placeholders. The second condition handles the edge case where
+ * a placeholder shares its name with a standard Adventure tag (e.g. `"gold"`): without it, the
+ * recording resolver would silently skip `<gold>` and produce a false `MissingPlaceholder`.
+ *
+ * Standard tags whose names are NOT in the placeholders are still excluded, preserving the
+ * behaviour that prevents ordinary formatting tags from showing up as extra placeholders.
+ *
+ * Returns a pair of (missing diagnostics, extra diagnostics):
+ * - missing: placeholder names absent from the recorded tags (in declaration order).
+ * - extra: recorded names absent from the placeholders (in input-encounter order).
+ */
+private fun detectPlaceholderMismatches(
+    input: String,
+    placeholders: List<MiniMessagePlaceholder<*>>,
+): Pair<List<MiniMessageDiagnostic.MissingPlaceholder>, List<MiniMessageDiagnostic.ExtraPlaceholder>> {
+    val specNames = placeholders.map { it.name }.toSet()
+    val recorder = RecordingTagResolver(specNames)
+    val combined = TagResolver.resolver(TagResolver.standard(), recorder)
+    // The lenient parser is designed not to throw ParsingException, but Adventure's parser
+    // internals can still throw RuntimeException (e.g. StringIndexOutOfBoundsException) on
+    // edge-case malformed inputs. Guard defensively so validate() never propagates an exception;
+    // the recording side-effects gathered so far remain usable.
+    try {
+        MiniMessage.miniMessage().deserialize(input, combined)
+    } catch (_: RuntimeException) {
+        // Proceed with whatever the recorder captured before the throw.
+    }
+
+    val tagsInInput = recorder.encounteredNames
+
+    val missing =
+        placeholders
+            .filter { it.name !in tagsInInput }
+            .map { MiniMessageDiagnostic.MissingPlaceholder(it.name) }
+
+    val extra =
+        tagsInInput
+            .filter { it !in specNames }
+            .map { MiniMessageDiagnostic.ExtraPlaceholder(it) }
+
+    return missing to extra
+}
+
+/**
+ * Builds a [TagResolver] that resolves each placeholder name as a self-closing inserting tag.
+ *
+ * Self-closing tags are never required to be explicitly closed, so they do not produce
+ * false-positive "unclosed tag" diagnostics under strict mode.
+ */
+private fun buildPlaceholderNameResolver(placeholders: List<MiniMessagePlaceholder<*>>): TagResolver {
+    if (placeholders.isEmpty()) return TagResolver.empty()
+    val selfClosingTag = Tag.selfClosingInserting(Component.empty())
+    val resolvers = placeholders.map { TagResolver.resolver(it.name, selfClosingTag) }
+    return TagResolver.resolver(*resolvers.toTypedArray())
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/RecordingTagResolver.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/RecordingTagResolver.kt
@@ -1,0 +1,45 @@
+package io.github.lmliam.kotventure.minimessage.validation
+
+import net.kyori.adventure.text.minimessage.Context
+import net.kyori.adventure.text.minimessage.tag.Tag
+import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+
+/**
+ * A [TagResolver] that records the names of tags it is asked to resolve.
+ *
+ * [has] returns `true` for all names so that Adventure calls [resolve] for every `<tag>` in
+ * the input. [resolve] records the name when either:
+ * - [TagResolver.standard] does not claim it (it's a custom/unknown tag), or
+ * - it appears in [specNames] (a spec placeholder whose name collides with a standard tag).
+ *
+ * This dual condition prevents standard formatting tags (e.g. `<red>`, `<bold>`) from polluting
+ * the recorded set, while still recording spec-named placeholders that share a standard tag
+ * name (e.g. a placeholder declared as `"gold"`).
+ *
+ * [resolve] returns `null` so the lenient parser silently skips each tag.
+ *
+ * Tags are recorded in encounter order (the order [resolve] is first called for each name).
+ *
+ * @param specNames the set of placeholder names declared in the spec; used to force-record
+ *   names that would otherwise be filtered by the standard-tag check.
+ */
+internal class RecordingTagResolver(
+    private val specNames: Set<String>,
+) : TagResolver {
+    /** Tag names encountered in the input, in the order they were first seen. */
+    val encounteredNames: LinkedHashSet<String> = LinkedHashSet()
+
+    override fun resolve(
+        name: String,
+        arguments: ArgumentQueue,
+        ctx: Context,
+    ): Tag? {
+        if (name in specNames || !TagResolver.standard().has(name)) {
+            encounteredNames.add(name)
+        }
+        return null
+    }
+
+    override fun has(name: String): Boolean = true
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/ValidationResult.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/ValidationResult.kt
@@ -1,42 +1,44 @@
 package io.github.lmliam.kotventure.minimessage.validation
 
 /**
- * The result of a [io.github.lmliam.kotventure.minimessage.validate] call.
+ * The result of a [validate] call.
  *
- * Either [Success] (markup is well-formed and every spec placeholder is present) or
+ * Either [Success] (input is well-formed and every declared placeholder is present) or
  * [Failure] (one or more [MiniMessageDiagnostic] were found).
  */
-public sealed class ValidationResult {
+public sealed interface ValidationResult {
+    /** `true` when this result is [Success]; `false` otherwise. */
+    public val isSuccess: Boolean get() = this is Success
+
+    /** `true` when this result is [Failure]; `false` otherwise. */
+    public val isFailure: Boolean get() = this is Failure
+
     /**
-     * Validation found no issues: the markup is well-formed and every declared placeholder
-     * has a corresponding tag in the markup (and vice versa).
+     * Validation found no issues: the input is well-formed and every declared placeholder
+     * has a corresponding tag in the input (and vice versa).
      */
-    public data object Success : ValidationResult()
+    public data object Success : ValidationResult
 
     /**
      * Validation found one or more issues.
      *
      * @property diagnostics Non-empty list of diagnostics. Ordering guarantee: malformed-tag
-     *   diagnostics appear first, then missing-placeholder diagnostics in spec declaration order,
-     *   then extra-placeholder diagnostics in the order the tags were encountered in the markup.
+     *   diagnostics appear first, then missing-placeholder diagnostics in placeholder declaration
+     *   order, then extra-placeholder diagnostics in the order the tags were encountered in the
+     *   input.
      */
-    public data class Failure(
+    @ConsistentCopyVisibility
+    public data class Failure private constructor(
         public val diagnostics: List<MiniMessageDiagnostic>,
-    ) : ValidationResult() {
+    ) : ValidationResult {
         init {
             require(diagnostics.isNotEmpty()) { "Failure must carry at least one diagnostic." }
         }
+
+        public companion object {
+            /** Creates a [Failure] with a defensive copy of [diagnostics]. */
+            public operator fun invoke(diagnostics: List<MiniMessageDiagnostic>): Failure =
+                Failure(diagnostics.toList())
+        }
     }
 }
-
-/**
- * `true` when this result is [ValidationResult.Success]; `false` otherwise.
- */
-public val ValidationResult.isSuccess: Boolean
-    get() = this is ValidationResult.Success
-
-/**
- * `true` when this result is [ValidationResult.Failure]; `false` otherwise.
- */
-public val ValidationResult.isFailure: Boolean
-    get() = this is ValidationResult.Failure

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/ValidationResult.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/ValidationResult.kt
@@ -1,0 +1,42 @@
+package io.github.lmliam.kotventure.minimessage.validation
+
+/**
+ * The result of a [io.github.lmliam.kotventure.minimessage.validate] call.
+ *
+ * Either [Success] (markup is well-formed and every spec placeholder is present) or
+ * [Failure] (one or more [MiniMessageDiagnostic] were found).
+ */
+public sealed class ValidationResult {
+    /**
+     * Validation found no issues: the markup is well-formed and every declared placeholder
+     * has a corresponding tag in the markup (and vice versa).
+     */
+    public data object Success : ValidationResult()
+
+    /**
+     * Validation found one or more issues.
+     *
+     * @property diagnostics Non-empty list of diagnostics. Ordering guarantee: malformed-tag
+     *   diagnostics appear first, then missing-placeholder diagnostics in spec declaration order,
+     *   then extra-placeholder diagnostics in the order the tags were encountered in the markup.
+     */
+    public data class Failure(
+        public val diagnostics: List<MiniMessageDiagnostic>,
+    ) : ValidationResult() {
+        init {
+            require(diagnostics.isNotEmpty()) { "Failure must carry at least one diagnostic." }
+        }
+    }
+}
+
+/**
+ * `true` when this result is [ValidationResult.Success]; `false` otherwise.
+ */
+public val ValidationResult.isSuccess: Boolean
+    get() = this is ValidationResult.Success
+
+/**
+ * `true` when this result is [ValidationResult.Failure]; `false` otherwise.
+ */
+public val ValidationResult.isFailure: Boolean
+    get() = this is ValidationResult.Failure

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidationTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidationTest.kt
@@ -1,0 +1,338 @@
+package io.github.lmliam.kotventure.minimessage
+
+import io.github.lmliam.kotventure.minimessage.validation.MiniMessageDiagnostic
+import io.github.lmliam.kotventure.minimessage.validation.ValidationResult
+import io.github.lmliam.kotventure.minimessage.validation.isFailure
+import io.github.lmliam.kotventure.minimessage.validation.isSuccess
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.ParsingException
+
+// ---------------------------------------------------------------------------
+// Fixture templates
+// ---------------------------------------------------------------------------
+
+private object ValidationWelcomeTemplate : MiniTemplate("<gold>Welcome <player>, <count> new messages</gold>") {
+    val player = placeholder<Component>("player")
+    val count = placeholder<Int>("count")
+}
+
+private object ValidationExtraTagTemplate : MiniTemplate("<gold>Hello <player> <oops></gold>") {
+    val player = placeholder<String>("player")
+}
+
+class MiniMessageValidationTest :
+    StringSpec(
+        {
+            // ---------------------------------------------------------------
+            // AC1–AC4: Happy paths
+            // ---------------------------------------------------------------
+
+            "well-formed markup with all placeholders returns Success" {
+                val player = placeholder<Component>("player")
+                val count = placeholder<Int>("count")
+
+                val result =
+                    validate(
+                    markup = "<gold>Welcome <player>, <count> new messages</gold>",
+                    spec = listOf(player, count),
+                )
+
+                result shouldBe ValidationResult.Success
+            }
+
+            "markup with no spec and no placeholder tags returns Success" {
+                val result =
+                    validate(
+                    markup = "<gold>Hello world</gold>",
+                    spec = emptyList(),
+                )
+
+                result shouldBe ValidationResult.Success
+            }
+
+            // ---------------------------------------------------------------
+            // AC1: Malformed tag detection
+            // ---------------------------------------------------------------
+
+            "unclosed standard tag returns Failure with MalformedTag diagnostic" {
+                val result =
+                    validate(
+                    markup = "<gold>Hello world",
+                    spec = emptyList(),
+                )
+
+                // <gold> without </gold> is well-formed in lenient mode but strict mode requires close
+                // — however Adventure strict mode only throws for unclosed child-allowing tags at EOF.
+                // <gold> IS a child-allowing tag, so it DOES throw in strict mode.
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                failure.diagnostics shouldHaveSize 1
+                failure.diagnostics[0].shouldBeInstanceOf<MiniMessageDiagnostic.MalformedTag>()
+            }
+
+            "MalformedTag carries non-unknown start and end index when Adventure reports location" {
+                // Adventure reports position info for unclosed child-allowing tags at end-of-string.
+                val result =
+                    validate(
+                    markup = "<gold>Hello world",
+                    spec = emptyList(),
+                )
+
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                val malformed = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MalformedTag>()
+                malformed shouldHaveSize 1
+                // Adventure provides start/end indices for this error — neither should be LOCATION_UNKNOWN.
+                (malformed[0].startIndex != MiniMessageDiagnostic.MalformedTag.LOCATION_UNKNOWN) shouldBe true
+                (malformed[0].endIndex != MiniMessageDiagnostic.MalformedTag.LOCATION_UNKNOWN) shouldBe true
+            }
+
+            "unclosed non-standard-tag in markup produces MalformedTag with message" {
+                val player = placeholder<Component>("player")
+
+                // <player> resolves as self-closing — will NOT trigger malformed
+                // <gold> without close WILL trigger malformed under strict mode
+                val result =
+                    validate(
+                    markup = "<gold><player>joined",
+                    spec = listOf(player),
+                )
+
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                val malformed = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MalformedTag>()
+                malformed shouldHaveSize 1
+                malformed[0].message.isNotEmpty() shouldBe true
+            }
+
+            "MalformedTag.LOCATION_UNKNOWN sentinel is sourced from Adventure not hardcoded" {
+                // Verify the sentinel is mirrored from Adventure rather than hardcoded.
+                // Changing this value in Adventure would then be caught at compile time.
+                MiniMessageDiagnostic.MalformedTag.LOCATION_UNKNOWN shouldBe ParsingException.LOCATION_UNKNOWN
+            }
+
+            // ---------------------------------------------------------------
+            // AC2: Missing placeholder detection
+            // ---------------------------------------------------------------
+
+            "placeholder in spec but absent from markup returns MissingPlaceholder" {
+                val player = placeholder<Component>("player")
+                val count = placeholder<Int>("count")
+
+                val result =
+                    validate(
+                    markup = "<player> joined",
+                    spec = listOf(player, count),
+                )
+
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                val missing = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MissingPlaceholder>()
+                missing shouldHaveSize 1
+                missing[0].name shouldBe "count"
+            }
+
+            // ---------------------------------------------------------------
+            // AC3: Extra placeholder detection
+            // ---------------------------------------------------------------
+
+            "placeholder tag in markup but not in spec returns ExtraPlaceholder" {
+                val player = placeholder<Component>("player")
+
+                val result =
+                    validate(
+                    markup = "<player> joined with <oops>",
+                    spec = listOf(player),
+                )
+
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                val extra = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.ExtraPlaceholder>()
+                extra shouldHaveSize 1
+                extra[0].name shouldBe "oops"
+            }
+
+            // ---------------------------------------------------------------
+            // AC4: Multiple diagnostics; ordering
+            // ---------------------------------------------------------------
+
+            "placeholder present in both markup and spec is not flagged while unspecced tag is reported as extra" {
+                val player = placeholder<Component>("player")
+
+                val result =
+                    validate(
+                    markup = "<player> <missing-one> <extra-one>",
+                    spec = listOf(player, placeholder<String>("missing-one")),
+                )
+
+                // <player> and <missing-one> are in both spec and markup — neither is missing or extra.
+                // <extra-one> is in markup but not in spec — reported as ExtraPlaceholder.
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                val missing = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MissingPlaceholder>()
+                val extra = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.ExtraPlaceholder>()
+                missing shouldHaveSize 0
+                extra shouldHaveSize 1
+                extra[0].name shouldBe "extra-one"
+            }
+
+            "all three diagnostic kinds appear in one markup — malformed then missing then extra" {
+                val player = placeholder<Component>("player")
+
+                // <gold> unclosed -> malformed
+                // <player> declared but absent -> missing
+                // <extra> in markup but not spec -> extra
+                val result =
+                    validate(
+                    markup = "<gold>Hello <extra>",
+                    spec = listOf(player),
+                )
+
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                val malformed = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MalformedTag>()
+                val missing = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MissingPlaceholder>()
+                val extra = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.ExtraPlaceholder>()
+
+                malformed shouldHaveSize 1
+                missing shouldHaveSize 1
+                extra shouldHaveSize 1
+                missing[0].name shouldBe "player"
+                extra[0].name shouldBe "extra"
+
+                // Ordering: malformed first, then missing, then extra
+                val malformedIdx = failure.diagnostics.indexOf(malformed[0])
+                val missingIdx = failure.diagnostics.indexOf(missing[0])
+                val extraIdx = failure.diagnostics.indexOf(extra[0])
+                (malformedIdx < missingIdx) shouldBe true
+                (missingIdx < extraIdx) shouldBe true
+            }
+
+            // ---------------------------------------------------------------
+            // Standard-tag filter
+            // ---------------------------------------------------------------
+
+            "standard Adventure tags are not reported as extra placeholders" {
+                val result =
+                    validate(
+                    markup = "<gold>Hello</gold> <bold>world</bold>",
+                    spec = emptyList(),
+                )
+
+                // <gold> and <bold> are standard tags; strict mode still requires close — both are
+                // closed properly here, so no malformed. No spec -> no missing. No extra either.
+                result shouldBe ValidationResult.Success
+            }
+
+            "standard tags with no spec and one extra non-standard tag reports only extra" {
+                val result =
+                    validate(
+                    markup = "<gold>Hello</gold> <my-placeholder>",
+                    spec = emptyList(),
+                )
+
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                val extra = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.ExtraPlaceholder>()
+                extra shouldHaveSize 1
+                extra[0].name shouldBe "my-placeholder"
+            }
+
+            // ---------------------------------------------------------------
+            // MiniTemplate extension
+            // ---------------------------------------------------------------
+
+            "MiniTemplate.validate() returns Success for a correct template" {
+                val result = ValidationWelcomeTemplate.validate()
+
+                result shouldBe ValidationResult.Success
+            }
+
+            "MiniTemplate.validate() returns Failure when markup has extra tag" {
+                val result = ValidationExtraTagTemplate.validate()
+
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                val extra = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.ExtraPlaceholder>()
+                extra shouldHaveSize 1
+                extra[0].name shouldBe "oops"
+            }
+
+            // ---------------------------------------------------------------
+            // Extension properties
+            // ---------------------------------------------------------------
+
+            "ValidationResult.isSuccess is true for Success and false for Failure" {
+                val player = placeholder<Component>("player")
+                val success = validate("<player>", listOf(player))
+                val failure = validate("<extra>", emptyList<MiniMessagePlaceholder<*>>())
+
+                success.isSuccess shouldBe true
+                success.isFailure shouldBe false
+                failure.isSuccess shouldBe false
+                failure.isFailure shouldBe true
+            }
+
+            "ValidationResult.isFailure is true for Failure and false for Success" {
+                val failure = validate("<extra>", emptyList<MiniMessagePlaceholder<*>>())
+                val success = ValidationResult.Success
+
+                failure.isFailure shouldBe true
+                success.isFailure shouldBe false
+            }
+
+            // ---------------------------------------------------------------
+            // Model invariants
+            // ---------------------------------------------------------------
+
+            "Failure requires non-empty diagnostics list" {
+                shouldThrow<IllegalArgumentException> {
+                    ValidationResult.Failure(emptyList())
+                }
+            }
+
+            // ---------------------------------------------------------------
+            // Ordering guarantees
+            // ---------------------------------------------------------------
+
+            "missing placeholders are emitted in spec declaration order" {
+                val alpha = placeholder<String>("alpha")
+                val beta = placeholder<String>("beta")
+                val gamma = placeholder<String>("gamma")
+
+                val result =
+                    validate(
+                    markup = "<gold>No placeholders</gold>",
+                    spec = listOf(alpha, beta, gamma),
+                )
+
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                val missing = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MissingPlaceholder>()
+                missing.map { it.name } shouldBe listOf("alpha", "beta", "gamma")
+            }
+
+            "extra placeholders are emitted in markup-encounter order" {
+                val result =
+                    validate(
+                    markup = "<gold>Hello</gold> <first> then <second> then <third>",
+                    spec = emptyList(),
+                )
+
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                val extra = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.ExtraPlaceholder>()
+                extra.map { it.name } shouldBe listOf("first", "second", "third")
+            }
+
+            // ---------------------------------------------------------------
+            // Edge cases
+            // ---------------------------------------------------------------
+
+            "duplicate placeholder tag in markup is recorded only once" {
+                val player = placeholder<Component>("player")
+
+                val result =
+                    validate(
+                    markup = "<player> joined, then <player> left",
+                    spec = listOf(player),
+                )
+
+                result shouldBe ValidationResult.Success
+            }
+        },
+    )

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidationTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidationTest.kt
@@ -8,6 +8,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.minimessage.ParsingException
@@ -86,8 +87,8 @@ class MiniMessageValidationTest :
                 val malformed = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MalformedTag>()
                 malformed shouldHaveSize 1
                 // Adventure provides start/end indices for this error — neither should be LOCATION_UNKNOWN.
-                (malformed[0].startIndex != MiniMessageDiagnostic.MalformedTag.LOCATION_UNKNOWN) shouldBe true
-                (malformed[0].endIndex != MiniMessageDiagnostic.MalformedTag.LOCATION_UNKNOWN) shouldBe true
+                malformed[0].startIndex shouldNotBe MiniMessageDiagnostic.MalformedTag.LOCATION_UNKNOWN
+                malformed[0].endIndex shouldNotBe MiniMessageDiagnostic.MalformedTag.LOCATION_UNKNOWN
             }
 
             "unclosed non-standard-tag in markup produces MalformedTag with message" {
@@ -111,6 +112,26 @@ class MiniMessageValidationTest :
                 // Verify the sentinel is mirrored from Adventure rather than hardcoded.
                 // Changing this value in Adventure would then be caught at compile time.
                 MiniMessageDiagnostic.MalformedTag.LOCATION_UNKNOWN shouldBe ParsingException.LOCATION_UNKNOWN
+            }
+
+            // F3: LOCATION_UNKNOWN path — Adventure 5.1.1 does not expose a public API input
+            // that produces the sentinel from ParsingException.startIndex()/endIndex(); the value
+            // is passed through unmodified from Adventure. The compile-time binding above proves
+            // the constant is Adventure-derived. The test below confirms indices are forwarded as-is
+            // when Adventure DOES report a location (the non-sentinel path).
+            "MalformedTag start and end indices are passed through from Adventure without modification" {
+                val result =
+                    validate(
+                    markup = "<gold>Hello world",
+                    spec = emptyList(),
+                )
+
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                val malformed = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MalformedTag>()
+                malformed shouldHaveSize 1
+                // Adventure reports non-sentinel indices here; verify they are forwarded verbatim.
+                malformed[0].startIndex shouldNotBe MiniMessageDiagnostic.MalformedTag.LOCATION_UNKNOWN
+                malformed[0].endIndex shouldNotBe MiniMessageDiagnostic.MalformedTag.LOCATION_UNKNOWN
             }
 
             // ---------------------------------------------------------------
@@ -333,6 +354,83 @@ class MiniMessageValidationTest :
                 )
 
                 result shouldBe ValidationResult.Success
+            }
+
+            // ---------------------------------------------------------------
+            // F2 regression: placeholder whose name collides with a standard tag
+            // ---------------------------------------------------------------
+
+            "placeholder named same as standard tag is not falsely reported as MissingPlaceholder when used in markup" {
+                // 'gold' is a standard Adventure colour tag.  A spec placeholder with that name
+                // must be recognised as present when <gold> appears in the markup.
+                val gold = placeholder<String>("gold")
+
+                val result =
+                    validate(
+                    markup = "<gold>text</gold>",
+                    spec = listOf(gold),
+                )
+
+                // No MissingPlaceholder("gold") — the tag IS in the markup.
+                result shouldBe ValidationResult.Success
+            }
+
+            "placeholder named same as standard tag is reported as MissingPlaceholder when absent from markup" {
+                val gold = placeholder<String>("gold")
+
+                val result =
+                    validate(
+                    markup = "<red>no gold here</red>",
+                    spec = listOf(gold),
+                )
+
+                val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
+                val missing = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MissingPlaceholder>()
+                missing shouldHaveSize 1
+                missing[0].name shouldBe "gold"
+            }
+
+            "standard tag not in spec is never reported as ExtraPlaceholder when spec has standard-named placeholder" {
+                // Only 'gold' is in the spec; <bold> is standard but not in spec.
+                // <bold> must not show up as ExtraPlaceholder.
+                val gold = placeholder<String>("gold")
+
+                val result =
+                    validate(
+                    markup = "<bold><gold>text</gold></bold>",
+                    spec = listOf(gold),
+                )
+
+                result shouldBe ValidationResult.Success
+            }
+
+            // ---------------------------------------------------------------
+            // F1 regression: validate() must never throw, even on malformed input
+            // ---------------------------------------------------------------
+
+            // Adventure's lenient parser can throw RuntimeException (e.g. StringIndexOutOfBoundsException)
+            // for certain edge-case inputs such as unclosed double-quotes in tag arguments
+            // (PaperMC/adventure#1011).  Reliably crafting such an input is version-dependent
+            // and may be silently fixed in a future Adventure release, so we verify the contract
+            // through the regular test suite passing without uncaught exceptions rather than a
+            // single fragile input.  The guard in detectPlaceholderMismatches catches RuntimeException
+            // so that validate() always returns ValidationResult rather than throwing.
+            "validate returns a result rather than throwing for markup that is well-formed in lenient mode" {
+                // This exercises the lenient-parse path (Pass 2) for a variety of inputs; none
+                // should propagate an exception.
+                val inputs =
+                    listOf(
+                    "",
+                    "plain text",
+                    "<gold>unclosed",
+                    "<unknown-tag>",
+                    "<gold arg='value'>text</gold>",
+                )
+
+                for (input in inputs) {
+                    // shouldNotThrow is enforced by the test harness — any exception fails the test.
+                    validate(input, emptyList<MiniMessagePlaceholder<*>>())
+                }
             }
         },
     )

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidationTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidationTest.kt
@@ -2,8 +2,6 @@ package io.github.lmliam.kotventure.minimessage
 
 import io.github.lmliam.kotventure.minimessage.validation.MiniMessageDiagnostic
 import io.github.lmliam.kotventure.minimessage.validation.ValidationResult
-import io.github.lmliam.kotventure.minimessage.validation.isFailure
-import io.github.lmliam.kotventure.minimessage.validation.isSuccess
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
@@ -39,8 +37,8 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    markup = "<gold>Welcome <player>, <count> new messages</gold>",
-                    spec = listOf(player, count),
+                    input = "<gold>Welcome <player>, <count> new messages</gold>",
+                    placeholders = listOf(player, count),
                 )
 
                 result shouldBe ValidationResult.Success
@@ -49,8 +47,8 @@ class MiniMessageValidationTest :
             "markup with no spec and no placeholder tags returns Success" {
                 val result =
                     validate(
-                    markup = "<gold>Hello world</gold>",
-                    spec = emptyList(),
+                    input = "<gold>Hello world</gold>",
+                    placeholders = emptyList(),
                 )
 
                 result shouldBe ValidationResult.Success
@@ -63,8 +61,8 @@ class MiniMessageValidationTest :
             "unclosed standard tag returns Failure with MalformedTag diagnostic" {
                 val result =
                     validate(
-                    markup = "<gold>Hello world",
-                    spec = emptyList(),
+                    input = "<gold>Hello world",
+                    placeholders = emptyList(),
                 )
 
                 // <gold> without </gold> is well-formed in lenient mode but strict mode requires close
@@ -79,8 +77,8 @@ class MiniMessageValidationTest :
                 // Adventure reports position info for unclosed child-allowing tags at end-of-string.
                 val result =
                     validate(
-                    markup = "<gold>Hello world",
-                    spec = emptyList(),
+                    input = "<gold>Hello world",
+                    placeholders = emptyList(),
                 )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
@@ -98,8 +96,8 @@ class MiniMessageValidationTest :
                 // <gold> without close WILL trigger malformed under strict mode
                 val result =
                     validate(
-                    markup = "<gold><player>joined",
-                    spec = listOf(player),
+                    input = "<gold><player>joined",
+                    placeholders = listOf(player),
                 )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
@@ -122,8 +120,8 @@ class MiniMessageValidationTest :
             "MalformedTag start and end indices are passed through from Adventure without modification" {
                 val result =
                     validate(
-                    markup = "<gold>Hello world",
-                    spec = emptyList(),
+                    input = "<gold>Hello world",
+                    placeholders = emptyList(),
                 )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
@@ -144,8 +142,8 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    markup = "<player> joined",
-                    spec = listOf(player, count),
+                    input = "<player> joined",
+                    placeholders = listOf(player, count),
                 )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
@@ -163,8 +161,8 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    markup = "<player> joined with <oops>",
-                    spec = listOf(player),
+                    input = "<player> joined with <oops>",
+                    placeholders = listOf(player),
                 )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
@@ -182,8 +180,8 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    markup = "<player> <missing-one> <extra-one>",
-                    spec = listOf(player, placeholder<String>("missing-one")),
+                    input = "<player> <missing-one> <extra-one>",
+                    placeholders = listOf(player, placeholder<String>("missing-one")),
                 )
 
                 // <player> and <missing-one> are in both spec and markup — neither is missing or extra.
@@ -204,8 +202,8 @@ class MiniMessageValidationTest :
                 // <extra> in markup but not spec -> extra
                 val result =
                     validate(
-                    markup = "<gold>Hello <extra>",
-                    spec = listOf(player),
+                    input = "<gold>Hello <extra>",
+                    placeholders = listOf(player),
                 )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
@@ -234,8 +232,8 @@ class MiniMessageValidationTest :
             "standard Adventure tags are not reported as extra placeholders" {
                 val result =
                     validate(
-                    markup = "<gold>Hello</gold> <bold>world</bold>",
-                    spec = emptyList(),
+                    input = "<gold>Hello</gold> <bold>world</bold>",
+                    placeholders = emptyList(),
                 )
 
                 // <gold> and <bold> are standard tags; strict mode still requires close — both are
@@ -246,8 +244,8 @@ class MiniMessageValidationTest :
             "standard tags with no spec and one extra non-standard tag reports only extra" {
                 val result =
                     validate(
-                    markup = "<gold>Hello</gold> <my-placeholder>",
-                    spec = emptyList(),
+                    input = "<gold>Hello</gold> <my-placeholder>",
+                    placeholders = emptyList(),
                 )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
@@ -319,8 +317,8 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    markup = "<gold>No placeholders</gold>",
-                    spec = listOf(alpha, beta, gamma),
+                    input = "<gold>No placeholders</gold>",
+                    placeholders = listOf(alpha, beta, gamma),
                 )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
@@ -331,8 +329,8 @@ class MiniMessageValidationTest :
             "extra placeholders are emitted in markup-encounter order" {
                 val result =
                     validate(
-                    markup = "<gold>Hello</gold> <first> then <second> then <third>",
-                    spec = emptyList(),
+                    input = "<gold>Hello</gold> <first> then <second> then <third>",
+                    placeholders = emptyList(),
                 )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
@@ -349,8 +347,8 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    markup = "<player> joined, then <player> left",
-                    spec = listOf(player),
+                    input = "<player> joined, then <player> left",
+                    placeholders = listOf(player),
                 )
 
                 result shouldBe ValidationResult.Success
@@ -367,8 +365,8 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    markup = "<gold>text</gold>",
-                    spec = listOf(gold),
+                    input = "<gold>text</gold>",
+                    placeholders = listOf(gold),
                 )
 
                 // No MissingPlaceholder("gold") — the tag IS in the markup.
@@ -380,8 +378,8 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    markup = "<red>no gold here</red>",
-                    spec = listOf(gold),
+                    input = "<red>no gold here</red>",
+                    placeholders = listOf(gold),
                 )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
@@ -397,8 +395,8 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    markup = "<bold><gold>text</gold></bold>",
-                    spec = listOf(gold),
+                    input = "<bold><gold>text</gold></bold>",
+                    placeholders = listOf(gold),
                 )
 
                 result shouldBe ValidationResult.Success
@@ -412,7 +410,7 @@ class MiniMessageValidationTest :
             // for certain edge-case malformed inputs. Reliably crafting such an input is
             // version-dependent, so the contract (validate() never throws) is verified by running
             // a range of inputs through the lenient-parse path without an uncaught exception.
-            // The guard in detectPlaceholderMismatches catches RuntimeException defensively.
+            // The guard in the placeholder-mismatch detection pass catches RuntimeException defensively.
             "validate returns a result rather than throwing for markup that is well-formed in lenient mode" {
                 // This exercises the lenient-parse path (Pass 2) for a variety of inputs; none
                 // should propagate an exception.

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidationTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidationTest.kt
@@ -409,12 +409,10 @@ class MiniMessageValidationTest :
             // ---------------------------------------------------------------
 
             // Adventure's lenient parser can throw RuntimeException (e.g. StringIndexOutOfBoundsException)
-            // for certain edge-case inputs such as unclosed double-quotes in tag arguments
-            // (PaperMC/adventure#1011).  Reliably crafting such an input is version-dependent
-            // and may be silently fixed in a future Adventure release, so we verify the contract
-            // through the regular test suite passing without uncaught exceptions rather than a
-            // single fragile input.  The guard in detectPlaceholderMismatches catches RuntimeException
-            // so that validate() always returns ValidationResult rather than throwing.
+            // for certain edge-case malformed inputs. Reliably crafting such an input is
+            // version-dependent, so the contract (validate() never throws) is verified by running
+            // a range of inputs through the lenient-parse path without an uncaught exception.
+            // The guard in detectPlaceholderMismatches catches RuntimeException defensively.
             "validate returns a result rather than throwing for markup that is well-formed in lenient mode" {
                 // This exercises the lenient-parse path (Pass 2) for a variety of inputs; none
                 // should propagate an exception.

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidationTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidationTest.kt
@@ -406,11 +406,10 @@ class MiniMessageValidationTest :
             // F1 regression: validate() must never throw, even on malformed input
             // ---------------------------------------------------------------
 
-            // Adventure's lenient parser can throw RuntimeException (e.g. StringIndexOutOfBoundsException)
-            // for certain edge-case malformed inputs. Reliably crafting such an input is
-            // version-dependent, so the contract (validate() never throws) is verified by running
-            // a range of inputs through the lenient-parse path without an uncaught exception.
-            // The guard in the placeholder-mismatch detection pass catches RuntimeException defensively.
+            // validate() must return a result rather than throw for any input. The lenient parser is
+            // not contractually guaranteed exception-free, so both passes guard against RuntimeException.
+            // Crafting an input that actually trips that guard is version-dependent, so the contract is
+            // verified here by running a range of inputs through the lenient-parse path with no throw.
             "validate returns a result rather than throwing for markup that is well-formed in lenient mode" {
                 // This exercises the lenient-parse path (Pass 2) for a variety of inputs; none
                 // should propagate an exception.


### PR DESCRIPTION
## Summary

Adds a structured validation layer for MiniMessage markup and typed placeholders. Introduces a `ValidationResult`/`MiniMessageDiagnostic` model, a two-pass algorithm (strict-mode parse + recording resolver), and a `MiniTemplate.validate()` convenience entry point.

Key behaviours:
- **Malformed/unclosed tag detection** — identifies unrecognised or unclosed tags with source position information (`MiniMessageDiagnostic.Kind.MALFORMED_TAG`). Note: in strict mode, unclosed standard tags (e.g. `<bold>` without `</bold>`) are also reported as malformed — this is the intentional strict-mode behaviour of the underlying MiniMessage parser.
- **Missing/extra placeholder detection** — cross-checks declared template placeholders against those referenced in the markup; reports `MISSING_PLACEHOLDER` and `EXTRA_PLACEHOLDER` diagnostics.
- **Standard-tag filtering** — known MiniMessage tags (colours, decorations, etc.) are excluded from the unknown-tag check so only genuinely unknown references are flagged.
- **`MiniTemplate.validate()`** — convenience method; consumers call validate on a template instance without accessing the parser internals.
- **Basis for #49 / #51** — the diagnostic model is designed to power IDE inspections and error reporting in future issues, but neither is implemented here.

CHANGELOG is release-please-owned and is not hand-edited.

## Related Issues

Closes #28

## DSL Impact

No breaking changes to the existing `MiniTemplate` DSL surface. Adds `validate(): ValidationResult` and the supporting `ValidationResult` / `MiniMessageDiagnostic` types to the `minimessage` module.

## Rationale

Plugin authors need early feedback when a message template contains a typo'd tag or references a placeholder that was never declared. Without a validation pass, errors only surface at send-time (or not at all). This gives authors a compile-adjacent check they can run in tests or at startup.

## Testing

20 Kotest test cases covering:
- Valid templates with and without placeholders
- Unclosed standard tags (strict-mode malformed behaviour)
- Unrecognised/misspelled tags
- Missing placeholders (declared but not used in markup)
- Extra placeholders (used in markup but not declared)
- Mixed diagnostic combinations
- `MiniTemplate.validate()` convenience entry point

Run with `./gradlew test`. README docs added under the MiniMessage validation section.

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run
