### PR TITLE
feat(minimessage): mini→DSL converter — click & hover events (slice 2)

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -6,12 +6,12 @@ They complement [`../../AGENTS.md`](../../AGENTS.md): AGENTS.md is the always-on
 
 Each skill is a directory with a `SKILL.md` (YAML frontmatter `name` + `description`, then the body).
 
-| Skill                                                             | Use when                                                      |
-|-------------------------------------------------------------------|---------------------------------------------------------------|
-| [`adding-a-dsl-feature`](adding-a-dsl-feature/SKILL.md)           | Implementing any new DSL feature / picking up a feature issue |
+| Skill                                                             | Use when                                                                   |
+|-------------------------------------------------------------------|----------------------------------------------------------------------------|
+| [`adding-a-dsl-feature`](adding-a-dsl-feature/SKILL.md)           | Implementing any new DSL feature / picking up a feature issue              |
 | [`idiomatic-kotlin-dsl`](idiomatic-kotlin-dsl/SKILL.md)           | **Required before designing/planning any API surface**; reviewing DSL code |
-| [`kyori-adventure-reference`](kyori-adventure-reference/SKILL.md) | You need an Adventure API and must not guess its shape        |
-| [`writing-component-tests`](writing-component-tests/SKILL.md)     | Writing tests for components / audiences                      |
+| [`kyori-adventure-reference`](kyori-adventure-reference/SKILL.md) | You need an Adventure API and must not guess its shape                     |
+| [`writing-component-tests`](writing-component-tests/SKILL.md)     | Writing tests for components / audiences                                   |
 
 **Agents:** before writing code, check whether one of these applies and follow it. If a skill conflicts with an explicit
 maintainer instruction, the maintainer wins.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report something that isn't working as expected.
 title: "bug: "
-labels: ["type: bug", "status: needs triage"]
+labels: [ "type: bug", "status: needs triage" ]
 body:
   - type: textarea
     attributes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,8 @@ Before sketching any public surface (and **before posting an implementation plan
 
 - **Compile-time beats runtime.** If a named thing can be a property, make it a property. Delegated properties
   (`by` + `PropertyDelegateProvider`) give you a compile-checked property *and* its name for runtime/registry interop —
-  reach for them before inventing key types or string lookups. Every runtime `require(...)` for a missing/typo'd/duplicate
+  reach for them before inventing key types or string lookups. Every runtime `require(...)` for a
+  missing/typo'd/duplicate
   name is a compile error you failed to design for.
 - **One way per use case.** Never ship a typed API and string overloads of it in parallel. Pick one; expose a single
   explicit string bridge only where interop (config, MiniMessage, cross-plugin) demands it.
@@ -145,7 +146,8 @@ Before sketching any public surface (and **before posting an implementation plan
 
 ## 9. Project skills
 
-Reusable playbooks — available via the `Skill` tool (Claude Code: `.claude/skills/`) or the `skill` tool (Copilot/Codex: `.agents/skills/`):
+Reusable playbooks — available via the `Skill` tool (Claude Code: `.claude/skills/`) or the `skill` tool (Copilot/Codex:
+`.agents/skills/`):
 
 - **`adding-a-dsl-feature`** — the end-to-end workflow for a new DSL feature.
 - **`idiomatic-kotlin-dsl`** — **required reading before designing or planning any API surface**: the resolution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,137 +8,152 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 
 ## [0.2.0](https://github.com/LMLiam/Kotventure/compare/0.1.0...0.2.0) (2026-06-15)
 
-
 ### ✨ Features
 
-* **minimessage:** add typed placeholders ([#142](https://github.com/LMLiam/Kotventure/issues/142)) ([02ce043](https://github.com/LMLiam/Kotventure/commit/02ce04337ad870b4a7f09cbfd7e09a670a1a13b8))
-* **minimessage:** add typed reusable message templates ([#144](https://github.com/LMLiam/Kotventure/issues/144)) ([722a5cd](https://github.com/LMLiam/Kotventure/commit/722a5cd92a9425e6e6e88b2e00abb1377fc8a5a1))
-* **minimessage:** validate markup and placeholders ([#145](https://github.com/LMLiam/Kotventure/issues/145)) ([bd3d6be](https://github.com/LMLiam/Kotventure/commit/bd3d6be2230b64aaeaafe39cc4c49de73a1c4f10))
-
+* **minimessage:** add typed
+  placeholders ([#142](https://github.com/LMLiam/Kotventure/issues/142)) ([02ce043](https://github.com/LMLiam/Kotventure/commit/02ce04337ad870b4a7f09cbfd7e09a670a1a13b8))
+* **minimessage:** add typed reusable message
+  templates ([#144](https://github.com/LMLiam/Kotventure/issues/144)) ([722a5cd](https://github.com/LMLiam/Kotventure/commit/722a5cd92a9425e6e6e88b2e00abb1377fc8a5a1))
+* **minimessage:** validate markup and
+  placeholders ([#145](https://github.com/LMLiam/Kotventure/issues/145)) ([bd3d6be](https://github.com/LMLiam/Kotventure/commit/bd3d6be2230b64aaeaafe39cc4c49de73a1c4f10))
 
 ### 📝 Documentation
 
-* **skills:** add detailed guidelines for agents and DSL workflows ([182a423](https://github.com/LMLiam/Kotventure/commit/182a4235bf20454eb351788c30871051b1fe228f))
+* **skills:** add detailed guidelines for agents and DSL
+  workflows ([182a423](https://github.com/LMLiam/Kotventure/commit/182a4235bf20454eb351788c30871051b1fe228f))
 
 ## [0.1.0](https://github.com/LMLiam/Kotventure/compare/0.0.11...0.1.0) (2026-06-12)
 
-
 ### ✨ Features
 
-* **minimessage:** add mini() passthrough and a tag-resolver DSL ([#138](https://github.com/LMLiam/Kotventure/issues/138)) ([5cd2a6b](https://github.com/LMLiam/Kotventure/commit/5cd2a6b03f6fe6385ea8a106ab3af3e59d75b6d4))
+* **minimessage:** add mini() passthrough and a tag-resolver
+  DSL ([#138](https://github.com/LMLiam/Kotventure/issues/138)) ([5cd2a6b](https://github.com/LMLiam/Kotventure/commit/5cd2a6b03f6fe6385ea8a106ab3af3e59d75b6d4))
 
 ## [0.0.11](https://github.com/LMLiam/Kotventure/compare/0.0.10...0.0.11) (2026-06-12)
 
-
 ### ✨ Features
 
-* **core:** add the component joining dsl ([#134](https://github.com/LMLiam/Kotventure/issues/134)) ([384e620](https://github.com/LMLiam/Kotventure/commit/384e620a4bbd9a5b39990009d28c8bee7d8487d7))
-
+* **core:** add the component joining
+  dsl ([#134](https://github.com/LMLiam/Kotventure/issues/134)) ([384e620](https://github.com/LMLiam/Kotventure/commit/384e620a4bbd9a5b39990009d28c8bee7d8487d7))
 
 ### 🔧 Refactors
 
-* **core:** rename XScopeBuilder classes to XBuilder ([#137](https://github.com/LMLiam/Kotventure/issues/137)) ([a95b834](https://github.com/LMLiam/Kotventure/commit/a95b834959e21b3fe6075c29ded8228fc464095a))
-
+* **core:** rename XScopeBuilder classes to
+  XBuilder ([#137](https://github.com/LMLiam/Kotventure/issues/137)) ([a95b834](https://github.com/LMLiam/Kotventure/commit/a95b834959e21b3fe6075c29ded8228fc464095a))
 
 ### 📝 Documentation
 
-* **skills:** clarify API design guidelines and enforce pre-planning checks ([ab5e4a9](https://github.com/LMLiam/Kotventure/commit/ab5e4a9fcecd4b81291144bbe8fb5ab5347b95e2))
+* **skills:** clarify API design guidelines and enforce pre-planning
+  checks ([ab5e4a9](https://github.com/LMLiam/Kotventure/commit/ab5e4a9fcecd4b81291144bbe8fb5ab5347b95e2))
 
 ## [0.0.10](https://github.com/LMLiam/Kotventure/compare/0.0.9...0.0.10) (2026-06-12)
 
-
 ### ✨ Features
 
-* **core:** add design-system themes and a registry ([#130](https://github.com/LMLiam/Kotventure/issues/130)) ([e968324](https://github.com/LMLiam/Kotventure/commit/e9683249b1d2c9d51c4aa0138d299f144dd2d0b4))
-
+* **core:** add design-system themes and a
+  registry ([#130](https://github.com/LMLiam/Kotventure/issues/130)) ([e968324](https://github.com/LMLiam/Kotventure/commit/e9683249b1d2c9d51c4aa0138d299f144dd2d0b4))
 
 ### 🔧 Refactors
 
-* **core:** internalize the registry behind feature facades ([#133](https://github.com/LMLiam/Kotventure/issues/133)) ([0b0cdb3](https://github.com/LMLiam/Kotventure/commit/0b0cdb3bec43dd9fdb0e961480ebcf8399d74acc))
+* **core:** internalize the registry behind feature
+  facades ([#133](https://github.com/LMLiam/Kotventure/issues/133)) ([0b0cdb3](https://github.com/LMLiam/Kotventure/commit/0b0cdb3bec43dd9fdb0e961480ebcf8399d74acc))
 
 ## [0.0.9](https://github.com/LMLiam/Kotventure/compare/0.0.8...0.0.9) (2026-06-11)
 
-
 ### ✨ Features
 
-* **core:** add click event dsl ([#125](https://github.com/LMLiam/Kotventure/issues/125)) ([a24b11f](https://github.com/LMLiam/Kotventure/commit/a24b11fe2660d138b16b3cf98816e879d0779402))
-* **core:** add hover event dsl ([#128](https://github.com/LMLiam/Kotventure/issues/128)) ([e089e58](https://github.com/LMLiam/Kotventure/commit/e089e58bb6e4ace4722da4bca7d769098b4ab28f))
-* **core:** replace direct click helpers ([#129](https://github.com/LMLiam/Kotventure/issues/129)) ([8090219](https://github.com/LMLiam/Kotventure/commit/8090219070789305bfe3b874292146069e1e10c3))
+* **core:** add click event
+  dsl ([#125](https://github.com/LMLiam/Kotventure/issues/125)) ([a24b11f](https://github.com/LMLiam/Kotventure/commit/a24b11fe2660d138b16b3cf98816e879d0779402))
+* **core:** add hover event
+  dsl ([#128](https://github.com/LMLiam/Kotventure/issues/128)) ([e089e58](https://github.com/LMLiam/Kotventure/commit/e089e58bb6e4ace4722da4bca7d769098b4ab28f))
+* **core:** replace direct click
+  helpers ([#129](https://github.com/LMLiam/Kotventure/issues/129)) ([8090219](https://github.com/LMLiam/Kotventure/commit/8090219070789305bfe3b874292146069e1e10c3))
 
 ## [0.0.8](https://github.com/LMLiam/Kotventure/compare/0.0.7...0.0.8) (2026-06-11)
 
-
 ### ✨ Features
 
-* **core:** add colour and gradient helpers ([#123](https://github.com/LMLiam/Kotventure/issues/123)) ([0482b7f](https://github.com/LMLiam/Kotventure/commit/0482b7f2c135419f1cc46ec2f78372bba5749b67))
+* **core:** add colour and gradient
+  helpers ([#123](https://github.com/LMLiam/Kotventure/issues/123)) ([0482b7f](https://github.com/LMLiam/Kotventure/commit/0482b7f2c135419f1cc46ec2f78372bba5749b67))
 
 ## [0.0.7](https://github.com/LMLiam/Kotventure/compare/0.0.6...0.0.7) (2026-06-10)
 
-
 ### ✨ Features
 
-* **core:** add object component dsl ([#120](https://github.com/LMLiam/Kotventure/issues/120)) ([48e4618](https://github.com/LMLiam/Kotventure/commit/48e46184b27f4513751e82f1efedc575046eb306))
-* **core:** add reusable style dsl ([#122](https://github.com/LMLiam/Kotventure/issues/122)) ([b4231e4](https://github.com/LMLiam/Kotventure/commit/b4231e49d084948e4b967bc08ceb05f613ef4999))
+* **core:** add object component
+  dsl ([#120](https://github.com/LMLiam/Kotventure/issues/120)) ([48e4618](https://github.com/LMLiam/Kotventure/commit/48e46184b27f4513751e82f1efedc575046eb306))
+* **core:** add reusable style
+  dsl ([#122](https://github.com/LMLiam/Kotventure/issues/122)) ([b4231e4](https://github.com/LMLiam/Kotventure/commit/b4231e49d084948e4b967bc08ceb05f613ef4999))
 
 ## [0.0.6](https://github.com/LMLiam/Kotventure/compare/0.0.5...0.0.6) (2026-06-10)
 
-
 ### ✨ Features
 
-* **core:** add adventure key helpers ([#118](https://github.com/LMLiam/Kotventure/issues/118)) ([e20e326](https://github.com/LMLiam/Kotventure/commit/e20e326ae0e5c644acc406a6727e61aa2b32d17c))
-* **core:** add block nbt position helpers ([#116](https://github.com/LMLiam/Kotventure/issues/116)) ([e4465d4](https://github.com/LMLiam/Kotventure/commit/e4465d4798107ee3511d530e8095611ebb40f846))
+* **core:** add adventure key
+  helpers ([#118](https://github.com/LMLiam/Kotventure/issues/118)) ([e20e326](https://github.com/LMLiam/Kotventure/commit/e20e326ae0e5c644acc406a6727e61aa2b32d17c))
+* **core:** add block nbt position
+  helpers ([#116](https://github.com/LMLiam/Kotventure/issues/116)) ([e4465d4](https://github.com/LMLiam/Kotventure/commit/e4465d4798107ee3511d530e8095611ebb40f846))
 
 ## [0.0.5](https://github.com/LMLiam/Kotventure/compare/0.0.4...0.0.5) (2026-06-10)
 
-
 ### ✨ Features
 
-* **core:** add block, entity and storage nbt components ([#112](https://github.com/LMLiam/Kotventure/issues/112)) ([ae5f438](https://github.com/LMLiam/Kotventure/commit/ae5f4382cc027002a174add91a715f79714b9b86))
+* **core:** add block, entity and storage nbt
+  components ([#112](https://github.com/LMLiam/Kotventure/issues/112)) ([ae5f438](https://github.com/LMLiam/Kotventure/commit/ae5f4382cc027002a174add91a715f79714b9b86))
 
 ## [0.0.4](https://github.com/LMLiam/Kotventure/compare/0.0.3...0.0.4) (2026-06-10)
 
-
 ### ✨ Features
 
-* **core:** add keybind, score and selector components ([#110](https://github.com/LMLiam/Kotventure/issues/110)) ([3d12be9](https://github.com/LMLiam/Kotventure/commit/3d12be9df99c2fbf9df6d2068f1ba47f64d1bf74))
+* **core:** add keybind, score and selector
+  components ([#110](https://github.com/LMLiam/Kotventure/issues/110)) ([3d12be9](https://github.com/LMLiam/Kotventure/commit/3d12be9df99c2fbf9df6d2068f1ba47f64d1bf74))
 
 ## [0.0.3](https://github.com/LMLiam/Kotventure/compare/0.0.2...0.0.3) (2026-06-09)
 
-
 ### ✨ Features
 
-* **core:** add translatable component builder ([#108](https://github.com/LMLiam/Kotventure/issues/108)) ([2453b68](https://github.com/LMLiam/Kotventure/commit/2453b68c666e0d6fbb62d3b075301235650d3771))
+* **core:** add translatable component
+  builder ([#108](https://github.com/LMLiam/Kotventure/issues/108)) ([2453b68](https://github.com/LMLiam/Kotventure/commit/2453b68c666e0d6fbb62d3b075301235650d3771))
 
 ## [0.0.2](https://github.com/LMLiam/Kotventure/compare/0.0.1...0.0.2) (2026-06-09)
 
-
 ### ✨ Features
 
-* **core:** add serializer extensions ([#96](https://github.com/LMLiam/Kotventure/issues/96)) ([eb43bc1](https://github.com/LMLiam/Kotventure/commit/eb43bc1d03a2fc99eddef21fc598c17d071d9ed8))
-* **core:** add text decoration dsl ([#94](https://github.com/LMLiam/Kotventure/issues/94)) ([ae00907](https://github.com/LMLiam/Kotventure/commit/ae009075207ac5cb286b90080653b680068478d3))
-* **core:** complete text component builder ([#102](https://github.com/LMLiam/Kotventure/issues/102)) ([5a35ff7](https://github.com/LMLiam/Kotventure/commit/5a35ff74e959df9106811748cb8e0ed32f7ffbe9))
-
+* **core:** add serializer
+  extensions ([#96](https://github.com/LMLiam/Kotventure/issues/96)) ([eb43bc1](https://github.com/LMLiam/Kotventure/commit/eb43bc1d03a2fc99eddef21fc598c17d071d9ed8))
+* **core:** add text decoration
+  dsl ([#94](https://github.com/LMLiam/Kotventure/issues/94)) ([ae00907](https://github.com/LMLiam/Kotventure/commit/ae009075207ac5cb286b90080653b680068478d3))
+* **core:** complete text component
+  builder ([#102](https://github.com/LMLiam/Kotventure/issues/102)) ([5a35ff7](https://github.com/LMLiam/Kotventure/commit/5a35ff74e959df9106811748cb8e0ed32f7ffbe9))
 
 ### 🐛 Fixes
 
-* **repo:** retarget issue template triage label ([f7b4d8e](https://github.com/LMLiam/Kotventure/commit/f7b4d8e7c84d6e52f2481bf519291d5b6889e86e))
-
+* **repo:** retarget issue template triage
+  label ([f7b4d8e](https://github.com/LMLiam/Kotventure/commit/f7b4d8e7c84d6e52f2481bf519291d5b6889e86e))
 
 ### 🔧 Refactors
 
-* **core:** remove ServiceLoader SPI for a hybrid registry ([#87](https://github.com/LMLiam/Kotventure/issues/87)) ([727ddb7](https://github.com/LMLiam/Kotventure/commit/727ddb7223c9d0457d46115057785d51f56f1fdc))
-
+* **core:** remove ServiceLoader SPI for a hybrid
+  registry ([#87](https://github.com/LMLiam/Kotventure/issues/87)) ([727ddb7](https://github.com/LMLiam/Kotventure/commit/727ddb7223c9d0457d46115057785d51f56f1fdc))
 
 ### 📝 Documentation
 
-* **docs:** add pre-alpha plan and roadmap ([#3](https://github.com/LMLiam/Kotventure/issues/3)) ([7c64292](https://github.com/LMLiam/Kotventure/commit/7c64292e8ac1e08367c5fc77b2c6258841c1a73e))
-* **readme:** add Adventure API version badge ([777ad48](https://github.com/LMLiam/Kotventure/commit/777ad4899bc9c0778e87dbef6f44d064a3a3b2a0))
-* **readme:** describe project goals ([3250a2a](https://github.com/LMLiam/Kotventure/commit/3250a2a48b47ed94efdcac2de5acb861f3a37f4a))
-* **readme:** fix license link ([651e012](https://github.com/LMLiam/Kotventure/commit/651e01216fd40fd4bfc7a4fd72f2e95c78901d44))
-* **readme:** link documentation ([4c18f9f](https://github.com/LMLiam/Kotventure/commit/4c18f9fa349bfcaabb57020da4c90589899d09fe))
-* **readme:** sync Kotlin badge with latest ([be7dd24](https://github.com/LMLiam/Kotventure/commit/be7dd24f7768f68be7f97cbcc4878ee1f597919d))
-* **repo:** add MIT license ([4b83302](https://github.com/LMLiam/Kotventure/commit/4b833021fc1844e6884cb82085c6a219456eabd6))
-* **repo:** rename project to Kotventure ([122487f](https://github.com/LMLiam/Kotventure/commit/122487f0f59be14c2f54705280e3cb95a3c7aaf7))
+* **docs:** add pre-alpha plan and
+  roadmap ([#3](https://github.com/LMLiam/Kotventure/issues/3)) ([7c64292](https://github.com/LMLiam/Kotventure/commit/7c64292e8ac1e08367c5fc77b2c6258841c1a73e))
+* **readme:** add Adventure API version
+  badge ([777ad48](https://github.com/LMLiam/Kotventure/commit/777ad4899bc9c0778e87dbef6f44d064a3a3b2a0))
+* **readme:** describe project
+  goals ([3250a2a](https://github.com/LMLiam/Kotventure/commit/3250a2a48b47ed94efdcac2de5acb861f3a37f4a))
+* **readme:** fix license
+  link ([651e012](https://github.com/LMLiam/Kotventure/commit/651e01216fd40fd4bfc7a4fd72f2e95c78901d44))
+* **readme:** link
+  documentation ([4c18f9f](https://github.com/LMLiam/Kotventure/commit/4c18f9fa349bfcaabb57020da4c90589899d09fe))
+* **readme:** sync Kotlin badge with
+  latest ([be7dd24](https://github.com/LMLiam/Kotventure/commit/be7dd24f7768f68be7f97cbcc4878ee1f597919d))
+* **repo:** add MIT
+  license ([4b83302](https://github.com/LMLiam/Kotventure/commit/4b833021fc1844e6884cb82085c6a219456eabd6))
+* **repo:** rename project to
+  Kotventure ([122487f](https://github.com/LMLiam/Kotventure/commit/122487f0f59be14c2f54705280e3cb95a3c7aaf7))
 
 ## [Unreleased]
 
@@ -152,7 +167,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
   unparsed, and component values, and `ComponentScope.mini(...)` integration for use inside the core DSL.
 - Text DSL composition helpers: `append(Component)`, `newline()`, and inline `style { }` blocks for the current
   component.
-- Translatable component DSL support for translation keys, fallback text, component arguments, boolean arguments, numeric
+- Translatable component DSL support for translation keys, fallback text, component arguments, boolean arguments,
+  numeric
   arguments, root styling, and child components.
 - Translatable component matchers for asserting keys, fallback text, and translation arguments in Kotest specs.
 - Shared `ComponentScope` support for styling and child builders across every component DSL scope.
@@ -171,7 +187,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 - Colour and gradient helpers for `hex("#RRGGBB")`, `rgb(...)`, normalized `hsv(...)`, named palette aliases,
   interpolation, and per-code-point gradient text.
 - Click event DSL support for Adventure's typed click actions and server-side callbacks, including reusable `click { }`
-  factories, scoped block application, file-URI-aware `open`, Kotlin duration callback options, and click-event component
+  factories, scoped block application, file-URI-aware `open`, Kotlin duration callback options, and click-event
+  component
   matchers.
 - Hover event DSL support for typed text, item data component, and entity payloads, including reusable hover factories,
   clearing/prebuilt interop, MiniMessage round-trip coverage, and hover-event component matchers.
@@ -222,4 +239,5 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 - Kotventure builds with the Java 25 Gradle toolchain; Adventure 5.x sets a Java 21+ consumer minimum.
 
 [Unreleased]: https://github.com/LMLiam/Kotventure/compare/0.0.1...HEAD
+
 [0.0.1]: https://github.com/LMLiam/Kotventure/releases/tag/0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,7 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
 ### Added
 
 - `miniToDsl(input)` in `kotventure-minimessage` for converting MiniMessage text into Kotventure DSL source for plain
-  text, recursive children, named/hex colours, and standard text decorations.
+  text, recursive children, named/hex colours, standard text decorations, and click/hover events.
 - Typed MiniMessage placeholders via `placeholder<T>(name)` and `resolve(...)`, covering component, string, numeric,
   and boolean values.
 - MiniMessage passthrough parsing via `kotventure-minimessage`, including `mini(...)`, placeholder resolvers for parsed,

--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ This project aims to:
 
 ## 📦 Modules (target architecture)
 
-| Module                          | Purpose                                                                          |
-|---------------------------------|----------------------------------------------------------------------------------|
-| `core`                          | Component / style / colour DSL, themes, audience-send DSL                        |
-| `serializer`                    | Optional Adventure serializer extension functions                                |
-| `minimessage`                   | Typed MiniMessage templates, validation, MiniMessage ⇄ DSL converter             |
-| `i18n`                          | Translation registry + per-player locale DSL                                     |
-| `test`                          | Kotest/JUnit component matchers + snapshot testing                               |
-| `ansi`                          | Render a `Component` to coloured terminal output                                 |
-| `coroutines`                    | suspend click-callbacks, async sending, animation scheduling                     |
-| `paper` / `velocity` / `fabric` | Platform adapters & extras                                                       |
-| `ksp`                           | Typed message-catalog codegen + compile-time validation                          |
-| `gradle-plugin`                 | Validate / pre-compile MiniMessage resource bundles at build time                |
-| `bom`                           | Bill of materials for aligning Kotventure and Adventure module versions          |
+| Module                          | Purpose                                                                 |
+|---------------------------------|-------------------------------------------------------------------------|
+| `core`                          | Component / style / colour DSL, themes, audience-send DSL               |
+| `serializer`                    | Optional Adventure serializer extension functions                       |
+| `minimessage`                   | Typed MiniMessage templates, validation, MiniMessage ⇄ DSL converter    |
+| `i18n`                          | Translation registry + per-player locale DSL                            |
+| `test`                          | Kotest/JUnit component matchers + snapshot testing                      |
+| `ansi`                          | Render a `Component` to coloured terminal output                        |
+| `coroutines`                    | suspend click-callbacks, async sending, animation scheduling            |
+| `paper` / `velocity` / `fabric` | Platform adapters & extras                                              |
+| `ksp`                           | Typed message-catalog codegen + compile-time validation                 |
+| `gradle-plugin`                 | Validate / pre-compile MiniMessage resource bundles at build time       |
+| `bom`                           | Bill of materials for aligning Kotventure and Adventure module versions |
 
 See [`docs/DESIGN.md`](docs/DESIGN.md) for the full design and the [Roadmap](docs/ROADMAP.md) for sequencing.
 
@@ -323,7 +323,8 @@ val forSam = WelcomeTemplate {
 
 `validate(input, placeholders)` checks a MiniMessage string against a declared set of placeholders and returns a
 structured `ValidationResult` — no exception escapes to the caller. It runs two passes: a strict-mode parse that catches
-malformed or unclosed tags, and a recording parse that cross-checks which placeholder tags appear in the input. Note that
+malformed or unclosed tags, and a recording parse that cross-checks which placeholder tags appear in the input. Note
+that
 strict mode requires all standard child-allowing tags (such as `<gold>`) to be explicitly closed; an unclosed standard
 tag is reported as a `MalformedTag` diagnostic.
 
@@ -495,7 +496,8 @@ val plain = message.toPlainText()
 
 `kotventure-test` starts the testing toolkit with structural component matchers such as `shouldContainText`,
 `shouldHaveColor`, `shouldHaveDecoration`, `shouldNotHaveDecoration`, `shouldHaveChildCount`, and translatable-specific
-assertions for keys, fallbacks, and arguments. It also includes keybind, score, selector, object component, block, entity,
+assertions for keys, fallbacks, and arguments. It also includes keybind, score, selector, object component, block,
+entity,
 and storage NBT assertions for the smaller component DSLs, plus click-event and hover-event assertions for all
 components.
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ val dslSource = miniToDsl("<red><bold>Hello")
 //         bold()
 //     }
 // }
+// Supported output also includes click { ... } and hover { ... } blocks for Adventure click and hover events.
 ```
 
 For messages that are rendered many times with different values, declare a typed template once and reuse it. Each

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -29,12 +29,12 @@ access.
 
 ## 2. Prior art & differentiation
 
-| Project                            | What it is                                                                  | Gap we exploit                                                              |
-|------------------------------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| Adventure's retired Kotlin extras  | Former official Kotlin builders/operators                                   | Removed in Adventure 5.0; no MiniMessage tooling, testing, or platform UX   |
-| Pluto‑Studio/`adventure-kt`        | The serious rival — component DSL, `mini()`, styles, titles, multi‑platform | No typed/validated MiniMessage, no testing toolkit, no codegen/ANSI tooling |
-| HoshiKurama component DSL          | `buildComponent {}`                                                         | Stale (2021), narrow                                                        |
-| KSpigot / KPaper                   | Broad Kotlin server libs that *include* a chat DSL                          | Not Adventure‑focused; tied to broader frameworks                           |
+| Project                           | What it is                                                                  | Gap we exploit                                                              |
+|-----------------------------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| Adventure's retired Kotlin extras | Former official Kotlin builders/operators                                   | Removed in Adventure 5.0; no MiniMessage tooling, testing, or platform UX   |
+| Pluto‑Studio/`adventure-kt`       | The serious rival — component DSL, `mini()`, styles, titles, multi‑platform | No typed/validated MiniMessage, no testing toolkit, no codegen/ANSI tooling |
+| HoshiKurama component DSL         | `buildComponent {}`                                                         | Stale (2021), narrow                                                        |
+| KSpigot / KPaper                  | Broad Kotlin server libs that *include* a chat DSL                          | Not Adventure‑focused; tied to broader frameworks                           |
 
 **Conclusion:** compete on *breadth + correctness tooling*, not on the basic component builder alone.
 
@@ -54,22 +54,22 @@ A **hybrid** structure: idiomatic DSL for ~95% of the surface, a small **explici
 behaviour, and **KSP** for compile‑time codegen. The previous `ServiceLoader`/`@ServiceContract` factory indirection is
 **removed** — it is unnecessary ceremony for a DSL library.
 
-| Module                | Depends on                             | Purpose                                                                                                                               |
-|-----------------------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `core`                | `adventure-api`                        | Component/style/colour/gradient DSL, theme engine, the registry, audience‑send DSL, animation **abstractions**                         |
-| `serializer`          | `adventure-api`, concrete serializers  | Optional `Component` serializer extensions such as MiniMessage and plain text                                                          |
-| `minimessage`         | `core`, `adventure-text-minimessage`   | Typed tag/placeholder DSL, typed templates, validation, MiniMessage ⇄ DSL converter                                                   |
-| `i18n`                | `core`, `minimessage`                  | Translation registry + per‑player locale DSL                                                                                          |
-| `test`                | `core` (test‑scoped for consumers)     | Kotest/JUnit matchers + snapshot testing                                                                                              |
-| `ansi`                | `core`                                 | Render a `Component` to coloured terminal output                                                                                      |
-| `coroutines`          | `core`, `kotlinx-coroutines`           | suspend click‑callbacks, async sending, animation scheduling                                                                          |
-| `annotations` + `ksp` | —                                      | Typed message‑catalog codegen + compile‑time style validation                                                                         |
-| `paper`               | `core` (+ Paper)                       | Scheduler/audience adapter, item **lore**/display‑name builders                                                                       |
-| `velocity`            | `core` (+ Velocity)                    | Proxy scheduler/audience adapter                                                                                                      |
-| `fabric`              | `core` (+ `adventure-platform-fabric`) | Fabric adapter                                                                                                                        |
-| `gradle-plugin`       | (own build)                            | Validate / pre‑compile MiniMessage resource bundles at build time                                                                     |
-| `bom`                 | —                                      | Bill‑of‑materials so consumers pin one version                                                                                        |
-| `e2e`                 | (all)                                  | Cross‑module integration tests                                                                                                        |
+| Module                | Depends on                             | Purpose                                                                                                        |
+|-----------------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| `core`                | `adventure-api`                        | Component/style/colour/gradient DSL, theme engine, the registry, audience‑send DSL, animation **abstractions** |
+| `serializer`          | `adventure-api`, concrete serializers  | Optional `Component` serializer extensions such as MiniMessage and plain text                                  |
+| `minimessage`         | `core`, `adventure-text-minimessage`   | Typed tag/placeholder DSL, typed templates, validation, MiniMessage ⇄ DSL converter                            |
+| `i18n`                | `core`, `minimessage`                  | Translation registry + per‑player locale DSL                                                                   |
+| `test`                | `core` (test‑scoped for consumers)     | Kotest/JUnit matchers + snapshot testing                                                                       |
+| `ansi`                | `core`                                 | Render a `Component` to coloured terminal output                                                               |
+| `coroutines`          | `core`, `kotlinx-coroutines`           | suspend click‑callbacks, async sending, animation scheduling                                                   |
+| `annotations` + `ksp` | —                                      | Typed message‑catalog codegen + compile‑time style validation                                                  |
+| `paper`               | `core` (+ Paper)                       | Scheduler/audience adapter, item **lore**/display‑name builders                                                |
+| `velocity`            | `core` (+ Velocity)                    | Proxy scheduler/audience adapter                                                                               |
+| `fabric`              | `core` (+ `adventure-platform-fabric`) | Fabric adapter                                                                                                 |
+| `gradle-plugin`       | (own build)                            | Validate / pre‑compile MiniMessage resource bundles at build time                                              |
+| `bom`                 | —                                      | Bill‑of‑materials so consumers pin one version                                                                 |
+| `e2e`                 | (all)                                  | Cross‑module integration tests                                                                                 |
 
 Modules are introduced **lazily, per phase** — not all scaffolded up front — to keep each change small.
 
@@ -252,23 +252,23 @@ with its own tests — to keep changes small and incremental.
 
 ## 12. Feature → phase matrix
 
-| Feature                           | Phase               |
-|-----------------------------------|---------------------|
-| Component test matchers           | 0 (seed) → 1 (full) |
-| Snapshot / golden testing         | 1                   |
-| Compile‑time style validation     | 4                   |
-| MiniMessage ⇄ DSL converter       | 1                   |
-| Animations                        | 3                   |
-| Chat pagination                   | 2                   |
-| GUI / lore & item‑text builders   | 2                   |
-| Managed boss bars / titles        | 2                   |
-| Typed message catalog (codegen)   | 3                   |
-| Translation registry + locale DSL | 3                   |
-| Design‑system themes              | 1                   |
-| Colour & gradient helpers         | 1                   |
-| ANSI terminal preview             | 3                   |
-| Coroutine integration             | 2                   |
-| Gradle build plugin               | 3                   |
+| Feature                           | Phase                             |
+|-----------------------------------|-----------------------------------|
+| Component test matchers           | 0 (seed) → 1 (full)               |
+| Snapshot / golden testing         | 1                                 |
+| Compile‑time style validation     | 4                                 |
+| MiniMessage ⇄ DSL converter       | 1                                 |
+| Animations                        | 3                                 |
+| Chat pagination                   | 2                                 |
+| GUI / lore & item‑text builders   | 2                                 |
+| Managed boss bars / titles        | 2                                 |
+| Typed message catalog (codegen)   | 3                                 |
+| Translation registry + locale DSL | 3                                 |
+| Design‑system themes              | 1                                 |
+| Colour & gradient helpers         | 1                                 |
+| ANSI terminal preview             | 3                                 |
+| Coroutine integration             | 2                                 |
+| Gradle build plugin               | 3                                 |
 | Serializer extensions             | 0 (seed, `serializer`) → 1 (full) |
 
 ## 13. Open questions / future

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -33,7 +33,8 @@ release bot behind `RELEASE_PLEASE_TOKEN` to create and update the Release PR br
 only after the required checks pass.
 
 If branch protection requires all PR checks, use `RELEASE_PLEASE_TOKEN` so the Release PR triggers the same CI workflows
-as human-authored PRs. If the repository falls back to `GITHUB_TOKEN`, release-please can still open PRs, but GitHub will
+as human-authored PRs. If the repository falls back to `GITHUB_TOKEN`, release-please can still open PRs, but GitHub
+will
 suppress workflows triggered by that token's PR, tag, and release events.
 
 ## Publishing Coordination

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/KotlinSourceBuilder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/KotlinSourceBuilder.kt
@@ -1,0 +1,59 @@
+package io.github.lmliam.kotventure.minimessage
+
+/**
+ * Accumulates indented lines of Kotlin source, owning indentation so callers describe the structure to emit rather than
+ * the whitespace in front of it.
+ */
+internal class KotlinSourceBuilder {
+    private val lines = mutableListOf<String>()
+    private var depth = 0
+
+    /** Appends [text] as one line at the current indentation. */
+    fun line(text: String) {
+        lines += INDENT.repeat(depth) + text
+    }
+
+    /** Emits `$header {`, runs [body] one level deeper, then the closing brace. */
+    fun block(
+        header: String,
+        body: KotlinSourceBuilder.() -> Unit,
+    ) {
+        line("$header {")
+        indented(body)
+        line("}")
+    }
+
+    /** Runs [body] one indentation level deeper. */
+    fun indented(body: KotlinSourceBuilder.() -> Unit) {
+        depth++
+        body()
+        depth--
+    }
+
+    /**
+     * Emits [opener], then each lambda in [arguments] on its own indented line, comma-separated with no trailing comma.
+     * The caller emits the closer so the choice between `)` and `) {` stays theirs.
+     */
+    fun openArguments(
+        opener: String,
+        arguments: List<() -> Unit>,
+    ) {
+        line(opener)
+        indented { commaSeparated(arguments) }
+    }
+
+    override fun toString(): String = lines.joinToString(separator = "\n")
+
+    private fun commaSeparated(parts: List<() -> Unit>) {
+        parts.forEachIndexed { index, part ->
+            part()
+            if (index != parts.lastIndex) {
+                lines[lines.lastIndex] += ","
+            }
+        }
+    }
+
+    private companion object {
+        const val INDENT: String = "    "
+    }
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/KotlinSourceBuilder.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/KotlinSourceBuilder.kt
@@ -3,6 +3,10 @@ package io.github.lmliam.kotventure.minimessage
 /**
  * Accumulates indented lines of Kotlin source, owning indentation so callers describe the structure to emit rather than
  * the whitespace in front of it.
+ *
+ * This type is generic Kotlin codegen and is not specific to MiniMessage; it lives here while `minimessage` is its only
+ * consumer. When a second consumer appears it should be promoted to a shared codegen module (tracked under the module
+ * restructure, issue #7) rather than reaching across feature packages.
  */
 internal class KotlinSourceBuilder {
     private val lines = mutableListOf<String>()

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
@@ -11,9 +11,9 @@ public fun mini(input: String): Component = parseMiniMessage(input)
 /**
  * Converts MiniMessage [input] into Kotventure component DSL source code.
  *
- * This first slice supports plain text, recursive text children, named and hex colours, and the standard text
- * decorations. Unsupported component types or style attributes from later slices fail with an [IllegalArgumentException]
- * instead of producing lossy source.
+ * The current slices support plain text, recursive text children, named and hex colours, the standard text decorations,
+ * click events, and hover events. Unsupported component types or style attributes from later slices fail with an
+ * [IllegalArgumentException] instead of producing lossy source.
  */
 public fun miniToDsl(input: String): String = MiniMessageToDslWriter.write(mini(input))
 

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslLiterals.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslLiterals.kt
@@ -25,6 +25,7 @@ internal fun dataComponentValueLiteral(value: DataComponentValue): String =
         is BinaryTagHolder -> "BinaryTagHolder.binaryTagHolder(\"${escapeKotlinString(value.string())}\")"
         is DataComponentValue.TagSerializable ->
             "BinaryTagHolder.binaryTagHolder(\"${escapeKotlinString(value.asBinaryTag().string())}\")"
+
         is DataComponentValue.Removed -> "DataComponentValue.removed()"
         else -> throw IllegalArgumentException(
             "miniToDsl does not yet support data component value ${value::class.qualifiedName}.",

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslLiterals.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslLiterals.kt
@@ -41,7 +41,7 @@ internal fun escapeKotlinString(value: String): String =
                 '\n' -> append("\\n")
                 '\r' -> append("\\r")
                 '\t' -> append("\\t")
-                '$' -> append("\\\$")
+                '$' -> append('\\').append('$')
                 else -> append(character)
             }
         }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslLiterals.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslLiterals.kt
@@ -1,0 +1,48 @@
+package io.github.lmliam.kotventure.minimessage
+
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.nbt.api.BinaryTagHolder
+import net.kyori.adventure.text.event.DataComponentValue
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextColor
+import java.util.Locale
+
+/** Renders [color] as the Kotventure colour-DSL expression that reconstructs it. */
+internal fun colorLiteral(color: TextColor): String =
+    if (color is NamedTextColor) {
+        "NamedTextColor.${color.name().uppercase(Locale.ROOT)}"
+    } else {
+        "TextColor.color(0x${color.asHexString().removePrefix("#").uppercase(Locale.ROOT)})"
+    }
+
+/** Renders [key] as a `key("namespace", "value")` call. */
+internal fun keyLiteral(key: Key): String =
+    "key(\"${escapeKotlinString(key.namespace())}\", \"${escapeKotlinString(key.value())}\")"
+
+/** Renders [value] as the Kotlin expression that reconstructs it, rejecting payloads the DSL cannot represent. */
+internal fun dataComponentValueLiteral(value: DataComponentValue): String =
+    when (value) {
+        is BinaryTagHolder -> "BinaryTagHolder.binaryTagHolder(\"${escapeKotlinString(value.string())}\")"
+        is DataComponentValue.TagSerializable ->
+            "BinaryTagHolder.binaryTagHolder(\"${escapeKotlinString(value.asBinaryTag().string())}\")"
+        is DataComponentValue.Removed -> "DataComponentValue.removed()"
+        else -> throw IllegalArgumentException(
+            "miniToDsl does not yet support data component value ${value::class.qualifiedName}.",
+        )
+    }
+
+/** Escapes [value] for embedding inside a double-quoted Kotlin string literal. */
+internal fun escapeKotlinString(value: String): String =
+    buildString {
+        value.forEach { character ->
+            when (character) {
+                '\\' -> append("\\\\")
+                '"' -> append("\\\"")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                '$' -> append("\\\$")
+                else -> append(character)
+            }
+        }
+    }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
@@ -49,6 +49,7 @@ internal object MiniMessageToDslSupport {
                 val entity = hover.value() as HoverEvent.ShowEntity
                 entity.name()?.let { name -> requireSupported(name) }
             }
+
             else -> Unit
         }
     }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
@@ -2,6 +2,7 @@ package io.github.lmliam.kotventure.minimessage
 
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.event.HoverEvent
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.format.TextDecoration.State
@@ -33,6 +34,22 @@ internal object MiniMessageToDslSupport {
         }
         require(style.shadowColor() == null) {
             "miniToDsl does not yet support shadow colours."
+        }
+        style.hoverEvent()?.let { hover -> requireSupportedHoverPayload(hover) }
+    }
+
+    /**
+     * Validates the nested component a hover event renders, so unsupported styles or non-text payloads are rejected up
+     * front instead of being silently dropped or triggering a cast failure while the DSL is written.
+     */
+    private fun requireSupportedHoverPayload(hover: HoverEvent<*>) {
+        when (hover.action()) {
+            HoverEvent.Action.SHOW_TEXT -> requireSupported(hover.value() as Component)
+            HoverEvent.Action.SHOW_ENTITY -> {
+                val entity = hover.value() as HoverEvent.ShowEntity
+                entity.name()?.let { name -> requireSupported(name) }
+            }
+            else -> Unit
         }
     }
 

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
@@ -18,7 +18,7 @@ internal object MiniMessageToDslSupport {
 
     fun requireSupported(component: Component) {
         require(component is TextComponent) {
-            "miniToDsl slice 1 supports only text component trees, but found ${component::class.simpleName}."
+            "miniToDsl supports only text component trees, but found ${component::class.simpleName}."
         }
         requireSupported(component.style())
         component.children().forEach(::requireSupported)
@@ -26,13 +26,13 @@ internal object MiniMessageToDslSupport {
 
     fun requireSupported(style: Style) {
         require(style.insertion() == null) {
-            "miniToDsl slice 2 does not support insertion text."
+            "miniToDsl does not yet support insertion text."
         }
         require(style.font() == null) {
-            "miniToDsl slice 2 does not support font styles."
+            "miniToDsl does not yet support font styles."
         }
         require(style.shadowColor() == null) {
-            "miniToDsl slice 2 does not support shadow colours."
+            "miniToDsl does not yet support shadow colours."
         }
     }
 

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
@@ -25,24 +25,20 @@ internal object MiniMessageToDslSupport {
     }
 
     fun requireSupported(style: Style) {
-        require(style.clickEvent() == null) {
-            "miniToDsl slice 1 does not support click events."
-        }
-        require(style.hoverEvent() == null) {
-            "miniToDsl slice 1 does not support hover events."
-        }
         require(style.insertion() == null) {
-            "miniToDsl slice 1 does not support insertion text."
+            "miniToDsl slice 2 does not support insertion text."
         }
         require(style.font() == null) {
-            "miniToDsl slice 1 does not support font styles."
+            "miniToDsl slice 2 does not support font styles."
         }
         require(style.shadowColor() == null) {
-            "miniToDsl slice 1 does not support shadow colours."
+            "miniToDsl slice 2 does not support shadow colours."
         }
     }
 
     fun hasDslOutput(style: Style): Boolean =
         style.color() != null ||
+                style.clickEvent() != null ||
+                style.hoverEvent() != null ||
                 decorations.any { (decoration) -> style.decoration(decoration) != State.NOT_SET }
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
@@ -1,7 +1,12 @@
 package io.github.lmliam.kotventure.minimessage
 
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.nbt.api.BinaryTagHolder
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.event.DataComponentValue
+import net.kyori.adventure.text.event.HoverEvent
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
@@ -17,24 +22,25 @@ internal object MiniMessageToDslWriter {
         }
 
         val lines = mutableListOf("component {")
-        appendRoot(component, lines)
+        appendRoot(component, 1, lines)
         lines += "}"
         return lines.joinToString(separator = "\n")
     }
 
     private fun appendRoot(
         component: Component,
+        indent: Int,
         lines: MutableList<String>,
     ) {
         if (component is TextComponent &&
             component.content().isEmpty() &&
             !MiniMessageToDslSupport.hasDslOutput(component.style())
         ) {
-            component.children().forEach { child -> appendComponent(child, 1, lines) }
+            component.children().forEach { child -> appendComponent(child, indent, lines) }
             return
         }
 
-        appendComponent(component, 1, lines)
+        appendComponent(component, indent, lines)
     }
 
     private fun appendComponent(
@@ -88,7 +94,152 @@ internal object MiniMessageToDslWriter {
             }
             lines += "${indent(indent)}}"
         }
+
+        style.clickEvent()?.let { event ->
+            appendClickEvent(event, indent, lines)
+        }
+
+        style.hoverEvent()?.let { event ->
+            appendHoverEvent(event, indent, lines)
+        }
     }
+
+    private fun appendClickEvent(
+        event: ClickEvent<*>,
+        indent: Int,
+        lines: MutableList<String>,
+    ) {
+        lines += "${indent(indent)}click {"
+        when (event.action()) {
+            ClickEvent.Action.OPEN_URL -> {
+                val payload = event.payload() as ClickEvent.Payload.Text
+                lines += "${indent(indent + 1)}openUrl(\"${escapeString(payload.value())}\")"
+            }
+            ClickEvent.Action.OPEN_FILE -> {
+                val payload = event.payload() as ClickEvent.Payload.Text
+                lines += "${indent(indent + 1)}openFile(\"${escapeString(payload.value())}\")"
+            }
+            ClickEvent.Action.RUN_COMMAND -> {
+                val payload = event.payload() as ClickEvent.Payload.Text
+                lines += "${indent(indent + 1)}run(\"${escapeString(payload.value())}\")"
+            }
+            ClickEvent.Action.SUGGEST_COMMAND -> {
+                val payload = event.payload() as ClickEvent.Payload.Text
+                lines += "${indent(indent + 1)}suggest(\"${escapeString(payload.value())}\")"
+            }
+            ClickEvent.Action.CHANGE_PAGE -> {
+                val payload = event.payload() as ClickEvent.Payload.Int
+                lines += "${indent(indent + 1)}changePage(${payload.integer()})"
+            }
+            ClickEvent.Action.COPY_TO_CLIPBOARD -> {
+                val payload = event.payload() as ClickEvent.Payload.Text
+                lines += "${indent(indent + 1)}copy(\"${escapeString(payload.value())}\")"
+            }
+            else -> {
+                lines += "${indent(indent + 1)}// callback not representable"
+            }
+        }
+        lines += "${indent(indent)}}"
+    }
+
+    private fun appendHoverEvent(
+        event: HoverEvent<*>,
+        indent: Int,
+        lines: MutableList<String>,
+    ) {
+        lines += "${indent(indent)}hover {"
+        when (event.action()) {
+            HoverEvent.Action.SHOW_TEXT -> {
+                val payload = event.value() as Component
+                lines += "${indent(indent + 1)}text {"
+                appendRoot(payload, indent + 2, lines)
+                lines += "${indent(indent + 1)}}"
+            }
+            HoverEvent.Action.SHOW_ITEM -> appendShowItem(event.value() as HoverEvent.ShowItem, indent + 1, lines)
+            HoverEvent.Action.SHOW_ENTITY -> appendShowEntity(event.value() as HoverEvent.ShowEntity, indent + 1, lines)
+            else -> error("miniToDsl slice 2 does not support hover action ${event.action().name()}.")
+        }
+        lines += "${indent(indent)}}"
+    }
+
+    private fun appendShowItem(
+        item: HoverEvent.ShowItem,
+        indent: Int,
+        lines: MutableList<String>,
+    ) {
+        require(item.nbt() == null) {
+            "miniToDsl slice 2 does not support legacy show-item NBT payloads."
+        }
+
+        val argumentLines = mutableListOf("${indent(indent + 1)}key = ${formatKey(item.item())}")
+        if (item.count() != 1) {
+            argumentLines += "${indent(indent + 1)}count = ${item.count()}"
+        }
+        if (item.dataComponents().isNotEmpty()) {
+            argumentLines += buildDataComponentsArgument(item.dataComponents(), indent)
+        }
+
+        if (argumentLines.size == 1) {
+            lines += "${indent(indent)}item(${formatKey(item.item())})"
+            return
+        }
+
+        lines += "${indent(indent)}item("
+        lines += argumentLines.joinToString(separator = ",\n")
+        lines += "${indent(indent)})"
+    }
+
+    private fun appendShowEntity(
+        entity: HoverEvent.ShowEntity,
+        indent: Int,
+        lines: MutableList<String>,
+    ) {
+        val header =
+            listOf(
+                "${indent(indent + 1)}type = ${formatKey(entity.type())}",
+                "${indent(indent + 1)}id = UUID.fromString(\"${entity.id()}\")",
+            ).joinToString(separator = ",\n")
+
+        entity.name()?.let { name ->
+            lines += "${indent(indent)}entity("
+            lines += header
+            lines += "${indent(indent)}) {"
+            appendRoot(name, indent + 1, lines)
+            lines += "${indent(indent)}}"
+            return
+        }
+
+        lines += "${indent(indent)}entity("
+        lines += header
+        lines += "${indent(indent)})"
+    }
+
+    private fun buildDataComponentsArgument(
+        dataComponents: Map<Key, DataComponentValue>,
+        indent: Int,
+    ): String {
+        val entries =
+            dataComponents.entries.joinToString(separator = ",\n") { (key, value) ->
+                "${indent(indent + 2)}${formatKey(key)} to ${formatDataComponentValue(value)}"
+            }
+        return buildString {
+            append("${indent(indent + 1)}dataComponents = mapOf(\n")
+            append(entries)
+            append("\n${indent(indent + 1)})")
+        }
+    }
+
+    private fun formatDataComponentValue(value: DataComponentValue): String =
+        when (value) {
+            is BinaryTagHolder -> "BinaryTagHolder.binaryTagHolder(\"${escapeString(value.string())}\")"
+            is DataComponentValue.TagSerializable ->
+                "BinaryTagHolder.binaryTagHolder(\"${escapeString(value.asBinaryTag().string())}\")"
+            is DataComponentValue.Removed -> "DataComponentValue.removed()"
+            else -> error("miniToDsl slice 2 does not support data component value ${value::class.qualifiedName}.")
+        }
+
+    private fun formatKey(key: Key): String =
+        "key(\"${escapeString(key.namespace())}\", \"${escapeString(key.value())}\")"
 
     private fun formatColor(color: TextColor): String =
         if (color is NamedTextColor) {

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
@@ -30,9 +30,9 @@ internal object MiniMessageToDslWriter {
 
     private fun Component.isEmptyComponent(): Boolean =
         this is TextComponent &&
-            content().isEmpty() &&
-            children().isEmpty() &&
-            !MiniMessageToDslSupport.hasDslOutput(style())
+                content().isEmpty() &&
+                children().isEmpty() &&
+                !MiniMessageToDslSupport.hasDslOutput(style())
 }
 
 /** Emits [component], unwrapping a content-less, style-less root into a bare sequence of its children. */

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
@@ -139,9 +139,11 @@ private fun KotlinSourceBuilder.appendShowItem(item: HoverEvent.ShowItem) {
 
 private fun KotlinSourceBuilder.appendDataComponents(dataComponents: Map<Key, DataComponentValue>) {
     val entries: List<() -> Unit> =
-        dataComponents.entries.map { (key, value) ->
-            { line("${keyLiteral(key)} to ${dataComponentValueLiteral(value)}") }
-        }
+        dataComponents.entries
+            .sortedBy { (key, _) -> key.asString() }
+            .map { (key, value) ->
+                { line("${keyLiteral(key)} to ${dataComponentValueLiteral(value)}") }
+            }
 
     openArguments("dataComponents = mapOf(", entries)
     line(")")

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
@@ -1,273 +1,165 @@
 package io.github.lmliam.kotventure.minimessage
 
 import net.kyori.adventure.key.Key
-import net.kyori.adventure.nbt.api.BinaryTagHolder
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.event.DataComponentValue
 import net.kyori.adventure.text.event.HoverEvent
-import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.Style
-import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration.State
-import java.util.Locale
 
+/**
+ * Walks a MiniMessage-parsed component tree and emits the equivalent Kotventure component DSL source.
+ *
+ * The walker decides *what* to emit; [KotlinSourceBuilder] owns indentation and [MiniMessageToDslLiterals] renders leaf
+ * values, so each function reads as the DSL it produces.
+ */
 internal object MiniMessageToDslWriter {
     fun write(component: Component): String {
         MiniMessageToDslSupport.requireSupported(component)
 
-        if (component.isEmptyDslComponent()) {
+        if (component.isEmptyComponent()) {
             return "component {}"
         }
 
-        val lines = mutableListOf("component {")
-        appendRoot(component, 1, lines)
-        lines += "}"
-        return lines.joinToString(separator = "\n")
+        return KotlinSourceBuilder()
+            .apply { block("component") { appendRoot(component) } }
+            .toString()
     }
 
-    private fun appendRoot(
-        component: Component,
-        indent: Int,
-        lines: MutableList<String>,
-    ) {
-        if (component is TextComponent &&
-            component.content().isEmpty() &&
-            !MiniMessageToDslSupport.hasDslOutput(component.style())
-        ) {
-            component.children().forEach { child -> appendComponent(child, indent, lines) }
-            return
-        }
-
-        appendComponent(component, indent, lines)
-    }
-
-    private fun appendComponent(
-        component: Component,
-        indent: Int,
-        lines: MutableList<String>,
-    ) {
-        component as TextComponent
-
-        val text = component.content()
-        val hasBlockBody = MiniMessageToDslSupport.hasDslOutput(component.style()) || component.children().isNotEmpty()
-
-        if (!hasBlockBody) {
-            lines += "${indent(indent)}text(\"${escapeString(text)}\")"
-            return
-        }
-
-        val openingLine =
-            if (text.isEmpty()) {
-                "${indent(indent)}text {"
-            } else {
-                "${indent(indent)}text(\"${escapeString(text)}\") {"
-            }
-        lines += openingLine
-        appendStyle(component.style(), indent + 1, lines)
-        component.children().forEach { child -> appendComponent(child, indent + 1, lines) }
-        lines += "${indent(indent)}}"
-    }
-
-    private fun appendStyle(
-        style: Style,
-        indent: Int,
-        lines: MutableList<String>,
-    ) {
-        style.color()?.let { color ->
-            lines += "${indent(indent)}color(${formatColor(color)})"
-        }
-
-        MiniMessageToDslSupport.decorations.forEach { (decoration, functionName) ->
-            if (style.decoration(decoration) == State.TRUE) {
-                lines += "${indent(indent)}$functionName()"
-            }
-        }
-
-        val disabledDecorations =
-            MiniMessageToDslSupport.decorations.filter { (decoration) -> style.decoration(decoration) == State.FALSE }
-        if (disabledDecorations.isNotEmpty()) {
-            lines += "${indent(indent)}style {"
-            disabledDecorations.forEach { (_, functionName) ->
-                lines += "${indent(indent + 1)}$functionName(false)"
-            }
-            lines += "${indent(indent)}}"
-        }
-
-        style.clickEvent()?.let { event ->
-            appendClickEvent(event, indent, lines)
-        }
-
-        style.hoverEvent()?.let { event ->
-            appendHoverEvent(event, indent, lines)
-        }
-    }
-
-    private fun appendClickEvent(
-        event: ClickEvent<*>,
-        indent: Int,
-        lines: MutableList<String>,
-    ) {
-        lines += "${indent(indent)}click {"
-        when (event.action()) {
-            ClickEvent.Action.OPEN_URL -> {
-                val payload = event.payload() as ClickEvent.Payload.Text
-                lines += "${indent(indent + 1)}openUrl(\"${escapeString(payload.value())}\")"
-            }
-            ClickEvent.Action.OPEN_FILE -> {
-                val payload = event.payload() as ClickEvent.Payload.Text
-                lines += "${indent(indent + 1)}openFile(\"${escapeString(payload.value())}\")"
-            }
-            ClickEvent.Action.RUN_COMMAND -> {
-                val payload = event.payload() as ClickEvent.Payload.Text
-                lines += "${indent(indent + 1)}run(\"${escapeString(payload.value())}\")"
-            }
-            ClickEvent.Action.SUGGEST_COMMAND -> {
-                val payload = event.payload() as ClickEvent.Payload.Text
-                lines += "${indent(indent + 1)}suggest(\"${escapeString(payload.value())}\")"
-            }
-            ClickEvent.Action.CHANGE_PAGE -> {
-                val payload = event.payload() as ClickEvent.Payload.Int
-                lines += "${indent(indent + 1)}changePage(${payload.integer()})"
-            }
-            ClickEvent.Action.COPY_TO_CLIPBOARD -> {
-                val payload = event.payload() as ClickEvent.Payload.Text
-                lines += "${indent(indent + 1)}copy(\"${escapeString(payload.value())}\")"
-            }
-            else -> {
-                lines += "${indent(indent + 1)}// callback not representable"
-            }
-        }
-        lines += "${indent(indent)}}"
-    }
-
-    private fun appendHoverEvent(
-        event: HoverEvent<*>,
-        indent: Int,
-        lines: MutableList<String>,
-    ) {
-        lines += "${indent(indent)}hover {"
-        when (event.action()) {
-            HoverEvent.Action.SHOW_TEXT -> {
-                val payload = event.value() as Component
-                lines += "${indent(indent + 1)}text {"
-                appendRoot(payload, indent + 2, lines)
-                lines += "${indent(indent + 1)}}"
-            }
-            HoverEvent.Action.SHOW_ITEM -> appendShowItem(event.value() as HoverEvent.ShowItem, indent + 1, lines)
-            HoverEvent.Action.SHOW_ENTITY -> appendShowEntity(event.value() as HoverEvent.ShowEntity, indent + 1, lines)
-            else -> error("miniToDsl slice 2 does not support hover action ${event.action().name()}.")
-        }
-        lines += "${indent(indent)}}"
-    }
-
-    private fun appendShowItem(
-        item: HoverEvent.ShowItem,
-        indent: Int,
-        lines: MutableList<String>,
-    ) {
-        require(item.nbt() == null) {
-            "miniToDsl slice 2 does not support legacy show-item NBT payloads."
-        }
-
-        val argumentLines = mutableListOf("${indent(indent + 1)}key = ${formatKey(item.item())}")
-        if (item.count() != 1) {
-            argumentLines += "${indent(indent + 1)}count = ${item.count()}"
-        }
-        if (item.dataComponents().isNotEmpty()) {
-            argumentLines += buildDataComponentsArgument(item.dataComponents(), indent)
-        }
-
-        if (argumentLines.size == 1) {
-            lines += "${indent(indent)}item(${formatKey(item.item())})"
-            return
-        }
-
-        lines += "${indent(indent)}item("
-        lines += argumentLines.joinToString(separator = ",\n")
-        lines += "${indent(indent)})"
-    }
-
-    private fun appendShowEntity(
-        entity: HoverEvent.ShowEntity,
-        indent: Int,
-        lines: MutableList<String>,
-    ) {
-        val header =
-            listOf(
-                "${indent(indent + 1)}type = ${formatKey(entity.type())}",
-                "${indent(indent + 1)}id = UUID.fromString(\"${entity.id()}\")",
-            ).joinToString(separator = ",\n")
-
-        entity.name()?.let { name ->
-            lines += "${indent(indent)}entity("
-            lines += header
-            lines += "${indent(indent)}) {"
-            appendRoot(name, indent + 1, lines)
-            lines += "${indent(indent)}}"
-            return
-        }
-
-        lines += "${indent(indent)}entity("
-        lines += header
-        lines += "${indent(indent)})"
-    }
-
-    private fun buildDataComponentsArgument(
-        dataComponents: Map<Key, DataComponentValue>,
-        indent: Int,
-    ): String {
-        val entries =
-            dataComponents.entries.joinToString(separator = ",\n") { (key, value) ->
-                "${indent(indent + 2)}${formatKey(key)} to ${formatDataComponentValue(value)}"
-            }
-        return buildString {
-            append("${indent(indent + 1)}dataComponents = mapOf(\n")
-            append(entries)
-            append("\n${indent(indent + 1)})")
-        }
-    }
-
-    private fun formatDataComponentValue(value: DataComponentValue): String =
-        when (value) {
-            is BinaryTagHolder -> "BinaryTagHolder.binaryTagHolder(\"${escapeString(value.string())}\")"
-            is DataComponentValue.TagSerializable ->
-                "BinaryTagHolder.binaryTagHolder(\"${escapeString(value.asBinaryTag().string())}\")"
-            is DataComponentValue.Removed -> "DataComponentValue.removed()"
-            else -> error("miniToDsl slice 2 does not support data component value ${value::class.qualifiedName}.")
-        }
-
-    private fun formatKey(key: Key): String =
-        "key(\"${escapeString(key.namespace())}\", \"${escapeString(key.value())}\")"
-
-    private fun formatColor(color: TextColor): String =
-        if (color is NamedTextColor) {
-            "NamedTextColor.${color.toString().uppercase(Locale.ROOT)}"
-        } else {
-            "TextColor.color(0x${color.asHexString().removePrefix("#").uppercase(Locale.ROOT)})"
-        }
-
-    private fun escapeString(value: String): String =
-        buildString {
-            value.forEach { character ->
-                when (character) {
-                    '\\' -> append("\\\\")
-                    '"' -> append("\\\"")
-                    '\n' -> append("\\n")
-                    '\r' -> append("\\r")
-                    '\t' -> append("\\t")
-                    '$' -> append('\\').append('$')
-                    else -> append(character)
-                }
-            }
-        }
-
-    private fun Component.isEmptyDslComponent(): Boolean =
+    private fun Component.isEmptyComponent(): Boolean =
         this is TextComponent &&
-                content().isEmpty() &&
-                children().isEmpty() &&
-                !MiniMessageToDslSupport.hasDslOutput(style())
+            content().isEmpty() &&
+            children().isEmpty() &&
+            !MiniMessageToDslSupport.hasDslOutput(style())
+}
 
-    private fun indent(level: Int): String = "    ".repeat(level)
+/** Emits [component], unwrapping a content-less, style-less root into a bare sequence of its children. */
+private fun KotlinSourceBuilder.appendRoot(component: Component) {
+    if (component is TextComponent &&
+        component.content().isEmpty() &&
+        !MiniMessageToDslSupport.hasDslOutput(component.style())
+    ) {
+        component.children().forEach { appendComponent(it as TextComponent) }
+        return
+    }
+
+    appendComponent(component as TextComponent)
+}
+
+private fun KotlinSourceBuilder.appendComponent(component: TextComponent) {
+    val text = component.content()
+    val hasBlockBody = MiniMessageToDslSupport.hasDslOutput(component.style()) || component.children().isNotEmpty()
+
+    if (!hasBlockBody) {
+        line("text(\"${escapeKotlinString(text)}\")")
+        return
+    }
+
+    val header = if (text.isEmpty()) "text" else "text(\"${escapeKotlinString(text)}\")"
+    block(header) {
+        appendStyle(component.style())
+        component.children().forEach { appendComponent(it as TextComponent) }
+    }
+}
+
+private fun KotlinSourceBuilder.appendStyle(style: Style) {
+    style.color()?.let { color -> line("color(${colorLiteral(color)})") }
+
+    MiniMessageToDslSupport.decorations.forEach { (decoration, functionName) ->
+        if (style.decoration(decoration) == State.TRUE) {
+            line("$functionName()")
+        }
+    }
+
+    val disabledDecorations =
+        MiniMessageToDslSupport.decorations.filter { (decoration) -> style.decoration(decoration) == State.FALSE }
+    if (disabledDecorations.isNotEmpty()) {
+        block("style") {
+            disabledDecorations.forEach { (_, functionName) -> line("$functionName(false)") }
+        }
+    }
+
+    style.clickEvent()?.let { event -> appendClickEvent(event) }
+    style.hoverEvent()?.let { event -> appendHoverEvent(event) }
+}
+
+private fun KotlinSourceBuilder.appendClickEvent(event: ClickEvent<*>) {
+    block("click") {
+        when (event.action()) {
+            ClickEvent.Action.OPEN_URL -> line("openUrl(\"${escapeKotlinString(event.textPayload())}\")")
+            ClickEvent.Action.OPEN_FILE -> line("openFile(\"${escapeKotlinString(event.textPayload())}\")")
+            ClickEvent.Action.RUN_COMMAND -> line("run(\"${escapeKotlinString(event.textPayload())}\")")
+            ClickEvent.Action.SUGGEST_COMMAND -> line("suggest(\"${escapeKotlinString(event.textPayload())}\")")
+            ClickEvent.Action.CHANGE_PAGE -> line("changePage(${event.intPayload()})")
+            ClickEvent.Action.COPY_TO_CLIPBOARD -> line("copy(\"${escapeKotlinString(event.textPayload())}\")")
+            else -> line("// callback not representable")
+        }
+    }
+}
+
+private fun ClickEvent<*>.textPayload(): String = (payload() as ClickEvent.Payload.Text).value()
+
+private fun ClickEvent<*>.intPayload(): Int = (payload() as ClickEvent.Payload.Int).integer()
+
+private fun KotlinSourceBuilder.appendHoverEvent(event: HoverEvent<*>) {
+    block("hover") {
+        when (event.action()) {
+            HoverEvent.Action.SHOW_TEXT -> block("text") { appendRoot(event.value() as Component) }
+            HoverEvent.Action.SHOW_ITEM -> appendShowItem(event.value() as HoverEvent.ShowItem)
+            HoverEvent.Action.SHOW_ENTITY -> appendShowEntity(event.value() as HoverEvent.ShowEntity)
+            else -> throw IllegalArgumentException(
+                "miniToDsl does not yet support the ${event.action().name()} hover action.",
+            )
+        }
+    }
+}
+
+private fun KotlinSourceBuilder.appendShowItem(item: HoverEvent.ShowItem) {
+    require(item.nbt() == null) {
+        "miniToDsl does not yet support legacy show-item NBT payloads."
+    }
+
+    val arguments =
+        buildList<() -> Unit> {
+            add { line("key = ${keyLiteral(item.item())}") }
+            if (item.count() != 1) add { line("count = ${item.count()}") }
+            if (item.dataComponents().isNotEmpty()) add { appendDataComponents(item.dataComponents()) }
+        }
+
+    if (arguments.size == 1) {
+        line("item(${keyLiteral(item.item())})")
+        return
+    }
+
+    openArguments("item(", arguments)
+    line(")")
+}
+
+private fun KotlinSourceBuilder.appendDataComponents(dataComponents: Map<Key, DataComponentValue>) {
+    val entries: List<() -> Unit> =
+        dataComponents.entries.map { (key, value) ->
+            { line("${keyLiteral(key)} to ${dataComponentValueLiteral(value)}") }
+        }
+
+    openArguments("dataComponents = mapOf(", entries)
+    line(")")
+}
+
+private fun KotlinSourceBuilder.appendShowEntity(entity: HoverEvent.ShowEntity) {
+    val arguments: List<() -> Unit> =
+        listOf(
+            { line("type = ${keyLiteral(entity.type())}") },
+            { line("id = UUID.fromString(\"${entity.id()}\")") },
+        )
+
+    openArguments("entity(", arguments)
+
+    val name = entity.name()
+    if (name == null) {
+        line(")")
+    } else {
+        block(")") { appendRoot(name) }
+    }
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplate.kt
@@ -123,7 +123,8 @@ public abstract class MiniTemplate(
  * @param placeholder a descriptor declared on this template.
  * @param value the value to substitute for [placeholder].
  */
-context(_: MiniTemplateBindingScope) public fun <T : Any> MiniTemplate.bind(
+context(_: MiniTemplateBindingScope)
+public fun <T : Any> MiniTemplate.bind(
     placeholder: MiniMessagePlaceholder<T>,
     value: T,
 ): Unit = contextOf<MiniTemplateBindingScope>().bind(placeholder, value)

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
@@ -1,5 +1,6 @@
 package io.github.lmliam.kotventure.minimessage
 
+import io.github.lmliam.kotventure.core.key.key
 import io.github.lmliam.kotventure.core.text.component
 import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldContainText
@@ -7,19 +8,24 @@ import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.nbt.api.BinaryTagHolder
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.event.DataComponentValue
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.minimessage.MiniMessage
+import java.util.UUID
 
 class MiniMessageToDslTest :
-    StringSpec(
-        {
-            "generates snapshot-style source for the join-message example" {
+    FunSpec({
+        context("text and style emission") {
+            test("generates snapshot-style source for the join-message example") {
                 val input = "<gold>[<gray>Server</gray>]</gold> <aqua>Alex</aqua> joined the game"
                 val expected =
                     component {
@@ -57,7 +63,7 @@ class MiniMessageToDslTest :
                 assertGoldenRoundTrip(input, expectedSource, expected)
             }
 
-            "escapes Kotlin string content in generated source" {
+            test("escapes Kotlin string content in generated source") {
                 val dollar = '$'
                 val escapedDollar = "\\$dollar"
                 val input = "say \\ \"hi\"\n\t${dollar}5\rcr"
@@ -70,7 +76,7 @@ class MiniMessageToDslTest :
                     """.trimIndent()
             }
 
-            "emits all standard text decorations" {
+            test("emits all standard text decorations") {
                 val input = "<bold><italic><underlined><strikethrough><obfuscated>styled"
 
                 miniToDsl(input) shouldBe
@@ -94,7 +100,7 @@ class MiniMessageToDslTest :
                 styled shouldHaveDecoration TextDecoration.OBFUSCATED
             }
 
-            "emits disabled decoration states that override inherited style" {
+            test("emits disabled decoration states that override inherited style") {
                 val input = "<bold>hot <!bold>cold"
 
                 miniToDsl(input) shouldBe
@@ -116,55 +122,7 @@ class MiniMessageToDslTest :
                 hot.childAt(0).shouldHaveDecoration(TextDecoration.BOLD, TextDecoration.State.FALSE)
             }
 
-            "rejects unsupported style metadata instead of dropping it" {
-                val error =
-                    shouldThrow<IllegalArgumentException> {
-                        miniToDsl("<click:run_command:'/spawn'>spawn</click>")
-                    }
-
-                error.message shouldContain "miniToDsl slice 1 does not support click events"
-            }
-
-            "rejects unsupported shadow colours instead of dropping them" {
-                val error =
-                    shouldThrow<IllegalArgumentException> {
-                        miniToDsl("<shadow:red>shadow</shadow>")
-                    }
-
-                error.message shouldContain "miniToDsl slice 1 does not support shadow colours"
-            }
-
-            "rejects unsupported component types" {
-                val error =
-                    shouldThrow<IllegalArgumentException> {
-                        miniToDsl("<key:key.jump>")
-                    }
-
-                error.message shouldContain "supports only text component trees"
-            }
-
-            "rejects unsupported component types in children" {
-                val error =
-                    shouldThrow<IllegalArgumentException> {
-                        MiniMessageToDslWriter.write(Component.empty().append(Component.keybind("key.jump")))
-                    }
-
-                error.message shouldContain "supports only text component trees"
-            }
-
-            "renders escaped MiniMessage tags as literal text" {
-                val generated = miniToDsl("\\<red>literal")
-
-                generated shouldBe
-                        """
-                    component {
-                        text("<red>literal")
-                    }
-                    """.trimIndent()
-                mini("\\<red>literal") shouldContainText "<red>literal"
-            }
-
-            "round-trips named colours and decorations against compiled expected DSL" {
+            test("round-trips named colours and decorations against compiled expected DSL") {
                 val input = "<red><bold>Hello"
                 val expected =
                     component {
@@ -189,7 +147,7 @@ class MiniMessageToDslTest :
                 expected.childAt(0) shouldHaveDecoration TextDecoration.BOLD
             }
 
-            "round-trips nested colours against compiled expected DSL" {
+            test("round-trips nested colours against compiled expected DSL") {
                 val input = "<gray>Hello <#12ab34>world</#12ab34></gray>"
                 val expected =
                     component {
@@ -218,13 +176,409 @@ class MiniMessageToDslTest :
                 expected.childAt(0).childAt(0) shouldHaveColor TextColor.color(0x12AB34)
             }
 
-            "renders an empty component for empty input" {
+            test("renders an empty component for empty input") {
                 val expected = component {}
 
                 assertGoldenRoundTrip("", "component {}", expected)
             }
-        },
+        }
+
+        context("click event emission") {
+            clickRoundTripCases.forEach { roundTrip ->
+                test(roundTrip.name) {
+                    assertGoldenRoundTrip(roundTrip.expectedSource, roundTrip.expectedComponent)
+                }
+            }
+
+            test("emits a marker for non-representable click actions") {
+                val payload = ClickEvent.Payload.custom(key("kotventure", "claim"))
+                val expected =
+                    component {
+                        text("Claim") {
+                            click(ClickEvent.Action.CUSTOM, payload)
+                        }
+                    }
+
+                MiniMessageToDslWriter.write(expected) shouldBe
+                        """
+                    component {
+                        text("Claim") {
+                            click {
+                                // callback not representable
+                            }
+                        }
+                    }
+                    """.trimIndent()
+            }
+
+            test("escapes Kotlin string content in click payloads") {
+                val dollar = '$'
+                val escapedDollar = "\\$dollar"
+                val expected =
+                    component {
+                        text("Copy") {
+                            click {
+                                copy("say \\ \"hi\"\n\t${dollar}5\rcr")
+                            }
+                        }
+                    }
+                val expectedSource =
+                    """
+                    component {
+                        text("Copy") {
+                            click {
+                                copy("say \\ \"hi\"\n\t${escapedDollar}5\rcr")
+                            }
+                        }
+                    }
+                    """.trimIndent()
+
+                assertGoldenRoundTrip(expectedSource, expected)
+            }
+        }
+
+        context("hover event emission") {
+            hoverRoundTripCases.forEach { roundTrip ->
+                test(roundTrip.name) {
+                    assertGoldenRoundTrip(roundTrip.expectedSource, roundTrip.expectedComponent)
+                }
+            }
+        }
+
+        context("unsupported input") {
+            test("rejects unsupported shadow colours instead of dropping them") {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        miniToDsl("<shadow:red>shadow</shadow>")
+                    }
+
+                error.message shouldContain "miniToDsl slice 2 does not support shadow colours"
+            }
+
+            test("rejects unsupported component types") {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        miniToDsl("<key:key.jump>")
+                    }
+
+                error.message shouldContain "supports only text component trees"
+            }
+
+            test("rejects unsupported component types in children") {
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        MiniMessageToDslWriter.write(Component.empty().append(Component.keybind("key.jump")))
+                    }
+
+                error.message shouldContain "supports only text component trees"
+            }
+        }
+
+        context("literal MiniMessage input") {
+            test("renders escaped MiniMessage tags as literal text") {
+                val generated = miniToDsl("\\<red>literal")
+
+                generated shouldBe
+                        """
+                    component {
+                        text("<red>literal")
+                    }
+                    """.trimIndent()
+                mini("\\<red>literal") shouldContainText "<red>literal"
+            }
+        }
+    })
+
+private val clickRoundTripCases: List<RoundTripCase> =
+    listOf(
+        RoundTripCase(
+            name = "round-trips open url click events against compiled expected DSL",
+            expectedSource =
+                """
+                component {
+                    text("Open") {
+                        click {
+                            openUrl("https://example.com")
+                        }
+                    }
+                }
+                """.trimIndent(),
+            expectedComponent =
+                component {
+                    text("Open") {
+                        click {
+                            openUrl("https://example.com")
+                        }
+                    }
+                },
+        ),
+        RoundTripCase(
+            name = "round-trips open file click events against compiled expected DSL",
+            expectedSource =
+                """
+                component {
+                    text("File") {
+                        click {
+                            openFile("/tmp/example.txt")
+                        }
+                    }
+                }
+                """.trimIndent(),
+            expectedComponent =
+                component {
+                    text("File") {
+                        click {
+                            openFile("/tmp/example.txt")
+                        }
+                    }
+                },
+        ),
+        RoundTripCase(
+            name = "round-trips run command click events against compiled expected DSL",
+            expectedSource =
+                """
+                component {
+                    text("Spawn") {
+                        click {
+                            run("/spawn")
+                        }
+                    }
+                }
+                """.trimIndent(),
+            expectedComponent =
+                component {
+                    text("Spawn") {
+                        click {
+                            run("/spawn")
+                        }
+                    }
+                },
+        ),
+        RoundTripCase(
+            name = "round-trips suggest command click events against compiled expected DSL",
+            expectedSource =
+                """
+                component {
+                    text("Reply") {
+                        click {
+                            suggest("/msg Alex ")
+                        }
+                    }
+                }
+                """.trimIndent(),
+            expectedComponent =
+                component {
+                    text("Reply") {
+                        click {
+                            suggest("/msg Alex ")
+                        }
+                    }
+                },
+        ),
+        RoundTripCase(
+            name = "round-trips change page click events against compiled expected DSL",
+            expectedSource =
+                """
+                component {
+                    text("Page") {
+                        click {
+                            changePage(4)
+                        }
+                    }
+                }
+                """.trimIndent(),
+            expectedComponent =
+                component {
+                    text("Page") {
+                        click {
+                            changePage(4)
+                        }
+                    }
+                },
+        ),
+        RoundTripCase(
+            name = "round-trips copy click events against compiled expected DSL",
+            expectedSource =
+                """
+                component {
+                    text("Copy") {
+                        click {
+                            copy("copied")
+                        }
+                    }
+                }
+                """.trimIndent(),
+            expectedComponent =
+                component {
+                    text("Copy") {
+                        click {
+                            copy("copied")
+                        }
+                    }
+                },
+        ),
     )
+
+private val hoverRoundTripCases: List<RoundTripCase> =
+    listOf(
+        RoundTripCase(
+            name = "round-trips show text hover events against compiled expected DSL",
+            expectedSource =
+                """
+                component {
+                    text("Spawn") {
+                        hover {
+                            text {
+                                text("Warp now") {
+                                    color(NamedTextColor.GOLD)
+                                }
+                            }
+                        }
+                    }
+                }
+                """.trimIndent(),
+            expectedComponent =
+                component {
+                    text("Spawn") {
+                        hover {
+                            text {
+                                text("Warp now") {
+                                    color(NamedTextColor.GOLD)
+                                }
+                            }
+                        }
+                    }
+                },
+        ),
+        RoundTripCase(
+            name = "round-trips show item hover events against compiled expected DSL",
+            expectedSource =
+                """
+                component {
+                    text("Loot") {
+                        hover {
+                            item(
+                                key = key("minecraft", "diamond_sword"),
+                                count = 2
+                            )
+                        }
+                    }
+                }
+                """.trimIndent(),
+            expectedComponent =
+                component {
+                    text("Loot") {
+                        hover {
+                            item(
+                                key = key("minecraft", "diamond_sword"),
+                                count = 2,
+                            )
+                        }
+                    }
+                },
+        ),
+        RoundTripCase(
+            name = "round-trips show item hover data components against compiled expected DSL",
+            expectedSource =
+                """
+                component {
+                    text("Loot data") {
+                        hover {
+                            item(
+                                key = key("minecraft", "diamond_sword"),
+                                dataComponents = mapOf(
+                                    key("minecraft", "custom_data") to BinaryTagHolder.binaryTagHolder("{kotventure:1b}")
+                                )
+                            )
+                        }
+                    }
+                }
+                """.trimIndent(),
+            expectedComponent =
+                component {
+                    text("Loot data") {
+                        hover {
+                            item(
+                                key = key("minecraft", "diamond_sword"),
+                                dataComponents =
+                                    mapOf<Key, DataComponentValue>(
+                                        key("minecraft", "custom_data") to
+                                                BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
+                                    ),
+                            )
+                        }
+                    }
+                },
+        ),
+        RoundTripCase(
+            name = "round-trips show entity hover events against compiled expected DSL",
+            expectedSource =
+                """
+                component {
+                    text("Mob") {
+                        hover {
+                            entity(
+                                type = key("minecraft", "zombie"),
+                                id = UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25")
+                            )
+                        }
+                    }
+                }
+                """.trimIndent(),
+            expectedComponent =
+                component {
+                    text("Mob") {
+                        hover {
+                            entity(
+                                type = key("minecraft", "zombie"),
+                                id = UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25"),
+                            )
+                        }
+                    }
+                },
+        ),
+        RoundTripCase(
+            name = "round-trips named show entity hover events against compiled expected DSL",
+            expectedSource =
+                """
+                component {
+                    text("Named mob") {
+                        hover {
+                            entity(
+                                type = key("minecraft", "player"),
+                                id = UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee")
+                            ) {
+                                text("Alex \"\$5\"") {
+                                    color(NamedTextColor.AQUA)
+                                }
+                            }
+                        }
+                    }
+                }
+                """.trimIndent(),
+            expectedComponent =
+                component {
+                    text("Named mob") {
+                        hover {
+                            entity(
+                                type = key("minecraft", "player"),
+                                id = UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee"),
+                            ) {
+                                text("Alex \"$5\"") {
+                                    color(NamedTextColor.AQUA)
+                                }
+                            }
+                        }
+                    }
+                },
+        ),
+    )
+
+private data class RoundTripCase(
+    val name: String,
+    val expectedSource: String,
+    val expectedComponent: Component,
+)
 
 private fun assertGoldenRoundTrip(
     input: String,
@@ -235,4 +589,13 @@ private fun assertGoldenRoundTrip(
 
     miniToDsl(input) shouldBe expectedSource
     MiniMessage.miniMessage().serialize(parsed) shouldBe MiniMessage.miniMessage().serialize(expectedComponent)
+}
+
+private fun assertGoldenRoundTrip(
+    expectedSource: String,
+    expectedComponent: Component,
+) {
+    val input = MiniMessage.miniMessage().serialize(expectedComponent)
+
+    assertGoldenRoundTrip(input, expectedSource, expectedComponent)
 }

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
@@ -24,27 +24,28 @@ import net.kyori.adventure.text.minimessage.MiniMessage
 import java.util.UUID
 
 class MiniMessageToDslTest :
-    FunSpec({
-        context("text and style emission") {
-            test("generates snapshot-style source for the join-message example") {
-                val input = "<gold>[<gray>Server</gray>]</gold> <aqua>Alex</aqua> joined the game"
-                val expected =
-                    component {
-                        text("[") {
-                            color(NamedTextColor.GOLD)
-                            text("Server") {
-                                color(NamedTextColor.GRAY)
+    FunSpec(
+        {
+            context("text and style emission") {
+                test("generates snapshot-style source for the join-message example") {
+                    val input = "<gold>[<gray>Server</gray>]</gold> <aqua>Alex</aqua> joined the game"
+                    val expected =
+                        component {
+                            text("[") {
+                                color(NamedTextColor.GOLD)
+                                text("Server") {
+                                    color(NamedTextColor.GRAY)
+                                }
+                                text("]")
                             }
-                            text("]")
+                            text(" ")
+                            text("Alex") {
+                                color(NamedTextColor.AQUA)
+                            }
+                            text(" joined the game")
                         }
-                        text(" ")
-                        text("Alex") {
-                            color(NamedTextColor.AQUA)
-                        }
-                        text(" joined the game")
-                    }
-                val expectedSource =
-                    """
+                    val expectedSource =
+                        """
                     component {
                         text("[") {
                             color(NamedTextColor.GOLD)
@@ -61,27 +62,27 @@ class MiniMessageToDslTest :
                     }
                     """.trimIndent()
 
-                assertGoldenRoundTrip(input, expectedSource, expected)
-            }
+                    assertGoldenRoundTrip(input, expectedSource, expected)
+                }
 
-            test("escapes Kotlin string content in generated source") {
-                val dollar = '$'
-                val escapedDollar = "\\$dollar"
-                val input = "say \\ \"hi\"\n\t${dollar}5\rcr"
+                test("escapes Kotlin string content in generated source") {
+                    val dollar = '$'
+                    val escapedDollar = "\\$dollar"
+                    val input = "say \\ \"hi\"\n\t${dollar}5\rcr"
 
-                miniToDsl(input) shouldBe
-                        """
+                    miniToDsl(input) shouldBe
+                            """
                     component {
                         text("say \\ \"hi\"\n\t${escapedDollar}5\rcr")
                     }
                     """.trimIndent()
-            }
+                }
 
-            test("emits all standard text decorations") {
-                val input = "<bold><italic><underlined><strikethrough><obfuscated>styled"
+                test("emits all standard text decorations") {
+                    val input = "<bold><italic><underlined><strikethrough><obfuscated>styled"
 
-                miniToDsl(input) shouldBe
-                        """
+                    miniToDsl(input) shouldBe
+                            """
                     component {
                         text("styled") {
                             bold()
@@ -93,19 +94,19 @@ class MiniMessageToDslTest :
                     }
                     """.trimIndent()
 
-                val styled = mini(input)
-                styled shouldHaveDecoration TextDecoration.BOLD
-                styled shouldHaveDecoration TextDecoration.ITALIC
-                styled shouldHaveDecoration TextDecoration.UNDERLINED
-                styled shouldHaveDecoration TextDecoration.STRIKETHROUGH
-                styled shouldHaveDecoration TextDecoration.OBFUSCATED
-            }
+                    val styled = mini(input)
+                    styled shouldHaveDecoration TextDecoration.BOLD
+                    styled shouldHaveDecoration TextDecoration.ITALIC
+                    styled shouldHaveDecoration TextDecoration.UNDERLINED
+                    styled shouldHaveDecoration TextDecoration.STRIKETHROUGH
+                    styled shouldHaveDecoration TextDecoration.OBFUSCATED
+                }
 
-            test("emits disabled decoration states that override inherited style") {
-                val input = "<bold>hot <!bold>cold"
+                test("emits disabled decoration states that override inherited style") {
+                    val input = "<bold>hot <!bold>cold"
 
-                miniToDsl(input) shouldBe
-                        """
+                    miniToDsl(input) shouldBe
+                            """
                     component {
                         text("hot ") {
                             bold()
@@ -118,77 +119,77 @@ class MiniMessageToDslTest :
                     }
                     """.trimIndent()
 
-                val hot = mini(input)
-                hot shouldHaveDecoration TextDecoration.BOLD
-                hot.childAt(0).shouldHaveDecoration(TextDecoration.BOLD, TextDecoration.State.FALSE)
-            }
+                    val hot = mini(input)
+                    hot shouldHaveDecoration TextDecoration.BOLD
+                    hot.childAt(0).shouldHaveDecoration(TextDecoration.BOLD, TextDecoration.State.FALSE)
+                }
 
-            test("round-trips named colours and decorations against compiled expected DSL") {
-                val input = "<red><bold>Hello"
-                val expected =
-                    component {
-                        text("Hello") {
-                            color(NamedTextColor.RED)
-                            bold()
-                        }
-                    }
-                val expectedSource =
-                    """
-                    component {
-                        text("Hello") {
-                            color(NamedTextColor.RED)
-                            bold()
-                        }
-                    }
-                    """.trimIndent()
-
-                assertGoldenRoundTrip(input, expectedSource, expected)
-                expected shouldHaveChildCount 1
-                expected.childAt(0) shouldHaveColor NamedTextColor.RED
-                expected.childAt(0) shouldHaveDecoration TextDecoration.BOLD
-            }
-
-            test("round-trips nested colours against compiled expected DSL") {
-                val input = "<gray>Hello <#12ab34>world</#12ab34></gray>"
-                val expected =
-                    component {
-                        text("Hello ") {
-                            color(NamedTextColor.GRAY)
-                            text("world") {
-                                color(TextColor.color(0x12AB34))
+                test("round-trips named colours and decorations against compiled expected DSL") {
+                    val input = "<red><bold>Hello"
+                    val expected =
+                        component {
+                            text("Hello") {
+                                color(NamedTextColor.RED)
+                                bold()
                             }
                         }
-                    }
-                val expectedSource =
-                    """
-                    component {
-                        text("Hello ") {
-                            color(NamedTextColor.GRAY)
-                            text("world") {
-                                color(TextColor.color(0x12AB34))
-                            }
-                        }
-                    }
-                    """.trimIndent()
-
-                assertGoldenRoundTrip(input, expectedSource, expected)
-                expected shouldHaveChildCount 1
-                expected.childAt(0) shouldHaveColor NamedTextColor.GRAY
-                expected.childAt(0).childAt(0) shouldHaveColor TextColor.color(0x12AB34)
-            }
-
-            test("renders an empty component for empty input") {
-                val expected = component {}
-
-                assertGoldenRoundTrip("", "component {}", expected)
-            }
-        }
-
-        context("click event emission") {
-            test("round-trips open url click events against compiled expected DSL") {
-                assertGoldenRoundTrip(
-                    expectedSource =
+                    val expectedSource =
                         """
+                    component {
+                        text("Hello") {
+                            color(NamedTextColor.RED)
+                            bold()
+                        }
+                    }
+                    """.trimIndent()
+
+                    assertGoldenRoundTrip(input, expectedSource, expected)
+                    expected shouldHaveChildCount 1
+                    expected.childAt(0) shouldHaveColor NamedTextColor.RED
+                    expected.childAt(0) shouldHaveDecoration TextDecoration.BOLD
+                }
+
+                test("round-trips nested colours against compiled expected DSL") {
+                    val input = "<gray>Hello <#12ab34>world</#12ab34></gray>"
+                    val expected =
+                        component {
+                            text("Hello ") {
+                                color(NamedTextColor.GRAY)
+                                text("world") {
+                                    color(TextColor.color(0x12AB34))
+                                }
+                            }
+                        }
+                    val expectedSource =
+                        """
+                    component {
+                        text("Hello ") {
+                            color(NamedTextColor.GRAY)
+                            text("world") {
+                                color(TextColor.color(0x12AB34))
+                            }
+                        }
+                    }
+                    """.trimIndent()
+
+                    assertGoldenRoundTrip(input, expectedSource, expected)
+                    expected shouldHaveChildCount 1
+                    expected.childAt(0) shouldHaveColor NamedTextColor.GRAY
+                    expected.childAt(0).childAt(0) shouldHaveColor TextColor.color(0x12AB34)
+                }
+
+                test("renders an empty component for empty input") {
+                    val expected = component {}
+
+                    assertGoldenRoundTrip("", "component {}", expected)
+                }
+            }
+
+            context("click event emission") {
+                test("round-trips open url click events against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
                         component {
                             text("Open") {
                                 click {
@@ -197,19 +198,19 @@ class MiniMessageToDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedComponent =
-                        component {
-                            text("Open") {
-                                click { openUrl("https://example.com") }
-                            }
-                        },
-                )
-            }
+                        expectedComponent =
+                            component {
+                                text("Open") {
+                                    click { openUrl("https://example.com") }
+                                }
+                            },
+                    )
+                }
 
-            test("round-trips open file click events against compiled expected DSL") {
-                assertGoldenRoundTrip(
-                    expectedSource =
-                        """
+                test("round-trips open file click events against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
                         component {
                             text("File") {
                                 click {
@@ -218,19 +219,19 @@ class MiniMessageToDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedComponent =
-                        component {
-                            text("File") {
-                                click { openFile("/tmp/example.txt") }
-                            }
-                        },
-                )
-            }
+                        expectedComponent =
+                            component {
+                                text("File") {
+                                    click { openFile("/tmp/example.txt") }
+                                }
+                            },
+                    )
+                }
 
-            test("round-trips run command click events against compiled expected DSL") {
-                assertGoldenRoundTrip(
-                    expectedSource =
-                        """
+                test("round-trips run command click events against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
                         component {
                             text("Spawn") {
                                 click {
@@ -239,19 +240,19 @@ class MiniMessageToDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedComponent =
-                        component {
-                            text("Spawn") {
-                                click { run("/spawn") }
-                            }
-                        },
-                )
-            }
+                        expectedComponent =
+                            component {
+                                text("Spawn") {
+                                    click { run("/spawn") }
+                                }
+                            },
+                    )
+                }
 
-            test("round-trips suggest command click events against compiled expected DSL") {
-                assertGoldenRoundTrip(
-                    expectedSource =
-                        """
+                test("round-trips suggest command click events against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
                         component {
                             text("Reply") {
                                 click {
@@ -260,19 +261,19 @@ class MiniMessageToDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedComponent =
-                        component {
-                            text("Reply") {
-                                click { suggest("/msg Alex ") }
-                            }
-                        },
-                )
-            }
+                        expectedComponent =
+                            component {
+                                text("Reply") {
+                                    click { suggest("/msg Alex ") }
+                                }
+                            },
+                    )
+                }
 
-            test("round-trips change page click events against compiled expected DSL") {
-                assertGoldenRoundTrip(
-                    expectedSource =
-                        """
+                test("round-trips change page click events against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
                         component {
                             text("Page") {
                                 click {
@@ -281,19 +282,19 @@ class MiniMessageToDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedComponent =
-                        component {
-                            text("Page") {
-                                click { changePage(4) }
-                            }
-                        },
-                )
-            }
+                        expectedComponent =
+                            component {
+                                text("Page") {
+                                    click { changePage(4) }
+                                }
+                            },
+                    )
+                }
 
-            test("round-trips copy click events against compiled expected DSL") {
-                assertGoldenRoundTrip(
-                    expectedSource =
-                        """
+                test("round-trips copy click events against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
                         component {
                             text("Copy") {
                                 click {
@@ -302,26 +303,26 @@ class MiniMessageToDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedComponent =
+                        expectedComponent =
+                            component {
+                                text("Copy") {
+                                    click { copy("copied") }
+                                }
+                            },
+                    )
+                }
+
+                test("emits a marker for non-representable click actions") {
+                    val payload = ClickEvent.Payload.custom(key("kotventure", "claim"))
+                    val expected =
                         component {
-                            text("Copy") {
-                                click { copy("copied") }
+                            text("Claim") {
+                                click(ClickEvent.Action.CUSTOM, payload)
                             }
-                        },
-                )
-            }
-
-            test("emits a marker for non-representable click actions") {
-                val payload = ClickEvent.Payload.custom(key("kotventure", "claim"))
-                val expected =
-                    component {
-                        text("Claim") {
-                            click(ClickEvent.Action.CUSTOM, payload)
                         }
-                    }
 
-                MiniMessageToDslWriter.write(expected) shouldBe
-                        """
+                    MiniMessageToDslWriter.write(expected) shouldBe
+                            """
                     component {
                         text("Claim") {
                             click {
@@ -330,21 +331,21 @@ class MiniMessageToDslTest :
                         }
                     }
                     """.trimIndent()
-            }
+                }
 
-            test("escapes Kotlin string content in click payloads") {
-                val dollar = '$'
-                val escapedDollar = "\\$dollar"
-                val expected =
-                    component {
-                        text("Copy") {
-                            click {
-                                copy("say \\ \"hi\"\n\t${dollar}5\rcr")
+                test("escapes Kotlin string content in click payloads") {
+                    val dollar = '$'
+                    val escapedDollar = "\\$dollar"
+                    val expected =
+                        component {
+                            text("Copy") {
+                                click {
+                                    copy("say \\ \"hi\"\n\t${dollar}5\rcr")
+                                }
                             }
                         }
-                    }
-                val expectedSource =
-                    """
+                    val expectedSource =
+                        """
                     component {
                         text("Copy") {
                             click {
@@ -354,15 +355,15 @@ class MiniMessageToDslTest :
                     }
                     """.trimIndent()
 
-                assertGoldenRoundTrip(expectedSource, expected)
+                    assertGoldenRoundTrip(expectedSource, expected)
+                }
             }
-        }
 
-        context("hover event emission") {
-            test("round-trips show text hover events against compiled expected DSL") {
-                assertGoldenRoundTrip(
-                    expectedSource =
-                        """
+            context("hover event emission") {
+                test("round-trips show text hover events against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
                         component {
                             text("Spawn") {
                                 hover {
@@ -375,25 +376,25 @@ class MiniMessageToDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedComponent =
-                        component {
-                            text("Spawn") {
-                                hover {
-                                    text {
-                                        text("Warp now") {
-                                            color(NamedTextColor.GOLD)
+                        expectedComponent =
+                            component {
+                                text("Spawn") {
+                                    hover {
+                                        text {
+                                            text("Warp now") {
+                                                color(NamedTextColor.GOLD)
+                                            }
                                         }
                                     }
                                 }
-                            }
-                        },
-                )
-            }
+                            },
+                    )
+                }
 
-            test("round-trips show item hover events against compiled expected DSL") {
-                assertGoldenRoundTrip(
-                    expectedSource =
-                        """
+                test("round-trips show item hover events against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
                         component {
                             text("Loot") {
                                 hover {
@@ -405,24 +406,24 @@ class MiniMessageToDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedComponent =
-                        component {
-                            text("Loot") {
-                                hover {
-                                    item(
-                                        key = key("minecraft", "diamond_sword"),
-                                        count = 2,
-                                    )
+                        expectedComponent =
+                            component {
+                                text("Loot") {
+                                    hover {
+                                        item(
+                                            key = key("minecraft", "diamond_sword"),
+                                            count = 2,
+                                        )
+                                    }
                                 }
-                            }
-                        },
-                )
-            }
+                            },
+                    )
+                }
 
-            test("round-trips show item hover data components against compiled expected DSL") {
-                assertGoldenRoundTrip(
-                    expectedSource =
-                        """
+                test("round-trips show item hover data components against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
                         component {
                             text("Loot data") {
                                 hover {
@@ -436,7 +437,26 @@ class MiniMessageToDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedComponent =
+                        expectedComponent =
+                            component {
+                                text("Loot data") {
+                                    hover {
+                                        item(
+                                            key = key("minecraft", "diamond_sword"),
+                                            dataComponents =
+                                                mapOf<Key, DataComponentValue>(
+                                                    key("minecraft", "custom_data") to
+                                                            BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
+                                                ),
+                                        )
+                                    }
+                                }
+                            },
+                    )
+                }
+
+                test("emits show item data components in a stable key order") {
+                    val loot =
                         component {
                             text("Loot data") {
                                 hover {
@@ -444,36 +464,20 @@ class MiniMessageToDslTest :
                                         key = key("minecraft", "diamond_sword"),
                                         dataComponents =
                                             mapOf<Key, DataComponentValue>(
+                                                key(
+                                                    "minecraft",
+                                                    "damage",
+                                                ) to BinaryTagHolder.binaryTagHolder("{value:5b}"),
                                                 key("minecraft", "custom_data") to
-                                                    BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
+                                                        BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
                                             ),
                                     )
                                 }
                             }
-                        },
-                )
-            }
-
-            test("emits show item data components in a stable key order") {
-                val loot =
-                    component {
-                        text("Loot data") {
-                            hover {
-                                item(
-                                    key = key("minecraft", "diamond_sword"),
-                                    dataComponents =
-                                        mapOf<Key, DataComponentValue>(
-                                            key("minecraft", "damage") to BinaryTagHolder.binaryTagHolder("{value:5b}"),
-                                            key("minecraft", "custom_data") to
-                                                BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
-                                        ),
-                                )
-                            }
                         }
-                    }
 
-                MiniMessageToDslWriter.write(loot) shouldBe
-                    """
+                    MiniMessageToDslWriter.write(loot) shouldBe
+                            """
                     component {
                         text("Loot data") {
                             hover {
@@ -488,12 +492,12 @@ class MiniMessageToDslTest :
                         }
                     }
                     """.trimIndent()
-            }
+                }
 
-            test("round-trips show entity hover events against compiled expected DSL") {
-                assertGoldenRoundTrip(
-                    expectedSource =
-                        """
+                test("round-trips show entity hover events against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
                         component {
                             text("Mob") {
                                 hover {
@@ -505,24 +509,24 @@ class MiniMessageToDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedComponent =
-                        component {
-                            text("Mob") {
-                                hover {
-                                    entity(
-                                        type = key("minecraft", "zombie"),
-                                        id = UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25"),
-                                    )
+                        expectedComponent =
+                            component {
+                                text("Mob") {
+                                    hover {
+                                        entity(
+                                            type = key("minecraft", "zombie"),
+                                            id = UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25"),
+                                        )
+                                    }
                                 }
-                            }
-                        },
-                )
-            }
+                            },
+                    )
+                }
 
-            test("round-trips named show entity hover events against compiled expected DSL") {
-                assertGoldenRoundTrip(
-                    expectedSource =
-                        """
+                test("round-trips named show entity hover events against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
                         component {
                             text("Named mob") {
                                 hover {
@@ -538,122 +542,123 @@ class MiniMessageToDslTest :
                             }
                         }
                         """.trimIndent(),
-                    expectedComponent =
-                        component {
-                            text("Named mob") {
-                                hover {
-                                    entity(
-                                        type = key("minecraft", "player"),
-                                        id = UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee"),
-                                    ) {
-                                        text("Alex \"$5\"") {
-                                            color(NamedTextColor.AQUA)
+                        expectedComponent =
+                            component {
+                                text("Named mob") {
+                                    hover {
+                                        entity(
+                                            type = key("minecraft", "player"),
+                                            id = UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee"),
+                                        ) {
+                                            text("Alex \"$5\"") {
+                                                color(NamedTextColor.AQUA)
+                                            }
                                         }
                                     }
                                 }
-                            }
-                        },
-                )
-            }
-        }
-
-        context("unsupported input") {
-            test("rejects unsupported shadow colours instead of dropping them") {
-                val error =
-                    shouldThrow<IllegalArgumentException> {
-                        miniToDsl("<shadow:red>shadow</shadow>")
-                    }
-
-                error.message shouldContain "miniToDsl does not yet support shadow colours"
+                            },
+                    )
+                }
             }
 
-            test("rejects unsupported component types") {
-                val error =
-                    shouldThrow<IllegalArgumentException> {
-                        miniToDsl("<key:key.jump>")
-                    }
+            context("unsupported input") {
+                test("rejects unsupported shadow colours instead of dropping them") {
+                    val error =
+                        shouldThrow<IllegalArgumentException> {
+                            miniToDsl("<shadow:red>shadow</shadow>")
+                        }
 
-                error.message shouldContain "supports only text component trees"
-            }
+                    error.message shouldContain "miniToDsl does not yet support shadow colours"
+                }
 
-            test("rejects unsupported component types in children") {
-                val error =
-                    shouldThrow<IllegalArgumentException> {
-                        MiniMessageToDslWriter.write(Component.empty().append(Component.keybind("key.jump")))
-                    }
+                test("rejects unsupported component types") {
+                    val error =
+                        shouldThrow<IllegalArgumentException> {
+                            miniToDsl("<key:key.jump>")
+                        }
 
-                error.message shouldContain "supports only text component trees"
-            }
+                    error.message shouldContain "supports only text component trees"
+                }
 
-            test("rejects unsupported styles nested in hover text payloads") {
-                val payload = Component.text("tip").insertion("/warp")
-                val component = Component.text("hover me").hoverEvent(HoverEvent.showText(payload))
+                test("rejects unsupported component types in children") {
+                    val error =
+                        shouldThrow<IllegalArgumentException> {
+                            MiniMessageToDslWriter.write(Component.empty().append(Component.keybind("key.jump")))
+                        }
 
-                val error =
-                    shouldThrow<IllegalArgumentException> {
-                        MiniMessageToDslWriter.write(component)
-                    }
+                    error.message shouldContain "supports only text component trees"
+                }
 
-                error.message shouldContain "insertion text"
-            }
+                test("rejects unsupported styles nested in hover text payloads") {
+                    val payload = Component.text("tip").insertion("/warp")
+                    val component = Component.text("hover me").hoverEvent(HoverEvent.showText(payload))
 
-            test("rejects legacy show-item NBT payloads") {
-                val legacyItem =
-                    Component
-                        .text("Loot")
-                        .hoverEvent(
-                            HoverEvent.showItem(
-                                key("minecraft", "diamond_sword"),
-                                1,
-                                BinaryTagHolder.binaryTagHolder("{}"),
-                            ),
-                        )
+                    val error =
+                        shouldThrow<IllegalArgumentException> {
+                            MiniMessageToDslWriter.write(component)
+                        }
 
-                val error =
-                    shouldThrow<IllegalArgumentException> {
-                        MiniMessageToDslWriter.write(legacyItem)
-                    }
+                    error.message shouldContain "insertion text"
+                }
 
-                error.message shouldContain "legacy show-item NBT"
-            }
+                test("rejects legacy show-item NBT payloads") {
+                    val legacyItem =
+                        Component
+                            .text("Loot")
+                            .hoverEvent(
+                                HoverEvent.showItem(
+                                    key("minecraft", "diamond_sword"),
+                                    1,
+                                    BinaryTagHolder.binaryTagHolder("{}"),
+                                ),
+                            )
 
-            test("rejects unsupported data component values") {
-                val unsupportedValue: DataComponentValue = object : DataComponentValue {}
-                val component =
-                    component {
-                        text("Loot") {
-                            hover {
-                                item(
-                                    key = key("minecraft", "diamond_sword"),
-                                    dataComponents = mapOf(key("minecraft", "custom_data") to unsupportedValue),
-                                )
+                    val error =
+                        shouldThrow<IllegalArgumentException> {
+                            MiniMessageToDslWriter.write(legacyItem)
+                        }
+
+                    error.message shouldContain "legacy show-item NBT"
+                }
+
+                test("rejects unsupported data component values") {
+                    val unsupportedValue: DataComponentValue = object : DataComponentValue {}
+                    val component =
+                        component {
+                            text("Loot") {
+                                hover {
+                                    item(
+                                        key = key("minecraft", "diamond_sword"),
+                                        dataComponents = mapOf(key("minecraft", "custom_data") to unsupportedValue),
+                                    )
+                                }
                             }
                         }
-                    }
 
-                val error =
-                    shouldThrow<IllegalArgumentException> {
-                        MiniMessageToDslWriter.write(component)
-                    }
+                    val error =
+                        shouldThrow<IllegalArgumentException> {
+                            MiniMessageToDslWriter.write(component)
+                        }
 
-                error.message shouldContain "data component value"
+                    error.message shouldContain "data component value"
+                }
             }
-        }
 
-        context("literal MiniMessage input") {
-            test("renders escaped MiniMessage tags as literal text") {
-                val generated = miniToDsl("\\<red>literal")
+            context("literal MiniMessage input") {
+                test("renders escaped MiniMessage tags as literal text") {
+                    val generated = miniToDsl("\\<red>literal")
 
-                generated shouldBe
-                        """
+                    generated shouldBe
+                            """
                     component {
                         text("<red>literal")
                     }
                     """.trimIndent()
-                mini("\\<red>literal") shouldContainText "<red>literal"
+                    mini("\\<red>literal") shouldContainText "<red>literal"
+                }
             }
-        }
-    })
+        },
+    )
 
 private fun assertGoldenRoundTrip(
     input: String,

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
@@ -16,6 +16,7 @@ import net.kyori.adventure.nbt.api.BinaryTagHolder
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.event.DataComponentValue
+import net.kyori.adventure.text.event.HoverEvent
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
@@ -184,10 +185,130 @@ class MiniMessageToDslTest :
         }
 
         context("click event emission") {
-            clickRoundTripCases.forEach { roundTrip ->
-                test(roundTrip.name) {
-                    assertGoldenRoundTrip(roundTrip.expectedSource, roundTrip.expectedComponent)
-                }
+            test("round-trips open url click events against compiled expected DSL") {
+                assertGoldenRoundTrip(
+                    expectedSource =
+                        """
+                        component {
+                            text("Open") {
+                                click {
+                                    openUrl("https://example.com")
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedComponent =
+                        component {
+                            text("Open") {
+                                click { openUrl("https://example.com") }
+                            }
+                        },
+                )
+            }
+
+            test("round-trips open file click events against compiled expected DSL") {
+                assertGoldenRoundTrip(
+                    expectedSource =
+                        """
+                        component {
+                            text("File") {
+                                click {
+                                    openFile("/tmp/example.txt")
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedComponent =
+                        component {
+                            text("File") {
+                                click { openFile("/tmp/example.txt") }
+                            }
+                        },
+                )
+            }
+
+            test("round-trips run command click events against compiled expected DSL") {
+                assertGoldenRoundTrip(
+                    expectedSource =
+                        """
+                        component {
+                            text("Spawn") {
+                                click {
+                                    run("/spawn")
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedComponent =
+                        component {
+                            text("Spawn") {
+                                click { run("/spawn") }
+                            }
+                        },
+                )
+            }
+
+            test("round-trips suggest command click events against compiled expected DSL") {
+                assertGoldenRoundTrip(
+                    expectedSource =
+                        """
+                        component {
+                            text("Reply") {
+                                click {
+                                    suggest("/msg Alex ")
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedComponent =
+                        component {
+                            text("Reply") {
+                                click { suggest("/msg Alex ") }
+                            }
+                        },
+                )
+            }
+
+            test("round-trips change page click events against compiled expected DSL") {
+                assertGoldenRoundTrip(
+                    expectedSource =
+                        """
+                        component {
+                            text("Page") {
+                                click {
+                                    changePage(4)
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedComponent =
+                        component {
+                            text("Page") {
+                                click { changePage(4) }
+                            }
+                        },
+                )
+            }
+
+            test("round-trips copy click events against compiled expected DSL") {
+                assertGoldenRoundTrip(
+                    expectedSource =
+                        """
+                        component {
+                            text("Copy") {
+                                click {
+                                    copy("copied")
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedComponent =
+                        component {
+                            text("Copy") {
+                                click { copy("copied") }
+                            }
+                        },
+                )
             }
 
             test("emits a marker for non-representable click actions") {
@@ -238,10 +359,201 @@ class MiniMessageToDslTest :
         }
 
         context("hover event emission") {
-            hoverRoundTripCases.forEach { roundTrip ->
-                test(roundTrip.name) {
-                    assertGoldenRoundTrip(roundTrip.expectedSource, roundTrip.expectedComponent)
-                }
+            test("round-trips show text hover events against compiled expected DSL") {
+                assertGoldenRoundTrip(
+                    expectedSource =
+                        """
+                        component {
+                            text("Spawn") {
+                                hover {
+                                    text {
+                                        text("Warp now") {
+                                            color(NamedTextColor.GOLD)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedComponent =
+                        component {
+                            text("Spawn") {
+                                hover {
+                                    text {
+                                        text("Warp now") {
+                                            color(NamedTextColor.GOLD)
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                )
+            }
+
+            test("round-trips show item hover events against compiled expected DSL") {
+                assertGoldenRoundTrip(
+                    expectedSource =
+                        """
+                        component {
+                            text("Loot") {
+                                hover {
+                                    item(
+                                        key = key("minecraft", "diamond_sword"),
+                                        count = 2
+                                    )
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedComponent =
+                        component {
+                            text("Loot") {
+                                hover {
+                                    item(
+                                        key = key("minecraft", "diamond_sword"),
+                                        count = 2,
+                                    )
+                                }
+                            }
+                        },
+                )
+            }
+
+            test("round-trips show item hover data components against compiled expected DSL") {
+                assertGoldenRoundTrip(
+                    expectedSource =
+                        """
+                        component {
+                            text("Loot data") {
+                                hover {
+                                    item(
+                                        key = key("minecraft", "diamond_sword"),
+                                        dataComponents = mapOf(
+                                            key("minecraft", "custom_data") to BinaryTagHolder.binaryTagHolder("{kotventure:1b}")
+                                        )
+                                    )
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedComponent =
+                        component {
+                            text("Loot data") {
+                                hover {
+                                    item(
+                                        key = key("minecraft", "diamond_sword"),
+                                        dataComponents =
+                                            mapOf<Key, DataComponentValue>(
+                                                key("minecraft", "custom_data") to
+                                                    BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
+                                            ),
+                                    )
+                                }
+                            }
+                        },
+                )
+            }
+
+            test("emits show item data components in a stable key order") {
+                val loot =
+                    component {
+                        text("Loot data") {
+                            hover {
+                                item(
+                                    key = key("minecraft", "diamond_sword"),
+                                    dataComponents =
+                                        mapOf<Key, DataComponentValue>(
+                                            key("minecraft", "damage") to BinaryTagHolder.binaryTagHolder("{value:5b}"),
+                                            key("minecraft", "custom_data") to
+                                                BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
+                                        ),
+                                )
+                            }
+                        }
+                    }
+
+                MiniMessageToDslWriter.write(loot) shouldBe
+                    """
+                    component {
+                        text("Loot data") {
+                            hover {
+                                item(
+                                    key = key("minecraft", "diamond_sword"),
+                                    dataComponents = mapOf(
+                                        key("minecraft", "custom_data") to BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
+                                        key("minecraft", "damage") to BinaryTagHolder.binaryTagHolder("{value:5b}")
+                                    )
+                                )
+                            }
+                        }
+                    }
+                    """.trimIndent()
+            }
+
+            test("round-trips show entity hover events against compiled expected DSL") {
+                assertGoldenRoundTrip(
+                    expectedSource =
+                        """
+                        component {
+                            text("Mob") {
+                                hover {
+                                    entity(
+                                        type = key("minecraft", "zombie"),
+                                        id = UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25")
+                                    )
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedComponent =
+                        component {
+                            text("Mob") {
+                                hover {
+                                    entity(
+                                        type = key("minecraft", "zombie"),
+                                        id = UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25"),
+                                    )
+                                }
+                            }
+                        },
+                )
+            }
+
+            test("round-trips named show entity hover events against compiled expected DSL") {
+                assertGoldenRoundTrip(
+                    expectedSource =
+                        """
+                        component {
+                            text("Named mob") {
+                                hover {
+                                    entity(
+                                        type = key("minecraft", "player"),
+                                        id = UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee")
+                                    ) {
+                                        text("Alex \"\$5\"") {
+                                            color(NamedTextColor.AQUA)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    expectedComponent =
+                        component {
+                            text("Named mob") {
+                                hover {
+                                    entity(
+                                        type = key("minecraft", "player"),
+                                        id = UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee"),
+                                    ) {
+                                        text("Alex \"$5\"") {
+                                            color(NamedTextColor.AQUA)
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                )
             }
         }
 
@@ -272,6 +584,60 @@ class MiniMessageToDslTest :
 
                 error.message shouldContain "supports only text component trees"
             }
+
+            test("rejects unsupported styles nested in hover text payloads") {
+                val payload = Component.text("tip").insertion("/warp")
+                val component = Component.text("hover me").hoverEvent(HoverEvent.showText(payload))
+
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        MiniMessageToDslWriter.write(component)
+                    }
+
+                error.message shouldContain "insertion text"
+            }
+
+            test("rejects legacy show-item NBT payloads") {
+                val legacyItem =
+                    Component
+                        .text("Loot")
+                        .hoverEvent(
+                            HoverEvent.showItem(
+                                key("minecraft", "diamond_sword"),
+                                1,
+                                BinaryTagHolder.binaryTagHolder("{}"),
+                            ),
+                        )
+
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        MiniMessageToDslWriter.write(legacyItem)
+                    }
+
+                error.message shouldContain "legacy show-item NBT"
+            }
+
+            test("rejects unsupported data component values") {
+                val unsupportedValue: DataComponentValue = object : DataComponentValue {}
+                val component =
+                    component {
+                        text("Loot") {
+                            hover {
+                                item(
+                                    key = key("minecraft", "diamond_sword"),
+                                    dataComponents = mapOf(key("minecraft", "custom_data") to unsupportedValue),
+                                )
+                            }
+                        }
+                    }
+
+                val error =
+                    shouldThrow<IllegalArgumentException> {
+                        MiniMessageToDslWriter.write(component)
+                    }
+
+                error.message shouldContain "data component value"
+            }
         }
 
         context("literal MiniMessage input") {
@@ -288,297 +654,6 @@ class MiniMessageToDslTest :
             }
         }
     })
-
-private val clickRoundTripCases: List<RoundTripCase> =
-    listOf(
-        RoundTripCase(
-            name = "round-trips open url click events against compiled expected DSL",
-            expectedSource =
-                """
-                component {
-                    text("Open") {
-                        click {
-                            openUrl("https://example.com")
-                        }
-                    }
-                }
-                """.trimIndent(),
-            expectedComponent =
-                component {
-                    text("Open") {
-                        click {
-                            openUrl("https://example.com")
-                        }
-                    }
-                },
-        ),
-        RoundTripCase(
-            name = "round-trips open file click events against compiled expected DSL",
-            expectedSource =
-                """
-                component {
-                    text("File") {
-                        click {
-                            openFile("/tmp/example.txt")
-                        }
-                    }
-                }
-                """.trimIndent(),
-            expectedComponent =
-                component {
-                    text("File") {
-                        click {
-                            openFile("/tmp/example.txt")
-                        }
-                    }
-                },
-        ),
-        RoundTripCase(
-            name = "round-trips run command click events against compiled expected DSL",
-            expectedSource =
-                """
-                component {
-                    text("Spawn") {
-                        click {
-                            run("/spawn")
-                        }
-                    }
-                }
-                """.trimIndent(),
-            expectedComponent =
-                component {
-                    text("Spawn") {
-                        click {
-                            run("/spawn")
-                        }
-                    }
-                },
-        ),
-        RoundTripCase(
-            name = "round-trips suggest command click events against compiled expected DSL",
-            expectedSource =
-                """
-                component {
-                    text("Reply") {
-                        click {
-                            suggest("/msg Alex ")
-                        }
-                    }
-                }
-                """.trimIndent(),
-            expectedComponent =
-                component {
-                    text("Reply") {
-                        click {
-                            suggest("/msg Alex ")
-                        }
-                    }
-                },
-        ),
-        RoundTripCase(
-            name = "round-trips change page click events against compiled expected DSL",
-            expectedSource =
-                """
-                component {
-                    text("Page") {
-                        click {
-                            changePage(4)
-                        }
-                    }
-                }
-                """.trimIndent(),
-            expectedComponent =
-                component {
-                    text("Page") {
-                        click {
-                            changePage(4)
-                        }
-                    }
-                },
-        ),
-        RoundTripCase(
-            name = "round-trips copy click events against compiled expected DSL",
-            expectedSource =
-                """
-                component {
-                    text("Copy") {
-                        click {
-                            copy("copied")
-                        }
-                    }
-                }
-                """.trimIndent(),
-            expectedComponent =
-                component {
-                    text("Copy") {
-                        click {
-                            copy("copied")
-                        }
-                    }
-                },
-        ),
-    )
-
-private val hoverRoundTripCases: List<RoundTripCase> =
-    listOf(
-        RoundTripCase(
-            name = "round-trips show text hover events against compiled expected DSL",
-            expectedSource =
-                """
-                component {
-                    text("Spawn") {
-                        hover {
-                            text {
-                                text("Warp now") {
-                                    color(NamedTextColor.GOLD)
-                                }
-                            }
-                        }
-                    }
-                }
-                """.trimIndent(),
-            expectedComponent =
-                component {
-                    text("Spawn") {
-                        hover {
-                            text {
-                                text("Warp now") {
-                                    color(NamedTextColor.GOLD)
-                                }
-                            }
-                        }
-                    }
-                },
-        ),
-        RoundTripCase(
-            name = "round-trips show item hover events against compiled expected DSL",
-            expectedSource =
-                """
-                component {
-                    text("Loot") {
-                        hover {
-                            item(
-                                key = key("minecraft", "diamond_sword"),
-                                count = 2
-                            )
-                        }
-                    }
-                }
-                """.trimIndent(),
-            expectedComponent =
-                component {
-                    text("Loot") {
-                        hover {
-                            item(
-                                key = key("minecraft", "diamond_sword"),
-                                count = 2,
-                            )
-                        }
-                    }
-                },
-        ),
-        RoundTripCase(
-            name = "round-trips show item hover data components against compiled expected DSL",
-            expectedSource =
-                """
-                component {
-                    text("Loot data") {
-                        hover {
-                            item(
-                                key = key("minecraft", "diamond_sword"),
-                                dataComponents = mapOf(
-                                    key("minecraft", "custom_data") to BinaryTagHolder.binaryTagHolder("{kotventure:1b}")
-                                )
-                            )
-                        }
-                    }
-                }
-                """.trimIndent(),
-            expectedComponent =
-                component {
-                    text("Loot data") {
-                        hover {
-                            item(
-                                key = key("minecraft", "diamond_sword"),
-                                dataComponents =
-                                    mapOf<Key, DataComponentValue>(
-                                        key("minecraft", "custom_data") to
-                                                BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
-                                    ),
-                            )
-                        }
-                    }
-                },
-        ),
-        RoundTripCase(
-            name = "round-trips show entity hover events against compiled expected DSL",
-            expectedSource =
-                """
-                component {
-                    text("Mob") {
-                        hover {
-                            entity(
-                                type = key("minecraft", "zombie"),
-                                id = UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25")
-                            )
-                        }
-                    }
-                }
-                """.trimIndent(),
-            expectedComponent =
-                component {
-                    text("Mob") {
-                        hover {
-                            entity(
-                                type = key("minecraft", "zombie"),
-                                id = UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25"),
-                            )
-                        }
-                    }
-                },
-        ),
-        RoundTripCase(
-            name = "round-trips named show entity hover events against compiled expected DSL",
-            expectedSource =
-                """
-                component {
-                    text("Named mob") {
-                        hover {
-                            entity(
-                                type = key("minecraft", "player"),
-                                id = UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee")
-                            ) {
-                                text("Alex \"\$5\"") {
-                                    color(NamedTextColor.AQUA)
-                                }
-                            }
-                        }
-                    }
-                }
-                """.trimIndent(),
-            expectedComponent =
-                component {
-                    text("Named mob") {
-                        hover {
-                            entity(
-                                type = key("minecraft", "player"),
-                                id = UUID.fromString("3f5f1f4e-29cb-4c98-93f0-3c7f4b52ddee"),
-                            ) {
-                                text("Alex \"$5\"") {
-                                    color(NamedTextColor.AQUA)
-                                }
-                            }
-                        }
-                    }
-                },
-        ),
-    )
-
-private data class RoundTripCase(
-    val name: String,
-    val expectedSource: String,
-    val expectedComponent: Component,
-)
 
 private fun assertGoldenRoundTrip(
     input: String,

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
@@ -252,7 +252,7 @@ class MiniMessageToDslTest :
                         miniToDsl("<shadow:red>shadow</shadow>")
                     }
 
-                error.message shouldContain "miniToDsl slice 2 does not support shadow colours"
+                error.message shouldContain "miniToDsl does not yet support shadow colours"
             }
 
             test("rejects unsupported component types") {


### PR DESCRIPTION
Closes #146

Issue plan: https://github.com/LMLiam/Kotventure/issues/146#issuecomment-4709461738

This slice extends miniToDsl to preserve Adventure click and hover events in the generated DSL source. It updates the writer, support checks, and tests, and refreshes the README/changelog notes for the new output.

Validation:
- ./gradlew projects
- ./gradlew :minimessage:test
- Result: both succeeded; :minimessage:test was UP-TO-DATE
