### PR TITLE
feat(core): shadow-colour and player-head DSL surfaces

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -115,6 +115,7 @@ val msg = component {
 // ── Reusable styles ────────────────────────────────────────────
 val headerStyle = style {
     color(GOLD)
+    shadow(BLACK)
     bold()
     italic(false)
     underlined(null)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -109,6 +109,7 @@ val msg = component {
     entityNbt("@p", "CustomName") { interpret(true) }
     storageNbt(key("kotventure", "messages"), "motd") { interpret(true) }
     display(sprite(key("minecraft", "block/stone"))) { fallback { text("[stone]") } }
+    display(head("Steve")) { fallback { text("[Steve]") } }
     mini("<gradient:gold:red>Epic</gradient>")
 }
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentBuilder.kt
@@ -17,6 +17,7 @@ import net.kyori.adventure.text.BlockNBTComponent
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.event.HoverEventSource
+import net.kyori.adventure.text.format.ShadowColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
@@ -36,6 +37,10 @@ internal abstract class ComponentBuilder<C : Component, B : AdventureComponentBu
 ) : ComponentScope {
     override fun color(color: TextColor) {
         builder.color(color)
+    }
+
+    override fun shadow(color: ShadowColor) {
+        builder.style { styleBuilder -> styleBuilder.shadowColor(color) }
     }
 
     override fun style(style: Style) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScope.kt
@@ -16,6 +16,7 @@ import io.github.lmliam.kotventure.core.translatable.TranslatableScope
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.BlockNBTComponent
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.ShadowColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
@@ -32,6 +33,22 @@ public interface ComponentScope :
      * Applies a text color to the component being configured.
      */
     public fun color(color: TextColor)
+
+    /**
+     * Applies [color] as the shadow color of the component being configured.
+     */
+    public fun shadow(color: ShadowColor)
+
+    /**
+     * Applies [color] as a shadow color with [alpha] opacity, where [alpha] is in the `0..255` range and defaults to
+     * fully opaque.
+     */
+    public fun shadow(
+        color: TextColor,
+        alpha: Int = 0xFF,
+    ) {
+        shadow(ShadowColor.shadowColor(color, alpha))
+    }
 
     /**
      * Applies a complete Adventure style to the component being configured.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectContentsDsl.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectContentsDsl.kt
@@ -2,7 +2,9 @@ package io.github.lmliam.kotventure.core.objectcomponent
 
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.`object`.ObjectContents
+import net.kyori.adventure.text.`object`.PlayerHeadObjectContents
 import net.kyori.adventure.text.`object`.SpriteObjectContents
+import java.util.UUID
 
 /**
  * Builds sprite object contents using Adventure's default sprite atlas.
@@ -16,3 +18,42 @@ public fun sprite(
     atlas: Key,
     sprite: Key,
 ): SpriteObjectContents = ObjectContents.sprite(atlas, sprite)
+
+/**
+ * Builds player-head object contents for the player named [name], rendering the hat layer when [hat] is `true`.
+ */
+public fun head(
+    name: String,
+    hat: Boolean = PlayerHeadObjectContents.DEFAULT_HAT,
+): PlayerHeadObjectContents =
+    ObjectContents
+    .playerHead()
+    .name(name)
+    .hat(hat)
+    .build()
+
+/**
+ * Builds player-head object contents for the player with UUID [id], rendering the hat layer when [hat] is `true`.
+ */
+public fun head(
+    id: UUID,
+    hat: Boolean = PlayerHeadObjectContents.DEFAULT_HAT,
+): PlayerHeadObjectContents =
+    ObjectContents
+    .playerHead()
+    .id(id)
+    .hat(hat)
+    .build()
+
+/**
+ * Builds player-head object contents drawn from the skin [texture] key, rendering the hat layer when [hat] is `true`.
+ */
+public fun head(
+    texture: Key,
+    hat: Boolean = PlayerHeadObjectContents.DEFAULT_HAT,
+): PlayerHeadObjectContents =
+    ObjectContents
+    .playerHead()
+    .texture(texture)
+    .hat(hat)
+    .build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleBuilder.kt
@@ -3,6 +3,7 @@ package io.github.lmliam.kotventure.core.style
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.event.HoverEventSource
+import net.kyori.adventure.text.format.ShadowColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
@@ -13,6 +14,10 @@ internal class StyleBuilder(
 ) : StyleScope {
     override fun color(color: TextColor?) {
         builder.color(color)
+    }
+
+    override fun shadow(color: ShadowColor?) {
+        builder.shadowColor(color)
     }
 
     override fun font(font: Key?) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleScope.kt
@@ -4,6 +4,7 @@ import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
 import io.github.lmliam.kotventure.core.event.ClickScope
 import io.github.lmliam.kotventure.core.event.HoverScope
 import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.format.ShadowColor
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.format.TextDecoration.State
@@ -19,6 +20,22 @@ public interface StyleScope :
      * Applies [color] to the style being configured, or clears the color when [color] is null.
      */
     public fun color(color: TextColor?)
+
+    /**
+     * Applies [color] as the shadow color of the style being configured, or clears it when [color] is null.
+     */
+    public fun shadow(color: ShadowColor?)
+
+    /**
+     * Applies [color] as a shadow color with [alpha] opacity, where [alpha] is in the `0..255` range and defaults to
+     * fully opaque.
+     */
+    public fun shadow(
+        color: TextColor,
+        alpha: Int = 0xFF,
+    ) {
+        shadow(ShadowColor.shadowColor(color, alpha))
+    }
 
     /**
      * Applies [font] to the style being configured, or clears the font when [font] is null.

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentDslTest.kt
@@ -19,6 +19,7 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.`object`.ObjectContents
+import java.util.UUID
 
 class ObjectComponentDslTest :
     StringSpec(
@@ -38,6 +39,37 @@ class ObjectComponentDslTest :
                 val contents = sprite(atlas, spriteKey)
 
                 contents shouldBe ObjectContents.sprite(atlas, spriteKey)
+            }
+
+            "builds player-head object contents from a name uuid or texture" {
+                val texture = key("minecraft", "entity/player/wide/steve")
+                val id = UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25")
+
+                head("Steve") shouldBe ObjectContents.playerHead("Steve")
+                head(id) shouldBe ObjectContents.playerHead(id)
+                head(texture) shouldBe ObjectContents.playerHead().texture(texture).build()
+            }
+
+            "toggles the player-head hat layer" {
+                head("Steve", hat = false) shouldBe
+                    ObjectContents
+                    .playerHead()
+                    .name("Steve")
+                    .hat(false)
+                    .build()
+            }
+
+            "builds a player-head object component with fallback" {
+                val component =
+                    display(head("Steve")) {
+                        fallback {
+                            text("[Steve]")
+                        }
+                    }.shouldBeObjectComponent()
+
+                component shouldHaveObjectContents head("Steve")
+                val fallback = checkNotNull(component.fallback())
+                fallback shouldContainText "[Steve]"
             }
 
             "builds an object component with sprite contents" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/style/StyleDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/style/StyleDslTest.kt
@@ -7,13 +7,16 @@ import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
 import io.github.lmliam.kotventure.test.text.shouldHaveFont
 import io.github.lmliam.kotventure.test.text.shouldHaveInsertion
+import io.github.lmliam.kotventure.test.text.shouldHaveShadowColor
 import io.github.lmliam.kotventure.test.text.shouldNotHaveColor
 import io.github.lmliam.kotventure.test.text.shouldNotHaveFont
 import io.github.lmliam.kotventure.test.text.shouldNotHaveInsertion
+import io.github.lmliam.kotventure.test.text.shouldNotHaveShadowColor
 import io.kotest.core.spec.style.StringSpec
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.ShadowColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.format.TextDecoration.State
@@ -147,6 +150,53 @@ class StyleDslTest :
                 child.shouldHaveDecoration(TextDecoration.UNDERLINED, State.NOT_SET)
                 child.shouldHaveDecoration(TextDecoration.STRIKETHROUGH, State.FALSE)
                 child.shouldHaveDecoration(TextDecoration.OBFUSCATED, State.NOT_SET)
+            }
+
+            "sets a raw shadow color on a reusable style and a component shortcut" {
+                val shadow = ShadowColor.shadowColor(0xFF112233.toInt())
+
+                val styled = Component.text("Spawn").style(style { shadow(shadow) })
+                val component =
+                    component {
+                        text("Spawn") {
+                            shadow(shadow)
+                        }
+                    }
+
+                styled shouldHaveShadowColor shadow
+                component.childAt(0) shouldHaveShadowColor shadow
+            }
+
+            "derives a shadow color from a text color and optional alpha" {
+                val opaque =
+                    component {
+                        text("Opaque") {
+                            shadow(NamedTextColor.BLACK)
+                        }
+                    }
+                val translucent =
+                    component {
+                        text("Translucent") {
+                            shadow(NamedTextColor.BLACK, alpha = 0x80)
+                        }
+                    }
+
+                opaque.childAt(0) shouldHaveShadowColor ShadowColor.shadowColor(NamedTextColor.BLACK, 0xFF)
+                translucent.childAt(0) shouldHaveShadowColor ShadowColor.shadowColor(NamedTextColor.BLACK, 0x80)
+            }
+
+            "clears the shadow color when null is provided" {
+                val base = Style.style().shadowColor(ShadowColor.shadowColor(0xFF112233.toInt())).build()
+
+                val component =
+                    component {
+                        style(base)
+                        style {
+                            shadow(null)
+                        }
+                    }
+
+                component.shouldNotHaveShadowColor()
             }
 
             "can clear nullable color font and insertion from an existing component style" {

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/text/ComponentMatchers.kt
@@ -18,6 +18,7 @@ import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.TranslatableComponent
 import net.kyori.adventure.text.TranslationArgument
 import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.format.ShadowColor
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
@@ -54,6 +55,22 @@ public infix fun Component.shouldHaveColor(expected: TextColor): Component =
 public fun Component.shouldNotHaveColor(): Component =
     apply {
         this should haveNoColor()
+    }
+
+/**
+ * Asserts that this component has [expected] as its root shadow color.
+ */
+public infix fun Component.shouldHaveShadowColor(expected: ShadowColor): Component =
+    apply {
+        this should haveShadowColor(expected)
+    }
+
+/**
+ * Asserts that this component has no root shadow color.
+ */
+public fun Component.shouldNotHaveShadowColor(): Component =
+    apply {
+        this should haveNoShadowColor()
     }
 
 /**
@@ -452,6 +469,26 @@ private fun haveNoColor(): Matcher<Component> =
             actual == null,
             { "Expected component color to be absent, but was <$actual>." },
             { "Expected component color to be present." },
+        )
+    }
+
+private fun haveShadowColor(expected: ShadowColor): Matcher<Component> =
+    Matcher { value ->
+        val actual = value.style().shadowColor()
+        MatcherResult(
+            actual == expected,
+            { "Expected component shadow color <$expected>, but was <$actual>." },
+            { "Expected component shadow color not to be <$expected>." },
+        )
+    }
+
+private fun haveNoShadowColor(): Matcher<Component> =
+    Matcher { value ->
+        val actual = value.style().shadowColor()
+        MatcherResult(
+            actual == null,
+            { "Expected component shadow color to be absent, but was <$actual>." },
+            { "Expected component shadow color to be present." },
         )
     }
 


### PR DESCRIPTION
## Summary

Adds the two core DSL surfaces that were missing for shadow colours and player heads:

- **`shadow(...)`** on `StyleScope` and `ComponentScope` — a raw `ShadowColor` (nullable on the style scope, to clear) plus a `TextColor` + optional `alpha` convenience, wired through `StyleBuilder` / `ComponentBuilder`. Mirrors how `color(...)` is exposed.
- **`head(...)`** object-contents factories in `…core.objectcomponent` alongside `sprite(...)` — `head(name)`, `head(id)`, `head(texture)`, each with a hat-layer toggle, returning Adventure `PlayerHeadObjectContents` for `display(...)`.

## Related Issues

Closes #157
Closes #158

## DSL Impact

```kotlin
text("Spawn") {
    color(NamedTextColor.GOLD)
    shadow(NamedTextColor.BLACK)                 // shadow from a text colour (opaque)
    shadow(NamedTextColor.BLACK, alpha = 0x80)   // explicit alpha
    shadow(ShadowColor.shadowColor(0x80000000.toInt())) // raw ARGB / clear with null on a style block
}

display(head("Steve")) { fallback { text("[Steve]") } }
display(head(UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25")))
display(head(key("minecraft", "entity/player/wide/steve")))   // skin texture
```

## Rationale

`Style` carries a shadow colour (MC 1.21.4) and `ObjectContents` a player head (MC 1.21.9), and MiniMessage produces both from `<shadow:…>` / `<head:…>`, but the DSL had no way to express either. These are the surfaces the MiniMessage→DSL converter needs to represent those tags without rejecting them.

**Sequencing note:** this PR is intentionally **core-only** and based on `master`. The converter consumption (lift the `<shadow>` / `<head>` rejections and emit `shadow(...)` / `display(head(...))`) lives in slice 4 (#148, PR #156), whose converter is not on `master` yet — `master`'s converter is at slice 2 and does not process object or shadow output at all. Once this merges, slice 4 rebases onto it and flips those rejections to emissions. Splitting it this way lets the surfaces land first, as requested.

## Testing

- `StyleDslTest`: raw shadow on a reusable `style { }` and the component `shadow(...)` shortcut; `TextColor` + alpha derivation (opaque and `0x80`); clearing with `shadow(null)`.
- `ObjectComponentDslTest`: `head(name | id | texture)` build the expected Adventure contents; hat toggle; `display(head(...)) { fallback { … } }`.
- New `shouldHaveShadowColor` / `shouldNotHaveShadowColor` matchers in the `test` toolkit.
- `./gradlew build` green (compile + Kotest + ktlint + spotless).

## Checklist

- [x] Linked related issue
- [x] Updated relevant `/docs` pages (`docs/DESIGN.md` canonical surface; CHANGELOG is release-please-owned)
- [x] Verified examples build and run (`./gradlew build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
