### PR TITLE
feat(minimessage): convert MiniMessage to DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 
 ### Added
 
+- `miniToDsl(input)` in `kotventure-minimessage` for converting MiniMessage text into Kotventure DSL source for plain
+  text, recursive children, named/hex colours, and standard text decorations.
 - Typed MiniMessage placeholders via `placeholder<T>(name)` and `resolve(...)`, covering component, string, numeric,
   and boolean values.
 - MiniMessage passthrough parsing via `kotventure-minimessage`, including `mini(...)`, placeholder resolvers for parsed,

--- a/README.md
+++ b/README.md
@@ -277,6 +277,14 @@ val nested = component {
         resolve(player, alex)
     }
 }
+
+val converted = miniToDsl("<red><bold>Hello")
+// component {
+//     text("Hello") {
+//         color(NamedTextColor.RED)
+//         bold()
+//     }
+// }
 ```
 
 For messages that are rendered many times with different values, declare a typed template once and reuse it. Each

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ val nested = component {
     }
 }
 
-val converted = miniToDsl("<red><bold>Hello")
+val dslSource = miniToDsl("<red><bold>Hello")
 // component {
 //     text("Hello") {
 //         color(NamedTextColor.RED)

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/ClickEventDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/ClickEventDslTest.kt
@@ -242,7 +242,7 @@ class ClickEventDslTest :
                 val audience = Audience.empty()
 
                 Component.text("Callback").clickEvent(event) shouldHaveClickEvent
-                    RecordingClickCallbackProvider.lastEvent
+                        RecordingClickCallbackProvider.lastEvent
                 RecordingClickCallbackProvider.lastOptions?.uses() shouldBe 3
                 RecordingClickCallbackProvider.lastOptions?.lifetime() shouldBe JavaDuration.ofMinutes(10)
 
@@ -264,7 +264,7 @@ class ClickEventDslTest :
                 val audience = Audience.empty()
 
                 Component.text("Callback").clickEvent(event) shouldHaveClickEvent
-                    RecordingClickCallbackProvider.lastEvent
+                        RecordingClickCallbackProvider.lastEvent
 
                 RecordingClickCallbackProvider.fire(audience)
 
@@ -289,7 +289,7 @@ class ClickEventDslTest :
                     }
 
                 Component.text("Callback").clickEvent(event) shouldHaveClickEvent
-                    RecordingClickCallbackProvider.lastEvent
+                        RecordingClickCallbackProvider.lastEvent
                 RecordingClickCallbackProvider.lastOptions shouldBe options
                 RecordingClickCallbackProvider.lastOptions?.uses() shouldBe 4
                 RecordingClickCallbackProvider.lastOptions?.lifetime() shouldBe lifetime

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/HoverEventDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/HoverEventDslTest.kt
@@ -133,7 +133,7 @@ class HoverEventDslTest :
                 component.childAt(0) shouldHaveHoverText Component.text("Text hover")
                 component.childAt(1) shouldHaveHoverItem HoverEvent.ShowItem.showItem(key("minecraft", "stone"), 1)
                 component.childAt(2) shouldHaveHoverEntity
-                    HoverEvent.ShowEntity.showEntity(key("minecraft", "zombie"), id)
+                        HoverEvent.ShowEntity.showEntity(key("minecraft", "zombie"), id)
             }
 
             "builds rich hover text from nested component DSL content" {

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
@@ -9,9 +9,13 @@ import net.kyori.adventure.text.minimessage.MiniMessage
 public fun mini(input: String): Component = parseMiniMessage(input)
 
 /**
- * Converts MiniMessage [input] into Kotventure component DSL source.
+ * Converts MiniMessage [input] into Kotventure component DSL source code.
+ *
+ * This first slice supports plain text, recursive text children, named and hex colours, and the standard text
+ * decorations. Unsupported component types or style attributes from later slices fail with an [IllegalArgumentException]
+ * instead of producing lossy source.
  */
-public fun miniToDsl(input: String): String = MiniMessageToDslWriter().write(mini(input))
+public fun miniToDsl(input: String): String = MiniMessageToDslWriter.write(mini(input))
 
 /**
  * Parses [input] with Adventure's default MiniMessage parser after configuring placeholder resolvers with [init].

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
@@ -9,6 +9,11 @@ import net.kyori.adventure.text.minimessage.MiniMessage
 public fun mini(input: String): Component = parseMiniMessage(input)
 
 /**
+ * Converts MiniMessage [input] into Kotventure component DSL source.
+ */
+public fun miniToDsl(input: String): String = MiniMessageToDslWriter().write(mini(input))
+
+/**
  * Parses [input] with Adventure's default MiniMessage parser after configuring placeholder resolvers with [init].
  */
 public fun mini(

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholder.kt
@@ -13,26 +13,26 @@ private val TAG_NAME_REGEX = Regex("[!?#]?[a-z0-9_-]+")
  * equal when they share both name and value type.
  */
 public class MiniMessagePlaceholder<T : Any>
-    @PublishedApi
-    internal constructor(
-        public val name: String,
-        internal val type: Class<T>,
-        internal val strategy: MiniMessagePlaceholderStrategy,
-    ) {
-        init {
-            require(TAG_NAME_REGEX.matches(name)) {
-                "MiniMessage placeholder names must match ${TAG_NAME_REGEX.pattern}; received '$name'."
-            }
+@PublishedApi
+internal constructor(
+    public val name: String,
+    internal val type: Class<T>,
+    internal val strategy: MiniMessagePlaceholderStrategy,
+) {
+    init {
+        require(TAG_NAME_REGEX.matches(name)) {
+            "MiniMessage placeholder names must match ${TAG_NAME_REGEX.pattern}; received '$name'."
         }
+    }
 
-        override fun equals(other: Any?): Boolean =
-            this === other ||
+    override fun equals(other: Any?): Boolean =
+        this === other ||
                 other is MiniMessagePlaceholder<*> &&
                 name == other.name &&
                 type == other.type
 
-        override fun hashCode(): Int = 31 * name.hashCode() + type.hashCode()
-    }
+    override fun hashCode(): Int = 31 * name.hashCode() + type.hashCode()
+}
 
 /**
  * Creates a typed MiniMessage placeholder descriptor named [name].

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholderStrategy.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessagePlaceholderStrategy.kt
@@ -22,7 +22,7 @@ internal inline fun <reified T : Any> miniMessagePlaceholderStrategy(): MiniMess
         else ->
             throw IllegalArgumentException(
                 "Supported MiniMessage placeholder types are ComponentLike, String, Number, and Boolean; " +
-                    "received ${T::class.qualifiedName}.",
+                        "received ${T::class.qualifiedName}.",
             )
     }
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageResolverBuilder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageResolverBuilder.kt
@@ -51,6 +51,7 @@ internal class MiniMessageResolverBuilder : MiniMessageResolverScope {
 
                 component(placeholder.name, componentValue)
             }
+
             MiniMessagePlaceholderStrategy.LITERAL -> unparsed(placeholder.name, value.toString())
         }
     }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
@@ -1,0 +1,44 @@
+package io.github.lmliam.kotventure.minimessage
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.format.Style
+import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.format.TextDecoration.State
+
+internal object MiniMessageToDslSupport {
+    val decorations: List<Pair<TextDecoration, String>> =
+        listOf(
+            TextDecoration.BOLD to "bold",
+            TextDecoration.ITALIC to "italic",
+            TextDecoration.UNDERLINED to "underlined",
+            TextDecoration.STRIKETHROUGH to "strikethrough",
+            TextDecoration.OBFUSCATED to "obfuscated",
+        )
+
+    fun requireSupported(component: Component) {
+        require(component is TextComponent) {
+            "miniToDsl slice 1 supports only text component trees, but found ${component::class.simpleName}."
+        }
+        requireSupported(component.style())
+    }
+
+    fun requireSupported(style: Style) {
+        require(style.clickEvent() == null) {
+            "miniToDsl slice 1 does not support click events."
+        }
+        require(style.hoverEvent() == null) {
+            "miniToDsl slice 1 does not support hover events."
+        }
+        require(style.insertion() == null) {
+            "miniToDsl slice 1 does not support insertion text."
+        }
+        require(style.font() == null) {
+            "miniToDsl slice 1 does not support font styles."
+        }
+    }
+
+    fun hasDslOutput(style: Style): Boolean =
+        style.color() != null ||
+            decorations.any { (decoration) -> style.decoration(decoration) != State.NOT_SET }
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
@@ -40,5 +40,5 @@ internal object MiniMessageToDslSupport {
 
     fun hasDslOutput(style: Style): Boolean =
         style.color() != null ||
-            decorations.any { (decoration) -> style.decoration(decoration) != State.NOT_SET }
+                decorations.any { (decoration) -> style.decoration(decoration) != State.NOT_SET }
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
@@ -21,6 +21,7 @@ internal object MiniMessageToDslSupport {
             "miniToDsl slice 1 supports only text component trees, but found ${component::class.simpleName}."
         }
         requireSupported(component.style())
+        component.children().forEach(::requireSupported)
     }
 
     fun requireSupported(style: Style) {
@@ -35,6 +36,9 @@ internal object MiniMessageToDslSupport {
         }
         require(style.font() == null) {
             "miniToDsl slice 1 does not support font styles."
+        }
+        require(style.shadowColor() == null) {
+            "miniToDsl slice 1 does not support shadow colours."
         }
     }
 

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
@@ -5,10 +5,10 @@ import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
-import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.format.TextDecoration.State
 import java.util.Locale
 
-internal class MiniMessageToDslWriter {
+internal object MiniMessageToDslWriter {
     fun write(component: Component): String {
         if (component.isEmptyDslComponent()) {
             return "component {}"
@@ -24,7 +24,10 @@ internal class MiniMessageToDslWriter {
         component: Component,
         lines: MutableList<String>,
     ) {
-        if (component is TextComponent && component.content().isEmpty() && !component.style().hasDslOutput()) {
+        if (component is TextComponent &&
+            component.content().isEmpty() &&
+            !MiniMessageToDslSupport.hasDslOutput(component.style())
+        ) {
             component.children().forEach { child -> appendComponent(child, 1, lines) }
             return
         }
@@ -37,12 +40,11 @@ internal class MiniMessageToDslWriter {
         indent: Int,
         lines: MutableList<String>,
     ) {
-        require(component is TextComponent) {
-            "miniToDsl slice 1 supports only text component trees, but found ${component::class.simpleName}."
-        }
+        MiniMessageToDslSupport.requireSupported(component)
+        component as TextComponent
 
         val text = component.content()
-        val hasBlockBody = component.style().hasDslOutput() || component.children().isNotEmpty()
+        val hasBlockBody = MiniMessageToDslSupport.hasDslOutput(component.style()) || component.children().isNotEmpty()
 
         if (!hasBlockBody) {
             lines += "${indent(indent)}text(\"${escapeString(text)}\")"
@@ -66,14 +68,26 @@ internal class MiniMessageToDslWriter {
         indent: Int,
         lines: MutableList<String>,
     ) {
+        MiniMessageToDslSupport.requireSupported(style)
+
         style.color()?.let { color ->
             lines += "${indent(indent)}color(${formatColor(color)})"
         }
 
-        decorationFunctions.forEach { (decoration, functionName) ->
-            if (style.decoration(decoration) == TextDecoration.State.TRUE) {
+        MiniMessageToDslSupport.decorations.forEach { (decoration, functionName) ->
+            if (style.decoration(decoration) == State.TRUE) {
                 lines += "${indent(indent)}$functionName()"
             }
+        }
+
+        val disabledDecorations =
+            MiniMessageToDslSupport.decorations.filter { (decoration) -> style.decoration(decoration) == State.FALSE }
+        if (disabledDecorations.isNotEmpty()) {
+            lines += "${indent(indent)}style {"
+            disabledDecorations.forEach { (_, functionName) ->
+                lines += "${indent(indent + 1)}$functionName(false)"
+            }
+            lines += "${indent(indent)}}"
         }
     }
 
@@ -91,33 +105,19 @@ internal class MiniMessageToDslWriter {
                     '\\' -> append("\\\\")
                     '"' -> append("\\\"")
                     '\n' -> append("\\n")
+                    '\r' -> append("\\r")
                     '\t' -> append("\\t")
-                    '$' -> append("\\$")
+                    '$' -> append('\\').append('$')
                     else -> append(character)
                 }
             }
         }
 
-    private fun Style.hasDslOutput(): Boolean =
-        color() != null ||
-            decorationFunctions.keys.any { decoration -> decoration(decoration) == TextDecoration.State.TRUE }
-
     private fun Component.isEmptyDslComponent(): Boolean =
         this is TextComponent &&
             content().isEmpty() &&
             children().isEmpty() &&
-            !style().hasDslOutput()
+            !MiniMessageToDslSupport.hasDslOutput(style())
 
     private fun indent(level: Int): String = "    ".repeat(level)
-
-    private companion object {
-        private val decorationFunctions: LinkedHashMap<TextDecoration, String> =
-            linkedMapOf(
-                TextDecoration.BOLD to "bold",
-                TextDecoration.ITALIC to "italic",
-                TextDecoration.UNDERLINED to "underlined",
-                TextDecoration.STRIKETHROUGH to "strikethrough",
-                TextDecoration.OBFUSCATED to "obfuscated",
-            )
-    }
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
@@ -1,0 +1,123 @@
+package io.github.lmliam.kotventure.minimessage
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.Style
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
+import java.util.Locale
+
+internal class MiniMessageToDslWriter {
+    fun write(component: Component): String {
+        if (component.isEmptyDslComponent()) {
+            return "component {}"
+        }
+
+        val lines = mutableListOf("component {")
+        appendRoot(component, lines)
+        lines += "}"
+        return lines.joinToString(separator = "\n")
+    }
+
+    private fun appendRoot(
+        component: Component,
+        lines: MutableList<String>,
+    ) {
+        if (component is TextComponent && component.content().isEmpty() && !component.style().hasDslOutput()) {
+            component.children().forEach { child -> appendComponent(child, 1, lines) }
+            return
+        }
+
+        appendComponent(component, 1, lines)
+    }
+
+    private fun appendComponent(
+        component: Component,
+        indent: Int,
+        lines: MutableList<String>,
+    ) {
+        require(component is TextComponent) {
+            "miniToDsl slice 1 supports only text component trees, but found ${component::class.simpleName}."
+        }
+
+        val text = component.content()
+        val hasBlockBody = component.style().hasDslOutput() || component.children().isNotEmpty()
+
+        if (!hasBlockBody) {
+            lines += "${indent(indent)}text(\"${escapeString(text)}\")"
+            return
+        }
+
+        val openingLine =
+            if (text.isEmpty()) {
+                "${indent(indent)}text {"
+            } else {
+                "${indent(indent)}text(\"${escapeString(text)}\") {"
+            }
+        lines += openingLine
+        appendStyle(component.style(), indent + 1, lines)
+        component.children().forEach { child -> appendComponent(child, indent + 1, lines) }
+        lines += "${indent(indent)}}"
+    }
+
+    private fun appendStyle(
+        style: Style,
+        indent: Int,
+        lines: MutableList<String>,
+    ) {
+        style.color()?.let { color ->
+            lines += "${indent(indent)}color(${formatColor(color)})"
+        }
+
+        decorationFunctions.forEach { (decoration, functionName) ->
+            if (style.decoration(decoration) == TextDecoration.State.TRUE) {
+                lines += "${indent(indent)}$functionName()"
+            }
+        }
+    }
+
+    private fun formatColor(color: TextColor): String =
+        if (color is NamedTextColor) {
+            "NamedTextColor.${color.toString().uppercase(Locale.ROOT)}"
+        } else {
+            "TextColor.color(0x${color.asHexString().removePrefix("#").uppercase(Locale.ROOT)})"
+        }
+
+    private fun escapeString(value: String): String =
+        buildString {
+            value.forEach { character ->
+                when (character) {
+                    '\\' -> append("\\\\")
+                    '"' -> append("\\\"")
+                    '\n' -> append("\\n")
+                    '\t' -> append("\\t")
+                    '$' -> append("\\$")
+                    else -> append(character)
+                }
+            }
+        }
+
+    private fun Style.hasDslOutput(): Boolean =
+        color() != null ||
+            decorationFunctions.keys.any { decoration -> decoration(decoration) == TextDecoration.State.TRUE }
+
+    private fun Component.isEmptyDslComponent(): Boolean =
+        this is TextComponent &&
+            content().isEmpty() &&
+            children().isEmpty() &&
+            !style().hasDslOutput()
+
+    private fun indent(level: Int): String = "    ".repeat(level)
+
+    private companion object {
+        private val decorationFunctions: LinkedHashMap<TextDecoration, String> =
+            linkedMapOf(
+                TextDecoration.BOLD to "bold",
+                TextDecoration.ITALIC to "italic",
+                TextDecoration.UNDERLINED to "underlined",
+                TextDecoration.STRIKETHROUGH to "strikethrough",
+                TextDecoration.OBFUSCATED to "obfuscated",
+            )
+    }
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
@@ -10,6 +10,8 @@ import java.util.Locale
 
 internal object MiniMessageToDslWriter {
     fun write(component: Component): String {
+        MiniMessageToDslSupport.requireSupported(component)
+
         if (component.isEmptyDslComponent()) {
             return "component {}"
         }
@@ -40,7 +42,6 @@ internal object MiniMessageToDslWriter {
         indent: Int,
         lines: MutableList<String>,
     ) {
-        MiniMessageToDslSupport.requireSupported(component)
         component as TextComponent
 
         val text = component.content()
@@ -68,8 +69,6 @@ internal object MiniMessageToDslWriter {
         indent: Int,
         lines: MutableList<String>,
     ) {
-        MiniMessageToDslSupport.requireSupported(style)
-
         style.color()?.let { color ->
             lines += "${indent(indent)}color(${formatColor(color)})"
         }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
@@ -115,9 +115,9 @@ internal object MiniMessageToDslWriter {
 
     private fun Component.isEmptyDslComponent(): Boolean =
         this is TextComponent &&
-            content().isEmpty() &&
-            children().isEmpty() &&
-            !MiniMessageToDslSupport.hasDslOutput(style())
+                content().isEmpty() &&
+                children().isEmpty() &&
+                !MiniMessageToDslSupport.hasDslOutput(style())
 
     private fun indent(level: Int): String = "    ".repeat(level)
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
@@ -123,7 +123,8 @@ public abstract class MiniTemplate(
  * @param placeholder a descriptor declared on this template.
  * @param value the value to substitute for [placeholder].
  */
-context(_: MiniTemplateBindingScope) public fun <T : Any> MiniTemplate.bind(
+context(_: MiniTemplateBindingScope)
+public fun <T : Any> MiniTemplate.bind(
     placeholder: MiniMessagePlaceholder<T>,
     value: T,
 ): Unit = contextOf<MiniTemplateBindingScope>().bind(placeholder, value)
@@ -162,7 +163,7 @@ public operator fun <T : MiniTemplate> T.invoke(block: context(MiniTemplateBindi
             ) {
                 require(placeholders[placeholder.name] === placeholder) {
                     "Placeholder '${placeholder.name}' is not declared on this template. " +
-                        "Declared placeholders: ${placeholders.keys}."
+                            "Declared placeholders: ${placeholders.keys}."
                 }
                 require(boundNames.add(placeholder.name)) {
                     "Placeholder '${placeholder.name}' is already bound in this template render."

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
@@ -123,8 +123,7 @@ public abstract class MiniTemplate(
  * @param placeholder a descriptor declared on this template.
  * @param value the value to substitute for [placeholder].
  */
-context(_: MiniTemplateBindingScope)
-public fun <T : Any> MiniTemplate.bind(
+context(_: MiniTemplateBindingScope) public fun <T : Any> MiniTemplate.bind(
     placeholder: MiniMessagePlaceholder<T>,
     value: T,
 ): Unit = contextOf<MiniTemplateBindingScope>().bind(placeholder, value)

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
@@ -19,32 +19,6 @@ import net.kyori.adventure.text.minimessage.MiniMessage
 class MiniMessageToDslTest :
     StringSpec(
         {
-            "generates snapshot-style source for styled plain text" {
-                miniToDsl("<red><bold>Hello") shouldBe
-                        """
-                    component {
-                        text("Hello") {
-                            color(NamedTextColor.RED)
-                            bold()
-                        }
-                    }
-                    """.trimIndent()
-            }
-
-            "generates snapshot-style source for nested children and hex colours" {
-                miniToDsl("<gray>Hello <#12ab34>world</#12ab34></gray>") shouldBe
-                        """
-                    component {
-                        text("Hello ") {
-                            color(NamedTextColor.GRAY)
-                            text("world") {
-                                color(TextColor.color(0x12AB34))
-                            }
-                        }
-                    }
-                    """.trimIndent()
-            }
-
             "generates snapshot-style source for the join-message example" {
                 val input = "<gold>[<gray>Server</gray>]</gold> <aqua>Alex</aqua> joined the game"
                 val expected =
@@ -97,7 +71,9 @@ class MiniMessageToDslTest :
             }
 
             "emits all standard text decorations" {
-                miniToDsl("<bold><italic><underlined><strikethrough><obfuscated>styled") shouldBe
+                val input = "<bold><italic><underlined><strikethrough><obfuscated>styled"
+
+                miniToDsl(input) shouldBe
                         """
                     component {
                         text("styled") {
@@ -109,10 +85,19 @@ class MiniMessageToDslTest :
                         }
                     }
                     """.trimIndent()
+
+                val styled = mini(input)
+                styled shouldHaveDecoration TextDecoration.BOLD
+                styled shouldHaveDecoration TextDecoration.ITALIC
+                styled shouldHaveDecoration TextDecoration.UNDERLINED
+                styled shouldHaveDecoration TextDecoration.STRIKETHROUGH
+                styled shouldHaveDecoration TextDecoration.OBFUSCATED
             }
 
             "emits disabled decoration states that override inherited style" {
-                miniToDsl("<bold>hot <!bold>cold") shouldBe
+                val input = "<bold>hot <!bold>cold"
+
+                miniToDsl(input) shouldBe
                         """
                     component {
                         text("hot ") {
@@ -125,6 +110,10 @@ class MiniMessageToDslTest :
                         }
                     }
                     """.trimIndent()
+
+                val hot = mini(input)
+                hot shouldHaveDecoration TextDecoration.BOLD
+                hot.childAt(0).shouldHaveDecoration(TextDecoration.BOLD, TextDecoration.State.FALSE)
             }
 
             "rejects unsupported style metadata instead of dropping it" {
@@ -136,10 +125,28 @@ class MiniMessageToDslTest :
                 error.message shouldContain "miniToDsl slice 1 does not support click events"
             }
 
+            "rejects unsupported shadow colours instead of dropping them" {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        miniToDsl("<shadow:red>shadow</shadow>")
+                    }
+
+                error.message shouldContain "miniToDsl slice 1 does not support shadow colours"
+            }
+
             "rejects unsupported component types" {
                 val error =
                     shouldThrow<IllegalArgumentException> {
-                        MiniMessageToDslWriter.write(Component.keybind("key.jump"))
+                        miniToDsl("<key:key.jump>")
+                    }
+
+                error.message shouldContain "supports only text component trees"
+            }
+
+            "rejects unsupported component types in children" {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        MiniMessageToDslWriter.write(Component.empty().append(Component.keybind("key.jump")))
                     }
 
                 error.message shouldContain "supports only text component trees"

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
@@ -6,8 +6,10 @@ import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextColor
@@ -82,14 +84,65 @@ class MiniMessageToDslTest :
             }
 
             "escapes Kotlin string content in generated source" {
-                val input = "say \\ \"hi\"\n\t\$5"
+                val dollar = '$'
+                val escapedDollar = "\\$dollar"
+                val input = "say \\ \"hi\"\n\t${dollar}5\rcr"
 
                 miniToDsl(input) shouldBe
                     """
                     component {
-                        text("say \\ \"hi\"\n\t\$5")
+                        text("say \\ \"hi\"\n\t${escapedDollar}5\rcr")
                     }
                     """.trimIndent()
+            }
+
+            "emits all standard text decorations" {
+                miniToDsl("<bold><italic><underlined><strikethrough><obfuscated>styled") shouldBe
+                    """
+                    component {
+                        text("styled") {
+                            bold()
+                            italic()
+                            underlined()
+                            strikethrough()
+                            obfuscated()
+                        }
+                    }
+                    """.trimIndent()
+            }
+
+            "emits disabled decoration states that override inherited style" {
+                miniToDsl("<bold>hot <!bold>cold") shouldBe
+                    """
+                    component {
+                        text("hot ") {
+                            bold()
+                            text("cold") {
+                                style {
+                                    bold(false)
+                                }
+                            }
+                        }
+                    }
+                    """.trimIndent()
+            }
+
+            "rejects unsupported style metadata instead of dropping it" {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        miniToDsl("<click:run_command:'/spawn'>spawn</click>")
+                    }
+
+                error.message shouldContain "miniToDsl slice 1 does not support click events"
+            }
+
+            "rejects unsupported component types" {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        MiniMessageToDslWriter.write(Component.keybind("key.jump"))
+                    }
+
+                error.message shouldContain "supports only text component trees"
             }
 
             "renders escaped MiniMessage tags as literal text" {

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
@@ -1,0 +1,178 @@
+package io.github.lmliam.kotventure.minimessage
+
+import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.minimessage.MiniMessage
+
+class MiniMessageToDslTest :
+    StringSpec(
+        {
+            "generates snapshot-style source for styled plain text" {
+                miniToDsl("<red><bold>Hello") shouldBe
+                    """
+                    component {
+                        text("Hello") {
+                            color(NamedTextColor.RED)
+                            bold()
+                        }
+                    }
+                    """.trimIndent()
+            }
+
+            "generates snapshot-style source for nested children and hex colours" {
+                miniToDsl("<gray>Hello <#12ab34>world</#12ab34></gray>") shouldBe
+                    """
+                    component {
+                        text("Hello ") {
+                            color(NamedTextColor.GRAY)
+                            text("world") {
+                                color(TextColor.color(0x12AB34))
+                            }
+                        }
+                    }
+                    """.trimIndent()
+            }
+
+            "generates snapshot-style source for the join-message example" {
+                val input = "<gold>[<gray>Server</gray>]</gold> <aqua>Alex</aqua> joined the game"
+                val expected =
+                    component {
+                        text("[") {
+                            color(NamedTextColor.GOLD)
+                            text("Server") {
+                                color(NamedTextColor.GRAY)
+                            }
+                            text("]")
+                        }
+                        text(" ")
+                        text("Alex") {
+                            color(NamedTextColor.AQUA)
+                        }
+                        text(" joined the game")
+                    }
+                val expectedSource =
+                    """
+                    component {
+                        text("[") {
+                            color(NamedTextColor.GOLD)
+                            text("Server") {
+                                color(NamedTextColor.GRAY)
+                            }
+                            text("]")
+                        }
+                        text(" ")
+                        text("Alex") {
+                            color(NamedTextColor.AQUA)
+                        }
+                        text(" joined the game")
+                    }
+                    """.trimIndent()
+
+                assertGoldenRoundTrip(input, expectedSource, expected)
+            }
+
+            "escapes Kotlin string content in generated source" {
+                val input = "say \\ \"hi\"\n\t\$5"
+
+                miniToDsl(input) shouldBe
+                    """
+                    component {
+                        text("say \\ \"hi\"\n\t\$5")
+                    }
+                    """.trimIndent()
+            }
+
+            "renders escaped MiniMessage tags as literal text" {
+                val generated = miniToDsl("\\<red>literal")
+
+                generated shouldBe
+                    """
+                    component {
+                        text("<red>literal")
+                    }
+                    """.trimIndent()
+                mini("\\<red>literal") shouldContainText "<red>literal"
+            }
+
+            "round-trips named colours and decorations against compiled expected DSL" {
+                val input = "<red><bold>Hello"
+                val expected =
+                    component {
+                        text("Hello") {
+                            color(NamedTextColor.RED)
+                            bold()
+                        }
+                    }
+                val expectedSource =
+                    """
+                    component {
+                        text("Hello") {
+                            color(NamedTextColor.RED)
+                            bold()
+                        }
+                    }
+                    """.trimIndent()
+
+                assertGoldenRoundTrip(input, expectedSource, expected)
+                expected shouldHaveChildCount 1
+                expected.childAt(0) shouldHaveColor NamedTextColor.RED
+                expected.childAt(0) shouldHaveDecoration TextDecoration.BOLD
+            }
+
+            "round-trips nested colours against compiled expected DSL" {
+                val input = "<gray>Hello <#12ab34>world</#12ab34></gray>"
+                val expected =
+                    component {
+                        text("Hello ") {
+                            color(NamedTextColor.GRAY)
+                            text("world") {
+                                color(TextColor.color(0x12AB34))
+                            }
+                        }
+                    }
+                val expectedSource =
+                    """
+                    component {
+                        text("Hello ") {
+                            color(NamedTextColor.GRAY)
+                            text("world") {
+                                color(TextColor.color(0x12AB34))
+                            }
+                        }
+                    }
+                    """.trimIndent()
+
+                assertGoldenRoundTrip(input, expectedSource, expected)
+                expected shouldHaveChildCount 1
+                expected.childAt(0) shouldHaveColor NamedTextColor.GRAY
+                expected.childAt(0).childAt(0) shouldHaveColor TextColor.color(0x12AB34)
+            }
+
+            "renders an empty component for empty input" {
+                val expected = component {}
+
+                assertGoldenRoundTrip("", "component {}", expected)
+            }
+        },
+    )
+
+private fun assertGoldenRoundTrip(
+    input: String,
+    expectedSource: String,
+    expectedComponent: Component,
+) {
+    val parsed = mini(input)
+
+    miniToDsl(input) shouldBe expectedSource
+    MiniMessage.miniMessage().serialize(parsed) shouldBe MiniMessage.miniMessage().serialize(expectedComponent)
+}

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
@@ -21,7 +21,7 @@ class MiniMessageToDslTest :
         {
             "generates snapshot-style source for styled plain text" {
                 miniToDsl("<red><bold>Hello") shouldBe
-                    """
+                        """
                     component {
                         text("Hello") {
                             color(NamedTextColor.RED)
@@ -33,7 +33,7 @@ class MiniMessageToDslTest :
 
             "generates snapshot-style source for nested children and hex colours" {
                 miniToDsl("<gray>Hello <#12ab34>world</#12ab34></gray>") shouldBe
-                    """
+                        """
                     component {
                         text("Hello ") {
                             color(NamedTextColor.GRAY)
@@ -89,7 +89,7 @@ class MiniMessageToDslTest :
                 val input = "say \\ \"hi\"\n\t${dollar}5\rcr"
 
                 miniToDsl(input) shouldBe
-                    """
+                        """
                     component {
                         text("say \\ \"hi\"\n\t${escapedDollar}5\rcr")
                     }
@@ -98,7 +98,7 @@ class MiniMessageToDslTest :
 
             "emits all standard text decorations" {
                 miniToDsl("<bold><italic><underlined><strikethrough><obfuscated>styled") shouldBe
-                    """
+                        """
                     component {
                         text("styled") {
                             bold()
@@ -113,7 +113,7 @@ class MiniMessageToDslTest :
 
             "emits disabled decoration states that override inherited style" {
                 miniToDsl("<bold>hot <!bold>cold") shouldBe
-                    """
+                        """
                     component {
                         text("hot ") {
                             bold()
@@ -149,7 +149,7 @@ class MiniMessageToDslTest :
                 val generated = miniToDsl("\\<red>literal")
 
                 generated shouldBe
-                    """
+                        """
                     component {
                         text("<red>literal")
                     }

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidationTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageValidationTest.kt
@@ -37,9 +37,9 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    input = "<gold>Welcome <player>, <count> new messages</gold>",
-                    placeholders = listOf(player, count),
-                )
+                        input = "<gold>Welcome <player>, <count> new messages</gold>",
+                        placeholders = listOf(player, count),
+                    )
 
                 result shouldBe ValidationResult.Success
             }
@@ -47,9 +47,9 @@ class MiniMessageValidationTest :
             "markup with no spec and no placeholder tags returns Success" {
                 val result =
                     validate(
-                    input = "<gold>Hello world</gold>",
-                    placeholders = emptyList(),
-                )
+                        input = "<gold>Hello world</gold>",
+                        placeholders = emptyList(),
+                    )
 
                 result shouldBe ValidationResult.Success
             }
@@ -61,9 +61,9 @@ class MiniMessageValidationTest :
             "unclosed standard tag returns Failure with MalformedTag diagnostic" {
                 val result =
                     validate(
-                    input = "<gold>Hello world",
-                    placeholders = emptyList(),
-                )
+                        input = "<gold>Hello world",
+                        placeholders = emptyList(),
+                    )
 
                 // <gold> without </gold> is well-formed in lenient mode but strict mode requires close
                 // — however Adventure strict mode only throws for unclosed child-allowing tags at EOF.
@@ -77,9 +77,9 @@ class MiniMessageValidationTest :
                 // Adventure reports position info for unclosed child-allowing tags at end-of-string.
                 val result =
                     validate(
-                    input = "<gold>Hello world",
-                    placeholders = emptyList(),
-                )
+                        input = "<gold>Hello world",
+                        placeholders = emptyList(),
+                    )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
                 val malformed = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MalformedTag>()
@@ -96,9 +96,9 @@ class MiniMessageValidationTest :
                 // <gold> without close WILL trigger malformed under strict mode
                 val result =
                     validate(
-                    input = "<gold><player>joined",
-                    placeholders = listOf(player),
-                )
+                        input = "<gold><player>joined",
+                        placeholders = listOf(player),
+                    )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
                 val malformed = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MalformedTag>()
@@ -120,9 +120,9 @@ class MiniMessageValidationTest :
             "MalformedTag start and end indices are passed through from Adventure without modification" {
                 val result =
                     validate(
-                    input = "<gold>Hello world",
-                    placeholders = emptyList(),
-                )
+                        input = "<gold>Hello world",
+                        placeholders = emptyList(),
+                    )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
                 val malformed = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MalformedTag>()
@@ -142,9 +142,9 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    input = "<player> joined",
-                    placeholders = listOf(player, count),
-                )
+                        input = "<player> joined",
+                        placeholders = listOf(player, count),
+                    )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
                 val missing = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MissingPlaceholder>()
@@ -161,9 +161,9 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    input = "<player> joined with <oops>",
-                    placeholders = listOf(player),
-                )
+                        input = "<player> joined with <oops>",
+                        placeholders = listOf(player),
+                    )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
                 val extra = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.ExtraPlaceholder>()
@@ -180,9 +180,9 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    input = "<player> <missing-one> <extra-one>",
-                    placeholders = listOf(player, placeholder<String>("missing-one")),
-                )
+                        input = "<player> <missing-one> <extra-one>",
+                        placeholders = listOf(player, placeholder<String>("missing-one")),
+                    )
 
                 // <player> and <missing-one> are in both spec and markup — neither is missing or extra.
                 // <extra-one> is in markup but not in spec — reported as ExtraPlaceholder.
@@ -202,9 +202,9 @@ class MiniMessageValidationTest :
                 // <extra> in markup but not spec -> extra
                 val result =
                     validate(
-                    input = "<gold>Hello <extra>",
-                    placeholders = listOf(player),
-                )
+                        input = "<gold>Hello <extra>",
+                        placeholders = listOf(player),
+                    )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
                 val malformed = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MalformedTag>()
@@ -232,9 +232,9 @@ class MiniMessageValidationTest :
             "standard Adventure tags are not reported as extra placeholders" {
                 val result =
                     validate(
-                    input = "<gold>Hello</gold> <bold>world</bold>",
-                    placeholders = emptyList(),
-                )
+                        input = "<gold>Hello</gold> <bold>world</bold>",
+                        placeholders = emptyList(),
+                    )
 
                 // <gold> and <bold> are standard tags; strict mode still requires close — both are
                 // closed properly here, so no malformed. No spec -> no missing. No extra either.
@@ -244,9 +244,9 @@ class MiniMessageValidationTest :
             "standard tags with no spec and one extra non-standard tag reports only extra" {
                 val result =
                     validate(
-                    input = "<gold>Hello</gold> <my-placeholder>",
-                    placeholders = emptyList(),
-                )
+                        input = "<gold>Hello</gold> <my-placeholder>",
+                        placeholders = emptyList(),
+                    )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
                 val extra = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.ExtraPlaceholder>()
@@ -317,9 +317,9 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    input = "<gold>No placeholders</gold>",
-                    placeholders = listOf(alpha, beta, gamma),
-                )
+                        input = "<gold>No placeholders</gold>",
+                        placeholders = listOf(alpha, beta, gamma),
+                    )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
                 val missing = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MissingPlaceholder>()
@@ -329,9 +329,9 @@ class MiniMessageValidationTest :
             "extra placeholders are emitted in markup-encounter order" {
                 val result =
                     validate(
-                    input = "<gold>Hello</gold> <first> then <second> then <third>",
-                    placeholders = emptyList(),
-                )
+                        input = "<gold>Hello</gold> <first> then <second> then <third>",
+                        placeholders = emptyList(),
+                    )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
                 val extra = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.ExtraPlaceholder>()
@@ -347,9 +347,9 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    input = "<player> joined, then <player> left",
-                    placeholders = listOf(player),
-                )
+                        input = "<player> joined, then <player> left",
+                        placeholders = listOf(player),
+                    )
 
                 result shouldBe ValidationResult.Success
             }
@@ -365,9 +365,9 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    input = "<gold>text</gold>",
-                    placeholders = listOf(gold),
-                )
+                        input = "<gold>text</gold>",
+                        placeholders = listOf(gold),
+                    )
 
                 // No MissingPlaceholder("gold") — the tag IS in the markup.
                 result shouldBe ValidationResult.Success
@@ -378,9 +378,9 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    input = "<red>no gold here</red>",
-                    placeholders = listOf(gold),
-                )
+                        input = "<red>no gold here</red>",
+                        placeholders = listOf(gold),
+                    )
 
                 val failure = result.shouldBeInstanceOf<ValidationResult.Failure>()
                 val missing = failure.diagnostics.filterIsInstance<MiniMessageDiagnostic.MissingPlaceholder>()
@@ -395,9 +395,9 @@ class MiniMessageValidationTest :
 
                 val result =
                     validate(
-                    input = "<bold><gold>text</gold></bold>",
-                    placeholders = listOf(gold),
-                )
+                        input = "<bold><gold>text</gold></bold>",
+                        placeholders = listOf(gold),
+                    )
 
                 result shouldBe ValidationResult.Success
             }
@@ -415,12 +415,12 @@ class MiniMessageValidationTest :
                 // should propagate an exception.
                 val inputs =
                     listOf(
-                    "",
-                    "plain text",
-                    "<gold>unclosed",
-                    "<unknown-tag>",
-                    "<gold arg='value'>text</gold>",
-                )
+                        "",
+                        "plain text",
+                        "<gold>unclosed",
+                        "<unknown-tag>",
+                        "<gold arg='value'>text</gold>",
+                    )
 
                 for (input in inputs) {
                     // shouldNotThrow is enforced by the test harness — any exception fails the test.

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateTest.kt
@@ -257,13 +257,13 @@ class MiniTemplateTest :
 
             "throws IllegalArgumentException when markup is empty" {
                 shouldThrow<IllegalArgumentException> {
-                    object : MiniTemplate("") { }
+                    object : MiniTemplate("") {}
                 }
             }
 
             "throws IllegalArgumentException when markup is blank" {
                 shouldThrow<IllegalArgumentException> {
-                    object : MiniTemplate("   ") { }
+                    object : MiniTemplate("   ") {}
                 }
             }
 

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchersTest.kt
@@ -174,7 +174,7 @@ class ComponentMatchersTest :
                 val failure =
                     shouldThrow<AssertionError> {
                         Component.translatable("item.minecraft.diamond") shouldHaveTranslationKey
-                            "item.minecraft.emerald"
+                                "item.minecraft.emerald"
                     }
                 val expectedMessage =
                     "Expected translation key <item.minecraft.emerald>, " +
@@ -564,7 +564,7 @@ class ComponentMatchersTest :
                         Component
                             .text("Run")
                             .clickEvent(ClickEvent.runCommand("/spawn")) shouldHaveClickAction
-                            ClickEvent.Action.SUGGEST_COMMAND
+                                ClickEvent.Action.SUGGEST_COMMAND
                     }
                 val expectedMessage =
                     "Expected click action <${ClickEvent.Action.SUGGEST_COMMAND}>, " +

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/HoverEventMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/text/HoverEventMatchersTest.kt
@@ -21,14 +21,14 @@ class HoverEventMatchersTest :
                 Component
                     .text("Hover")
                     .hoverEvent(HoverEvent.showText(Component.text("Tooltip"))) shouldHaveHoverAction
-                    HoverEvent.Action.SHOW_TEXT
+                        HoverEvent.Action.SHOW_TEXT
             }
 
             "matches text hover payloads" {
                 Component
                     .text("Hover")
                     .hoverEvent(HoverEvent.showText(Component.text("Tooltip"))) shouldHaveHoverText
-                    Component.text("Tooltip")
+                        Component.text("Tooltip")
             }
 
             "matches item hover payloads" {
@@ -70,7 +70,7 @@ class HoverEventMatchersTest :
                         Component
                             .text("Hover")
                             .hoverEvent(HoverEvent.showText(Component.text("Tooltip"))) shouldHaveHoverAction
-                            HoverEvent.Action.SHOW_ITEM
+                                HoverEvent.Action.SHOW_ITEM
                     }
                 val expectedMessage =
                     "Expected hover action <${HoverEvent.Action.SHOW_ITEM}>, " +
@@ -85,7 +85,7 @@ class HoverEventMatchersTest :
                         Component
                             .text("Hover")
                             .hoverEvent(HoverEvent.showText(Component.text("actual"))) shouldHaveHoverText
-                            Component.text("expected")
+                                Component.text("expected")
                     }
                 val expectedMessage =
                     "Expected hover text payload <${Component.text("expected")}>, " +
@@ -100,7 +100,7 @@ class HoverEventMatchersTest :
                 val failure =
                     shouldThrow<AssertionError> {
                         Component.text("Hover").hoverEvent(HoverEvent.showItem(item)) shouldHaveHoverText
-                            Component.text("expected")
+                                Component.text("expected")
                     }
                 val expectedMessage =
                     "Expected hover text payload <${Component.text("expected")}>, " +


### PR DESCRIPTION
Closes #29

Plan: https://github.com/LMLiam/Kotventure/issues/29#issuecomment-4703758935

Summary
- Slice 1 adds MiniMessage -> DSL conversion by introducing a writer that walks Adventure MiniMessage nodes and emits the project DSL surface.
- Tests cover the expected DSL output for the supported structures in this slice.
- README and CHANGELOG were updated for the user-facing behavior change.

Scope exclusions / deferred follow-ups
- Special-case carriage return escaping is deferred.
- KDoc can still be expanded to describe malformed input behavior.
- Follow-up refs: #146, #147, #148.

Validation
- ./gradlew ktlintFormat PASS
- git diff --check PASS
- ./gradlew :minimessage:test --tests io.github.lmliam.kotventure.minimessage.MiniMessageToDslTest PASS
- ./gradlew :minimessage:test PASS
- ./gradlew ktlintCheck spotlessCheck PASS
- ./gradlew build PASS

Reviewer pass
- PASS, with no critical or important findings.
- Minor notes only: no special-case carriage return escaping; malformed-input KDoc could be more explicit.