### PR TITLE
feat(minimessage): mini→DSL converter — structured components (slice 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@ val dslSource = miniToDsl("<red><bold>Hello")
 //         bold()
 //     }
 // }
-// Supported output also includes click { ... } and hover { ... } blocks for Adventure click and hover events.
+// Supported output also includes click { ... } and hover { ... } blocks for Adventure click and hover events, plus the
+// structured components translatable(...) { ... } (with recursive arguments), keybind(...), score(...), and selector(...).
 ```
 
 For messages that are rendered many times with different values, declare a typed template once and reuse it. Each

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableComponentBuilder.kt
@@ -1,6 +1,8 @@
 package io.github.lmliam.kotventure.core.translatable
 
 import io.github.lmliam.kotventure.core.component.ComponentBuilder
+import io.github.lmliam.kotventure.core.text.TextBuilder
+import io.github.lmliam.kotventure.core.text.TextScope
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentLike
 import net.kyori.adventure.text.TranslatableComponent
@@ -20,6 +22,10 @@ internal class TranslatableComponentBuilder(
 
     override fun arg(value: ComponentLike) {
         arguments += TranslationArgument.component(value)
+    }
+
+    override fun arg(init: TextScope.() -> Unit) {
+        arguments += TranslationArgument.component(TextBuilder().apply(init).build())
     }
 
     override fun arg(value: Boolean) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableScope.kt
@@ -2,6 +2,7 @@ package io.github.lmliam.kotventure.core.translatable
 
 import io.github.lmliam.kotventure.core.component.ComponentScope
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.core.text.TextScope
 import net.kyori.adventure.text.ComponentLike
 
 /**
@@ -18,6 +19,11 @@ public interface TranslatableScope : ComponentScope {
      * Appends a component-like translation argument.
      */
     public fun arg(value: ComponentLike)
+
+    /**
+     * Builds an inline component translation argument from [init] and appends it.
+     */
+    public fun arg(init: TextScope.() -> Unit)
 
     /**
      * Appends a boolean translation argument.

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableDslTest.kt
@@ -48,6 +48,20 @@ class TranslatableDslTest :
                 component.shouldHaveArguments(TranslationArgument.component(item))
             }
 
+            "builds an inline component argument" {
+                val component =
+                    translatable("chat.type.text") {
+                        arg {
+                            content("Alex")
+                            color(NamedTextColor.AQUA)
+                        }
+                    }
+
+                component.shouldHaveArguments(
+                    TranslationArgument.component(Component.text("Alex").color(NamedTextColor.AQUA)),
+                )
+            }
+
             "adds boolean and numeric arguments" {
                 val component =
                     translatable("settings.toggle") {

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
@@ -11,9 +11,10 @@ public fun mini(input: String): Component = parseMiniMessage(input)
 /**
  * Converts MiniMessage [input] into Kotventure component DSL source code.
  *
- * The current slices support plain text, recursive text children, named and hex colours, the standard text decorations,
- * click events, and hover events. Unsupported component types or style attributes from later slices fail with an
- * [IllegalArgumentException] instead of producing lossy source.
+ * The current slices support plain text, recursive children, named and hex colours, the standard text decorations,
+ * click events, hover events, and the structured components — translatable (with recursive arguments), keybind, score,
+ * and selector. Unsupported component types or style attributes from later slices fail with an [IllegalArgumentException]
+ * instead of producing lossy source.
  */
 public fun miniToDsl(input: String): String = MiniMessageToDslWriter.write(mini(input))
 

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
@@ -37,11 +37,20 @@ internal object MiniMessageToDslSupport {
         requireSupportedPayload(component)
     }
 
-    /** Validates the nested components a structured component carries so unsupported styles are rejected up front. */
+    /**
+     * Validates the payload a structured component carries beyond its style and children — translatable arguments and
+     * selector separators are recursed so unsupported styles are rejected up front, and a score's obsolete fixed
+     * [ScoreComponent.value] is rejected because the DSL cannot represent it and dropping it would be lossy.
+     */
     private fun requireSupportedPayload(component: Component) {
         when (component) {
             is TranslatableComponent -> component.arguments().forEach(::requireSupportedArgument)
             is SelectorComponent -> component.separator()?.let(::requireSupported)
+            is ScoreComponent ->
+                require(component.value() == null) {
+                    "miniToDsl does not yet support score components with a fixed value."
+                }
+
             else -> Unit
         }
     }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSupport.kt
@@ -1,7 +1,12 @@
 package io.github.lmliam.kotventure.minimessage
 
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.KeybindComponent
+import net.kyori.adventure.text.ScoreComponent
+import net.kyori.adventure.text.SelectorComponent
 import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.TranslatableComponent
+import net.kyori.adventure.text.TranslationArgument
 import net.kyori.adventure.text.event.HoverEvent
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextDecoration
@@ -18,11 +23,35 @@ internal object MiniMessageToDslSupport {
         )
 
     fun requireSupported(component: Component) {
-        require(component is TextComponent) {
-            "miniToDsl supports only text component trees, but found ${component::class.simpleName}."
+        require(
+            component is TextComponent ||
+                component is TranslatableComponent ||
+                component is KeybindComponent ||
+                component is ScoreComponent ||
+                component is SelectorComponent,
+        ) {
+            "miniToDsl does not yet support ${component::class.simpleName} components."
         }
         requireSupported(component.style())
         component.children().forEach(::requireSupported)
+        requireSupportedPayload(component)
+    }
+
+    /** Validates the nested components a structured component carries so unsupported styles are rejected up front. */
+    private fun requireSupportedPayload(component: Component) {
+        when (component) {
+            is TranslatableComponent -> component.arguments().forEach(::requireSupportedArgument)
+            is SelectorComponent -> component.separator()?.let(::requireSupported)
+            else -> Unit
+        }
+    }
+
+    private fun requireSupportedArgument(argument: TranslationArgument) {
+        val value = argument.value()
+        require(value is Component) {
+            "miniToDsl does not yet support non-component translatable arguments (${value::class.qualifiedName})."
+        }
+        requireSupported(value)
     }
 
     fun requireSupported(style: Style) {

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
@@ -147,8 +147,8 @@ private fun KotlinSourceBuilder.appendStructured(
 
 private fun KotlinSourceBuilder.appendArgument(argument: TranslationArgument) {
     val value = argument.value()
-    require(value is Component) {
-        "miniToDsl does not yet support non-component translatable arguments (${value::class.qualifiedName})."
+    check(value is Component) {
+        "miniToDsl reached an unvalidated ${value::class.simpleName} translatable argument."
     }
     appendComponentArgument("arg", value)
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
@@ -2,7 +2,12 @@ package io.github.lmliam.kotventure.minimessage
 
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.KeybindComponent
+import net.kyori.adventure.text.ScoreComponent
+import net.kyori.adventure.text.SelectorComponent
 import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.TranslatableComponent
+import net.kyori.adventure.text.TranslationArgument
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.event.DataComponentValue
 import net.kyori.adventure.text.event.HoverEvent
@@ -35,20 +40,38 @@ internal object MiniMessageToDslWriter {
                 !MiniMessageToDslSupport.hasDslOutput(style())
 }
 
-/** Emits [component], unwrapping a content-less, style-less root into a bare sequence of its children. */
+/** Emits [component], unwrapping a content-less, style-less text root into a bare sequence of its children. */
 private fun KotlinSourceBuilder.appendRoot(component: Component) {
     if (component is TextComponent &&
         component.content().isEmpty() &&
         !MiniMessageToDslSupport.hasDslOutput(component.style())
     ) {
-        component.children().forEach { appendComponent(it as TextComponent) }
+        component.children().forEach { appendComponent(it) }
         return
     }
 
-    appendComponent(component as TextComponent)
+    appendComponent(component)
 }
 
-private fun KotlinSourceBuilder.appendComponent(component: TextComponent) {
+/**
+ * Dispatches to the emitter for [component]'s concrete type. Every emission is a self-contained call expression, so it
+ * reads the same whether it appends a child inside a scope or stands alone as a translatable argument or separator.
+ *
+ * [MiniMessageToDslSupport.requireSupported] runs before any emission, so an unrecognised type here is a broken
+ * invariant rather than user input.
+ */
+private fun KotlinSourceBuilder.appendComponent(component: Component) {
+    when (component) {
+        is TextComponent -> appendText(component)
+        is TranslatableComponent -> appendTranslatable(component)
+        is KeybindComponent -> appendKeybind(component)
+        is ScoreComponent -> appendScore(component)
+        is SelectorComponent -> appendSelector(component)
+        else -> error("miniToDsl reached an unvalidated ${component::class.simpleName} component.")
+    }
+}
+
+private fun KotlinSourceBuilder.appendText(component: TextComponent) {
     val text = component.content()
     val hasBlockBody = MiniMessageToDslSupport.hasDslOutput(component.style()) || component.children().isNotEmpty()
 
@@ -60,8 +83,90 @@ private fun KotlinSourceBuilder.appendComponent(component: TextComponent) {
     val header = if (text.isEmpty()) "text" else "text(\"${escapeKotlinString(text)}\")"
     block(header) {
         appendStyle(component.style())
-        component.children().forEach { appendComponent(it as TextComponent) }
+        component.children().forEach { appendComponent(it) }
     }
+}
+
+private fun KotlinSourceBuilder.appendTranslatable(component: TranslatableComponent) {
+    val fallback = component.fallback()
+    val arguments = component.arguments()
+    appendStructured(
+        header = "translatable(\"${escapeKotlinString(component.key())}\")",
+        component = component,
+        hasExtraBody = fallback != null || arguments.isNotEmpty(),
+    ) {
+        fallback?.let { line("fallback(\"${escapeKotlinString(it)}\")") }
+        arguments.forEach { appendArgument(it) }
+    }
+}
+
+private fun KotlinSourceBuilder.appendKeybind(component: KeybindComponent) {
+    appendStructured("keybind(\"${escapeKotlinString(component.keybind())}\")", component) {}
+}
+
+private fun KotlinSourceBuilder.appendScore(component: ScoreComponent) {
+    val name = escapeKotlinString(component.name())
+    val objective = escapeKotlinString(component.objective())
+    appendStructured("score(\"$name\", \"$objective\")", component) {}
+}
+
+private fun KotlinSourceBuilder.appendSelector(component: SelectorComponent) {
+    val separator = component.separator()
+    appendStructured(
+        header = "selector(\"${escapeKotlinString(component.pattern())}\")",
+        component = component,
+        hasExtraBody = separator != null,
+    ) {
+        separator?.let { appendComponentArgument("separator", it) }
+    }
+}
+
+/**
+ * Emits [header] as a bare call when [component] carries no style, children, or [hasExtraBody], otherwise opens a block
+ * and emits [body] (component-specific configuration such as fallback, arguments, or a separator) ahead of the shared
+ * style and children.
+ */
+private fun KotlinSourceBuilder.appendStructured(
+    header: String,
+    component: Component,
+    hasExtraBody: Boolean = false,
+    body: KotlinSourceBuilder.() -> Unit,
+) {
+    val hasStyle = MiniMessageToDslSupport.hasDslOutput(component.style())
+    if (!hasExtraBody && !hasStyle && component.children().isEmpty()) {
+        line(header)
+        return
+    }
+
+    block(header) {
+        body()
+        appendStyle(component.style())
+        component.children().forEach { appendComponent(it) }
+    }
+}
+
+private fun KotlinSourceBuilder.appendArgument(argument: TranslationArgument) {
+    val value = argument.value()
+    require(value is Component) {
+        "miniToDsl does not yet support non-component translatable arguments (${value::class.qualifiedName})."
+    }
+    appendComponentArgument("arg", value)
+}
+
+/**
+ * Emits `$label { ... }`, recursing through [appendRoot] for the wrapped component.
+ *
+ * The builder-block form (`arg { … }`, `separator { … }`) is used rather than a value argument because the per-type
+ * builders (`text`, `translatable`, …) are members of
+ * [io.github.lmliam.kotventure.core.component.ComponentScope] that return `Unit`, so an unwrapped `text("…")` could not
+ * type-check as a [net.kyori.adventure.text.ComponentLike] value. Both [io.github.lmliam.kotventure.core.translatable]
+ * `arg` and [io.github.lmliam.kotventure.core.selector] `separator` expose a `TextScope` block overload for exactly this.
+ */
+private fun KotlinSourceBuilder.appendComponentArgument(
+    label: String,
+    component: Component,
+) {
+    block(label) { appendRoot(component) }
 }
 
 private fun KotlinSourceBuilder.appendStyle(style: Style) {

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
@@ -14,6 +14,7 @@ import io.kotest.matchers.string.shouldContain
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.nbt.api.BinaryTagHolder
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TranslationArgument
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.event.DataComponentValue
 import net.kyori.adventure.text.event.HoverEvent
@@ -561,6 +562,226 @@ class MiniMessageToDslTest :
                 }
             }
 
+            context("structured component emission") {
+                test("round-trips keybind components against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        input = "<key:key.jump>",
+                        expectedSource =
+                            """
+                        component {
+                            keybind("key.jump")
+                        }
+                        """.trimIndent(),
+                        expectedComponent = component { keybind("key.jump") },
+                    )
+                }
+
+                test("round-trips keybind components carrying style against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
+                        component {
+                            keybind("key.sneak") {
+                                color(NamedTextColor.GREEN)
+                            }
+                        }
+                        """.trimIndent(),
+                        expectedComponent =
+                            component {
+                                keybind("key.sneak") {
+                                    color(NamedTextColor.GREEN)
+                                }
+                            },
+                    )
+                }
+
+                test("round-trips keybind components carrying click events against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
+                        component {
+                            keybind("key.jump") {
+                                click {
+                                    run("/help")
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                        expectedComponent =
+                            component {
+                                keybind("key.jump") {
+                                    click { run("/help") }
+                                }
+                            },
+                    )
+                }
+
+                test("round-trips score components against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        input = "<score:player:objective>",
+                        expectedSource =
+                            """
+                        component {
+                            score("player", "objective")
+                        }
+                        """.trimIndent(),
+                        expectedComponent = component { score("player", "objective") },
+                    )
+                }
+
+                test("round-trips selector components against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        input = "<selector:'@p'>",
+                        expectedSource =
+                            """
+                        component {
+                            selector("@p")
+                        }
+                        """.trimIndent(),
+                        expectedComponent = component { selector("@p") },
+                    )
+                }
+
+                test("round-trips selector separators against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        input = "<selector:'@e':', '>",
+                        expectedSource =
+                            """
+                        component {
+                            selector("@e") {
+                                separator {
+                                    text(", ")
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                        expectedComponent =
+                            component {
+                                selector("@e") {
+                                    separator { text(", ") }
+                                }
+                            },
+                    )
+                }
+
+                test("round-trips argument-free translatable components against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        input = "<lang:death.fell.accident.ladder>",
+                        expectedSource =
+                            """
+                        component {
+                            translatable("death.fell.accident.ladder")
+                        }
+                        """.trimIndent(),
+                        expectedComponent = component { translatable("death.fell.accident.ladder") },
+                    )
+                }
+
+                test("round-trips translatable arguments against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        input = "<lang:multiplayer.player.joined:Alex>",
+                        expectedSource =
+                            """
+                        component {
+                            translatable("multiplayer.player.joined") {
+                                arg {
+                                    text("Alex")
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                        expectedComponent =
+                            component {
+                                translatable("multiplayer.player.joined") {
+                                    arg { text("Alex") }
+                                }
+                            },
+                    )
+                }
+
+                test("recurses nested styled translatable arguments against compiled expected DSL") {
+                    assertGoldenRoundTrip(
+                        input = "<lang:'k':'<red>x<bold>y'>",
+                        expectedSource =
+                            """
+                        component {
+                            translatable("k") {
+                                arg {
+                                    text("x") {
+                                        color(NamedTextColor.RED)
+                                        text("y") {
+                                            bold()
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                        expectedComponent =
+                            component {
+                                translatable("k") {
+                                    arg {
+                                        text("x") {
+                                            color(NamedTextColor.RED)
+                                            text("y") { bold() }
+                                        }
+                                    }
+                                }
+                            },
+                    )
+                }
+
+                test("round-trips translatable components nesting other structured components") {
+                    assertGoldenRoundTrip(
+                        input = "<lang:k:a>:<lang:k:b>",
+                        expectedSource =
+                            """
+                        component {
+                            translatable("k") {
+                                arg {
+                                    text("a")
+                                }
+                                text(":")
+                                translatable("k") {
+                                    arg {
+                                        text("b")
+                                    }
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                        expectedComponent =
+                            component {
+                                translatable("k") {
+                                    arg { text("a") }
+                                    text(":")
+                                    translatable("k") {
+                                        arg { text("b") }
+                                    }
+                                }
+                            },
+                    )
+                }
+
+                test("emits translatable fallback text") {
+                    val translatable =
+                        component {
+                            translatable("menu.singleplayer") {
+                                fallback("Singleplayer")
+                            }
+                        }
+
+                    MiniMessageToDslWriter.write(translatable) shouldBe
+                            """
+                    component {
+                        translatable("menu.singleplayer") {
+                            fallback("Singleplayer")
+                        }
+                    }
+                    """.trimIndent()
+                }
+            }
+
             context("unsupported input") {
                 test("rejects unsupported shadow colours instead of dropping them") {
                     val error =
@@ -571,22 +792,68 @@ class MiniMessageToDslTest :
                     error.message shouldContain "miniToDsl does not yet support shadow colours"
                 }
 
-                test("rejects unsupported component types") {
+                test("rejects component types from later slices") {
                     val error =
                         shouldThrow<IllegalArgumentException> {
-                            miniToDsl("<key:key.jump>")
+                            MiniMessageToDslWriter.write(Component.storageNBT("CustomData", key("minecraft", "data")))
                         }
 
-                    error.message shouldContain "supports only text component trees"
+                    error.message shouldContain "does not yet support"
+                    error.message shouldContain "StorageNBT"
                 }
 
-                test("rejects unsupported component types in children") {
+                test("rejects component types from later slices nested in children") {
+                    val nested = Component.empty().append(Component.storageNBT("CustomData", key("minecraft", "data")))
+
                     val error =
                         shouldThrow<IllegalArgumentException> {
-                            MiniMessageToDslWriter.write(Component.empty().append(Component.keybind("key.jump")))
+                            MiniMessageToDslWriter.write(nested)
                         }
 
-                    error.message shouldContain "supports only text component trees"
+                    error.message shouldContain "does not yet support"
+                }
+
+                test("rejects non-component translatable arguments") {
+                    val translatable =
+                        Component
+                            .translatable()
+                            .key("stat.generic")
+                            .arguments(TranslationArgument.bool(true))
+                            .build()
+
+                    val error =
+                        shouldThrow<IllegalArgumentException> {
+                            MiniMessageToDslWriter.write(translatable)
+                        }
+
+                    error.message shouldContain "non-component translatable arguments"
+                }
+
+                test("rejects unsupported styles nested in translatable arguments") {
+                    val translatable =
+                        Component
+                            .translatable()
+                            .key("chat.type.text")
+                            .arguments(Component.text("Alex").insertion("/msg Alex "))
+                            .build()
+
+                    val error =
+                        shouldThrow<IllegalArgumentException> {
+                            MiniMessageToDslWriter.write(translatable)
+                        }
+
+                    error.message shouldContain "insertion text"
+                }
+
+                test("rejects unsupported styles nested in selector separators") {
+                    val selector = Component.selector("@e").separator(Component.text(", ").insertion("/spy"))
+
+                    val error =
+                        shouldThrow<IllegalArgumentException> {
+                            MiniMessageToDslWriter.write(selector)
+                        }
+
+                    error.message shouldContain "insertion text"
                 }
 
                 test("rejects unsupported styles nested in hover text payloads") {

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
@@ -780,6 +780,30 @@ class MiniMessageToDslTest :
                     }
                     """.trimIndent()
                 }
+
+                test("emits a structured component carrying arguments, style, and children together") {
+                    val translatable =
+                        component {
+                            translatable("commands.give.success.single") {
+                                arg { text("Alex") }
+                                color(NamedTextColor.GREEN)
+                                text("!")
+                            }
+                        }
+
+                    MiniMessageToDslWriter.write(translatable) shouldBe
+                            """
+                    component {
+                        translatable("commands.give.success.single") {
+                            arg {
+                                text("Alex")
+                            }
+                            color(NamedTextColor.GREEN)
+                            text("!")
+                        }
+                    }
+                    """.trimIndent()
+                }
             }
 
             context("unsupported input") {
@@ -811,6 +835,17 @@ class MiniMessageToDslTest :
                         }
 
                     error.message shouldContain "does not yet support"
+                }
+
+                test("rejects score components with a fixed value instead of dropping it") {
+                    val score = Component.score("player", "objective").value("7")
+
+                    val error =
+                        shouldThrow<IllegalArgumentException> {
+                            MiniMessageToDslWriter.write(score)
+                        }
+
+                    error.message shouldContain "score components with a fixed value"
                 }
 
                 test("rejects non-component translatable arguments") {


### PR DESCRIPTION
## Summary

Slice 3 of the MiniMessage → DSL converter (#29). The walker is now polymorphic over component type and emits the **structured (non-text) components** in addition to text:

- `TranslatableComponent` → `translatable(key) { fallback(...); arg { ... } }`, with arguments recursed through the walker (including nested styled components).
- `KeybindComponent` → `keybind("...")`
- `ScoreComponent` → `score("name", "objective")`
- `SelectorComponent` → `selector("...") { separator { ... } }`

Each reuses the slice 1/2 style + click/hover emission, so a structured component carrying a colour or event renders correctly.

## Related Issues

Closes #147

## DSL Impact

- **New public API (core):** `TranslatableScope.arg(init: TextScope.() -> Unit)` — an inline component-argument builder, mirroring the existing `SelectorScope.separator(init:)`. This is what lets the converter emit the idiomatic `arg { text("Alex") }` instead of `arg(component { text("Alex") })`. (The per-type builders — `text`, `translatable`, … — are `Unit`-returning members of `ComponentScope`, so a bare `text("…")` cannot be passed as a `ComponentLike` value; the block overload is the clean way through.)
- **Converter (`miniToDsl`)** now accepts the four structured component types; previously they failed with "supports only text component trees". Genuinely unsupported types (NBT, object) still fail loudly rather than producing lossy source.

Example:

```kotlin
miniToDsl("<lang:multiplayer.player.joined:'<aqua>Alex'>")
// component {
//     translatable("multiplayer.player.joined") {
//         arg {
//             text("Alex") {
//                 color(NamedTextColor.AQUA)
//             }
//         }
//     }
// }
```

## Rationale

The converter is a migration/learning aid; structured components are common in real server messages (translation keys, keybind hints, selectors). Emitting them as compilable DSL — rather than rejecting the whole tree — is required for the converter to be usable on real MiniMessage.

## Testing

- **`minimessage`** (`MiniMessageToDslTest`): per-type golden round-trips against **compiled** expected DSL (no `eval`) for keybind, score, selector (+separator), and translatable (no-arg, single arg, **nested styled arg**, and a translatable root nesting another translatable child). Structured components carrying style and click events. A direct-write snapshot for `fallback`. New rejection tests: later-slice component types (top-level and nested as a child), non-component translatable arguments, and unsupported styles nested in translatable arguments / selector separators.
- **`core`** (`TranslatableDslTest`): new test for the `arg { }` inline-argument builder.
- `./gradlew build` green (compile + all tests + `ktlintCheck`/`spotlessCheck` + `explicitApi`).

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages (README converter note; CHANGELOG is release-please-managed)
- [x] Verified examples build and run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
