### PR TITLE
feat(serializer): complete serializer extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,8 @@ once it reaches `1.0.0`. During pre-alpha (`0.0.x`), breaking changes may land i
   matchers.
 - Hover event DSL support for typed text, item data component, and entity payloads, including reusable hover factories,
   clearing/prebuilt interop, MiniMessage round-trip coverage, and hover-event component matchers.
+- Serializer helpers for legacy ampersand, legacy section, JSON, plain text, and MiniMessage round-trips through
+  `kotventure-serializer`, including matching `String` parsing extensions.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ callers opt into concrete Adventure serializers:
 ```kotlin
 val legacy = message.toLegacy()      // LegacyComponentSerializer.legacyAmpersand()
 val section = message.toSection()    // LegacyComponentSerializer.legacySection()
-val json = message.toJson()          // GsonComponentSerializer.gson()
+val json = message.toJson()          // GsonComponentSerializer with JSONOptions.compatibility()
 val plain = message.toPlain()        // PlainTextComponentSerializer.plainText()
 val mini = message.toMini()          // MiniMessage.miniMessage()
 

--- a/README.md
+++ b/README.md
@@ -497,11 +497,11 @@ val json = message.toJson()          // GsonComponentSerializer with JSONOptions
 val plain = message.toPlain()        // PlainTextComponentSerializer.plainText()
 val mini = message.toMini()          // MiniMessage.miniMessage()
 
-val fromLegacy = "&aHello".legacy()
-val fromSection = "\u00a7bHello".section()
-val fromJson = json.fromJson()
-val fromPlain = "Hello".plainText()
-val fromMini = "<red>Hello".mini()
+val fromLegacy = "&aHello".asLegacyComponent()
+val fromSection = "\u00a7bHello".asSectionComponent()
+val fromJson = json.asJsonComponent()
+val fromPlain = "Hello".asPlainComponent()
+val fromMini = "<red>Hello".asMiniComponent()
 ```
 
 `kotventure-test` starts the testing toolkit with structural component matchers such as `shouldContainText`,

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The current build enables the first lazy modules:
 - `kotventure-minimessage` — `mini(...)` parsing plus typed placeholders via `placeholder<T>(name)` and
   `resolve(placeholder, value)`, alongside the `parsed`, `unparsed`, and `component` resolvers; typed reusable
   templates via `MiniTemplate` with compile-checked `bind(placeholder, value)` at the call site
-- `kotventure-serializer` — `Component.toMiniMessage()` and `Component.toPlainText()` wrappers around Adventure
+- `kotventure-serializer` — `Component` and `String` helpers for Adventure legacy, JSON, plain text, and MiniMessage
   serializers
 - `kotventure-test` — Kotest component matchers consumed test-scoped by library modules
 - `kotventure-bom` — a Gradle/Maven BOM aligning enabled Kotventure artifacts and Adventure 5.1.1 dependencies
@@ -491,8 +491,17 @@ Serializer helpers live in `kotventure-serializer` so `kotventure-core` can stay
 callers opt into concrete Adventure serializers:
 
 ```kotlin
-val mini = message.toMiniMessage()
-val plain = message.toPlainText()
+val legacy = message.toLegacy()      // LegacyComponentSerializer.legacyAmpersand()
+val section = message.toSection()    // LegacyComponentSerializer.legacySection()
+val json = message.toJson()          // GsonComponentSerializer.gson()
+val plain = message.toPlain()        // PlainTextComponentSerializer.plainText()
+val mini = message.toMini()          // MiniMessage.miniMessage()
+
+val fromLegacy = "&aHello".legacy()
+val fromSection = "\u00a7bHello".section()
+val fromJson = json.fromJson()
+val fromPlain = "Hello".plain()
+val fromMini = "<red>Hello".mini()
 ```
 
 `kotventure-test` starts the testing toolkit with structural component matchers such as `shouldContainText`,

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ val mini = message.toMini()          // MiniMessage.miniMessage()
 val fromLegacy = "&aHello".legacy()
 val fromSection = "\u00a7bHello".section()
 val fromJson = json.fromJson()
-val fromPlain = "Hello".plain()
+val fromPlain = "Hello".plainText()
 val fromMini = "<red>Hello".mini()
 ```
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -162,8 +162,8 @@ component shouldHaveColor AQUA
 component shouldContainText "world"
 component.shouldMatchSnapshot()
 println(component.toAnsi())
-println(component.toMiniMessage())
-println(component.toPlainText())
+println(component.toMini())
+println(component.toPlain())
 ```
 
 ## 6. MiniMessage strategy

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,11 +13,14 @@ configurations {
 ext.kotventureDependencies = [
         "adventure-api"                  : catalog.findLibrary('adventure-api').get(),
         "adventure-bom"                  : catalog.findLibrary('adventure-bom').get(),
-        "adventure-text-minimessage"     : catalog.findLibrary('adventure-text-minimessage').get(),
-        "adventure-text-serializer-plain": catalog.findLibrary('adventure-text-serializer-plain').get(),
-        "kctfork-core"                   : catalog.findLibrary('kctfork-core').get(),
-        "kotest-assertions-core"         : catalog.findLibrary('kotest-assertions-core').get(),
-        "kotest-runner-junit5"           : catalog.findLibrary('kotest-runner-junit5').get()
+        "adventure-text-minimessage"              : catalog.findLibrary('adventure-text-minimessage').get(),
+        "adventure-text-serializer-gson"          : catalog.findLibrary('adventure-text-serializer-gson').get(),
+        "adventure-text-serializer-json-legacy-impl": catalog.findLibrary('adventure-text-serializer-json-legacy-impl').get(),
+        "adventure-text-serializer-legacy"        : catalog.findLibrary('adventure-text-serializer-legacy').get(),
+        "adventure-text-serializer-plain"         : catalog.findLibrary('adventure-text-serializer-plain').get(),
+        "kctfork-core"                            : catalog.findLibrary('kctfork-core').get(),
+        "kotest-assertions-core"                  : catalog.findLibrary('kotest-assertions-core').get(),
+        "kotest-runner-junit5"                    : catalog.findLibrary('kotest-runner-junit5').get()
 ]
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,9 @@ spotlessKtlint = "1.7.0"
 adventure-api = { module = "net.kyori:adventure-api", version.ref = "adventureApi" }
 adventure-bom = { module = "net.kyori:adventure-bom", version.ref = "adventureApi" }
 adventure-text-minimessage = { module = "net.kyori:adventure-text-minimessage", version.ref = "adventureApi" }
+adventure-text-serializer-gson = { module = "net.kyori:adventure-text-serializer-gson", version.ref = "adventureApi" }
+adventure-text-serializer-json-legacy-impl = { module = "net.kyori:adventure-text-serializer-json-legacy-impl", version.ref = "adventureApi" }
+adventure-text-serializer-legacy = { module = "net.kyori:adventure-text-serializer-legacy", version.ref = "adventureApi" }
 adventure-text-serializer-plain = { module = "net.kyori:adventure-text-serializer-plain", version.ref = "adventureApi" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 kctfork-core = { module = "dev.zacsweers.kctfork:core", version.ref = "kctfork" }

--- a/modules/bom/build.gradle
+++ b/modules/bom/build.gradle
@@ -17,6 +17,9 @@ dependencies {
 
         api libs.adventure.api
         api libs.adventure.text.minimessage
+        api libs.adventure.text.serializer.gson
+        api libs.adventure.text.serializer.json.legacy.impl
+        api libs.adventure.text.serializer.legacy
         api libs.adventure.text.serializer.plain
     }
 }

--- a/modules/serializer/build.gradle
+++ b/modules/serializer/build.gradle
@@ -7,6 +7,9 @@ dependencies {
     api kotventureDependencies."adventure-api"
 
     implementation kotventureDependencies."adventure-text-minimessage"
+    implementation kotventureDependencies."adventure-text-serializer-gson"
+    implementation kotventureDependencies."adventure-text-serializer-json-legacy-impl"
+    implementation kotventureDependencies."adventure-text-serializer-legacy"
     implementation kotventureDependencies."adventure-text-serializer-plain"
 
     testImplementation project(':core')

--- a/modules/serializer/src/main/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensions.kt
+++ b/modules/serializer/src/main/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensions.kt
@@ -68,7 +68,7 @@ public fun Component.toPlain(): String = PlainTextComponentSerializer.plainText(
 /**
  * Deserializes this plain text string to an Adventure text component.
  */
-public fun String.plain(): Component = PlainTextComponentSerializer.plainText().deserialize(this)
+public fun String.plainText(): Component = PlainTextComponentSerializer.plainText().deserialize(this)
 
 /**
  * Serializes this component to plain text using Adventure's default plain text serializer.

--- a/modules/serializer/src/main/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensions.kt
+++ b/modules/serializer/src/main/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensions.kt
@@ -3,8 +3,17 @@ package io.github.lmliam.kotventure.serializer
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import net.kyori.adventure.text.serializer.json.JSONOptions
+import net.kyori.adventure.text.serializer.json.legacyimpl.NBTLegacyHoverEventSerializer
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
+
+private val jsonSerializer: GsonComponentSerializer =
+    GsonComponentSerializer
+        .builder()
+        .options(JSONOptions.compatibility())
+        .legacyHoverEventSerializer(NBTLegacyHoverEventSerializer.get())
+        .build()
 
 /**
  * Serializes this component to legacy ampersand (`&`) formatting.
@@ -29,12 +38,12 @@ public fun String.section(): Component = LegacyComponentSerializer.legacySection
 /**
  * Serializes this component to Adventure's JSON component format.
  */
-public fun Component.toJson(): String = GsonComponentSerializer.gson().serialize(this)
+public fun Component.toJson(): String = jsonSerializer.serialize(this)
 
 /**
  * Deserializes this Adventure JSON component string to an Adventure component.
  */
-public fun String.fromJson(): Component = GsonComponentSerializer.gson().deserialize(this)
+public fun String.fromJson(): Component = jsonSerializer.deserialize(this)
 
 /**
  * Serializes this component to MiniMessage markup using Adventure's default MiniMessage serializer.

--- a/modules/serializer/src/main/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensions.kt
+++ b/modules/serializer/src/main/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensions.kt
@@ -2,14 +2,66 @@ package io.github.lmliam.kotventure.serializer
 
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
+
+/**
+ * Serializes this component to legacy ampersand (`&`) formatting.
+ */
+public fun Component.toLegacy(): String = LegacyComponentSerializer.legacyAmpersand().serialize(this)
+
+/**
+ * Deserializes this legacy ampersand (`&`) string to an Adventure component.
+ */
+public fun String.legacy(): Component = LegacyComponentSerializer.legacyAmpersand().deserialize(this)
+
+/**
+ * Serializes this component to legacy section-sign formatting.
+ */
+public fun Component.toSection(): String = LegacyComponentSerializer.legacySection().serialize(this)
+
+/**
+ * Deserializes this legacy section-sign string to an Adventure component.
+ */
+public fun String.section(): Component = LegacyComponentSerializer.legacySection().deserialize(this)
+
+/**
+ * Serializes this component to Adventure's JSON component format.
+ */
+public fun Component.toJson(): String = GsonComponentSerializer.gson().serialize(this)
+
+/**
+ * Deserializes this Adventure JSON component string to an Adventure component.
+ */
+public fun String.fromJson(): Component = GsonComponentSerializer.gson().deserialize(this)
 
 /**
  * Serializes this component to MiniMessage markup using Adventure's default MiniMessage serializer.
  */
-public fun Component.toMiniMessage(): String = MiniMessage.miniMessage().serialize(this)
+public fun Component.toMini(): String = MiniMessage.miniMessage().serialize(this)
+
+/**
+ * Deserializes this MiniMessage string to an Adventure component.
+ */
+public fun String.mini(): Component = MiniMessage.miniMessage().deserialize(this)
+
+/**
+ * Serializes this component to MiniMessage markup using Adventure's default MiniMessage serializer.
+ */
+public fun Component.toMiniMessage(): String = toMini()
 
 /**
  * Serializes this component to plain text using Adventure's default plain text serializer.
  */
-public fun Component.toPlainText(): String = PlainTextComponentSerializer.plainText().serialize(this)
+public fun Component.toPlain(): String = PlainTextComponentSerializer.plainText().serialize(this)
+
+/**
+ * Deserializes this plain text string to an Adventure text component.
+ */
+public fun String.plain(): Component = PlainTextComponentSerializer.plainText().deserialize(this)
+
+/**
+ * Serializes this component to plain text using Adventure's default plain text serializer.
+ */
+public fun Component.toPlainText(): String = toPlain()

--- a/modules/serializer/src/main/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensions.kt
+++ b/modules/serializer/src/main/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensions.kt
@@ -23,7 +23,7 @@ public fun Component.toLegacy(): String = LegacyComponentSerializer.legacyAmpers
 /**
  * Deserializes this legacy ampersand (`&`) string to an Adventure component.
  */
-public fun String.legacy(): Component = LegacyComponentSerializer.legacyAmpersand().deserialize(this)
+public fun String.asLegacyComponent(): Component = LegacyComponentSerializer.legacyAmpersand().deserialize(this)
 
 /**
  * Serializes this component to legacy section-sign formatting.
@@ -33,7 +33,7 @@ public fun Component.toSection(): String = LegacyComponentSerializer.legacySecti
 /**
  * Deserializes this legacy section-sign string to an Adventure component.
  */
-public fun String.section(): Component = LegacyComponentSerializer.legacySection().deserialize(this)
+public fun String.asSectionComponent(): Component = LegacyComponentSerializer.legacySection().deserialize(this)
 
 /**
  * Serializes this component to Adventure's JSON component format.
@@ -43,7 +43,7 @@ public fun Component.toJson(): String = jsonSerializer.serialize(this)
 /**
  * Deserializes this Adventure JSON component string to an Adventure component.
  */
-public fun String.fromJson(): Component = jsonSerializer.deserialize(this)
+public fun String.asJsonComponent(): Component = jsonSerializer.deserialize(this)
 
 /**
  * Serializes this component to MiniMessage markup using Adventure's default MiniMessage serializer.
@@ -53,12 +53,7 @@ public fun Component.toMini(): String = MiniMessage.miniMessage().serialize(this
 /**
  * Deserializes this MiniMessage string to an Adventure component.
  */
-public fun String.mini(): Component = MiniMessage.miniMessage().deserialize(this)
-
-/**
- * Serializes this component to MiniMessage markup using Adventure's default MiniMessage serializer.
- */
-public fun Component.toMiniMessage(): String = toMini()
+public fun String.asMiniComponent(): Component = MiniMessage.miniMessage().deserialize(this)
 
 /**
  * Serializes this component to plain text using Adventure's default plain text serializer.
@@ -68,9 +63,4 @@ public fun Component.toPlain(): String = PlainTextComponentSerializer.plainText(
 /**
  * Deserializes this plain text string to an Adventure text component.
  */
-public fun String.plainText(): Component = PlainTextComponentSerializer.plainText().deserialize(this)
-
-/**
- * Serializes this component to plain text using Adventure's default plain text serializer.
- */
-public fun Component.toPlainText(): String = toPlain()
+public fun String.asPlainComponent(): Component = PlainTextComponentSerializer.plainText().deserialize(this)

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -88,6 +88,28 @@ class ComponentSerializerExtensionsTest :
                 roundTripped shouldHaveHoverText Component.text("Teleport")
             }
 
+            "deserializes legacy item hover JSON strings" {
+                val legacyJson =
+                    """
+                    {
+                      "text": "Hover",
+                      "hoverEvent": {
+                        "action": "show_item",
+                        "id": "minecraft:diamond_sword",
+                        "Count": 1
+                      }
+                    }
+                    """.trimIndent()
+                val item =
+                    HoverEvent.ShowItem.showItem(
+                        key("minecraft", "diamond_sword"),
+                        1,
+                        null as BinaryTagHolder?,
+                    )
+
+                legacyJson.fromJson() shouldHaveHoverItem item
+            }
+
             "serializes unstyled component text to MiniMessage text" {
                 val message =
                     component {

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -9,16 +9,19 @@ import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldBeObjectComponent
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveClickEvent
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldHaveHoverEntity
 import io.github.lmliam.kotventure.test.text.shouldHaveHoverItem
 import io.github.lmliam.kotventure.test.text.shouldHaveHoverText
 import io.github.lmliam.kotventure.test.text.shouldHaveObjectContents
+import io.github.lmliam.kotventure.test.text.shouldNotHaveColor
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.nbt.api.BinaryTagHolder
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.event.DataComponentValue
 import net.kyori.adventure.text.event.HoverEvent
 import net.kyori.adventure.text.format.NamedTextColor
@@ -43,6 +46,46 @@ class ComponentSerializerExtensionsTest :
                     }
 
                 message.toPlainText() shouldBe "Hello world"
+                message.toPlain() shouldBe "Hello world"
+            }
+
+            "deserializes plain text strings" {
+                val message = "Hello world".plain()
+
+                message shouldContainText "Hello world"
+                message.shouldNotHaveColor()
+            }
+
+            "round-trips legacy ampersand strings" {
+                val message = "&aHello".legacy()
+
+                message shouldContainText "Hello"
+                message shouldHaveColor NamedTextColor.GREEN
+                message.toLegacy() shouldBe "&aHello"
+            }
+
+            "round-trips legacy section strings" {
+                val message = "\u00a7bHello".section()
+
+                message shouldContainText "Hello"
+                message shouldHaveColor NamedTextColor.AQUA
+                message.toSection() shouldBe "\u00a7bHello"
+            }
+
+            "round-trips JSON strings with color and events" {
+                val message =
+                    Component
+                        .text("Portal", NamedTextColor.LIGHT_PURPLE)
+                        .clickEvent(ClickEvent.runCommand("/spawn"))
+                        .hoverEvent(Component.text("Teleport"))
+
+                val json = message.toJson()
+                val roundTripped = json.fromJson()
+
+                roundTripped shouldContainText "Portal"
+                roundTripped shouldHaveColor NamedTextColor.LIGHT_PURPLE
+                roundTripped shouldHaveClickEvent ClickEvent.runCommand("/spawn")
+                roundTripped shouldHaveHoverText Component.text("Teleport")
             }
 
             "serializes unstyled component text to MiniMessage text" {
@@ -52,6 +95,14 @@ class ComponentSerializerExtensionsTest :
                     }
 
                 message.toMiniMessage() shouldBe "Hello"
+                message.toMini() shouldBe "Hello"
+            }
+
+            "deserializes MiniMessage strings" {
+                val message = "<red>Hello".mini()
+
+                message shouldContainText "Hello"
+                message shouldHaveColor NamedTextColor.RED
             }
 
             "round-trips MiniMessage output through Adventure" {

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -50,7 +50,7 @@ class ComponentSerializerExtensionsTest :
             }
 
             "deserializes plain text strings" {
-                val message = "Hello world".plain()
+                val message = "Hello world".plainText()
 
                 message shouldContainText "Hello world"
                 message.shouldNotHaveColor()

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -75,7 +75,7 @@ class ComponentSerializerExtensionsTest :
             "round-trips JSON strings with color and events" {
                 val message =
                     Component
-                        .text("Portal", NamedTextColor.LIGHT_PURPLE)
+                        .text("Portal", hex("#123ABC"))
                         .clickEvent(ClickEvent.runCommand("/spawn"))
                         .hoverEvent(Component.text("Teleport"))
 
@@ -83,7 +83,7 @@ class ComponentSerializerExtensionsTest :
                 val roundTripped = json.fromJson()
 
                 roundTripped shouldContainText "Portal"
-                roundTripped shouldHaveColor NamedTextColor.LIGHT_PURPLE
+                roundTripped shouldHaveColor hex("#123ABC")
                 roundTripped shouldHaveClickEvent ClickEvent.runCommand("/spawn")
                 roundTripped shouldHaveHoverText Component.text("Teleport")
             }

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -45,19 +45,18 @@ class ComponentSerializerExtensionsTest :
                         }
                     }
 
-                message.toPlainText() shouldBe "Hello world"
                 message.toPlain() shouldBe "Hello world"
             }
 
             "deserializes plain text strings" {
-                val message = "Hello world".plainText()
+                val message = "Hello world".asPlainComponent()
 
                 message shouldContainText "Hello world"
                 message.shouldNotHaveColor()
             }
 
             "round-trips legacy ampersand strings" {
-                val message = "&aHello".legacy()
+                val message = "&aHello".asLegacyComponent()
 
                 message shouldContainText "Hello"
                 message shouldHaveColor NamedTextColor.GREEN
@@ -65,7 +64,7 @@ class ComponentSerializerExtensionsTest :
             }
 
             "round-trips legacy section strings" {
-                val message = "\u00a7bHello".section()
+                val message = "\u00a7bHello".asSectionComponent()
 
                 message shouldContainText "Hello"
                 message shouldHaveColor NamedTextColor.AQUA
@@ -80,7 +79,7 @@ class ComponentSerializerExtensionsTest :
                         .hoverEvent(Component.text("Teleport"))
 
                 val json = message.toJson()
-                val roundTripped = json.fromJson()
+                val roundTripped = json.asJsonComponent()
 
                 roundTripped shouldContainText "Portal"
                 roundTripped shouldHaveColor hex("#123ABC")
@@ -107,7 +106,7 @@ class ComponentSerializerExtensionsTest :
                         null as BinaryTagHolder?,
                     )
 
-                legacyJson.fromJson() shouldHaveHoverItem item
+                legacyJson.asJsonComponent() shouldHaveHoverItem item
             }
 
             "serializes unstyled component text to MiniMessage text" {
@@ -116,12 +115,11 @@ class ComponentSerializerExtensionsTest :
                         text("Hello")
                     }
 
-                message.toMiniMessage() shouldBe "Hello"
                 message.toMini() shouldBe "Hello"
             }
 
             "deserializes MiniMessage strings" {
-                val message = "<red>Hello".mini()
+                val message = "<red>Hello".asMiniComponent()
 
                 message shouldContainText "Hello"
                 message shouldHaveColor NamedTextColor.RED
@@ -135,7 +133,7 @@ class ComponentSerializerExtensionsTest :
                         }
                     }
 
-                val serialized = message.toMiniMessage()
+                val serialized = message.toMini()
                 serialized shouldBe "<red>Alert"
 
                 val roundTripped = MiniMessage.miniMessage().deserialize(serialized)
@@ -152,7 +150,7 @@ class ComponentSerializerExtensionsTest :
                         }
                     }
 
-                val serialized = message.toMiniMessage()
+                val serialized = message.toMini()
                 serialized shouldBe "<#123ABC>Brand"
 
                 val roundTripped = MiniMessage.miniMessage().deserialize(serialized)
@@ -169,7 +167,7 @@ class ComponentSerializerExtensionsTest :
                         }
                     }
 
-                val serialized = message.toMiniMessage()
+                val serialized = message.toMini()
                 serialized shouldBe "<red>a</red><gold>c</gold><aqua>e"
 
                 val roundTripped = MiniMessage.miniMessage().deserialize(serialized)
@@ -185,14 +183,14 @@ class ComponentSerializerExtensionsTest :
                 val contents = sprite(key("minecraft", "block/stone"))
                 val message = display(contents)
 
-                message.toPlainText() shouldBe "[block/stone]"
+                message.toPlain() shouldBe "[block/stone]"
             }
 
             "round-trips sprite object components through MiniMessage" {
                 val contents = sprite(key("minecraft", "block/stone"))
                 val message = display(contents)
 
-                val serialized = message.toMiniMessage()
+                val serialized = message.toMini()
                 serialized shouldBe "<sprite:'minecraft:block/stone'>"
 
                 val roundTripped = MiniMessage.miniMessage().deserialize(serialized).shouldBeObjectComponent()
@@ -210,7 +208,7 @@ class ComponentSerializerExtensionsTest :
                         }
                     }
 
-                val roundTripped = MiniMessage.miniMessage().deserialize(message.toMiniMessage())
+                val roundTripped = MiniMessage.miniMessage().deserialize(message.toMini())
 
                 roundTripped shouldHaveHoverText Component.text("Tooltip")
             }
@@ -233,7 +231,7 @@ class ComponentSerializerExtensionsTest :
                         }
                     }
 
-                val roundTripped = MiniMessage.miniMessage().deserialize(message.toMiniMessage())
+                val roundTripped = MiniMessage.miniMessage().deserialize(message.toMini())
 
                 roundTripped shouldHaveHoverItem item
             }
@@ -260,7 +258,7 @@ class ComponentSerializerExtensionsTest :
                         }
                     }
 
-                val roundTripped = MiniMessage.miniMessage().deserialize(message.toMiniMessage())
+                val roundTripped = MiniMessage.miniMessage().deserialize(message.toMini())
 
                 roundTripped shouldHaveHoverEntity entity
             }


### PR DESCRIPTION
## Summary

Completes the serializer extension surface with legacy ampersand, legacy section, JSON, plain text, and MiniMessage component/string helpers.

## Related Issues

Closes #30

## DSL Impact

Adds concise `Component` serializers: `toLegacy()`, `toSection()`, `toJson()`, `toPlain()`, and `toMini()`.

Adds explicit `String` parsers: `asLegacyComponent()`, `asSectionComponent()`, `asJsonComponent()`, `asPlainComponent()`, and `asMiniComponent()`.

## Rationale

Plugin authors can round-trip Adventure components through the common text formats without pulling serializer dependencies into `kotventure-core`.

## Testing

- `./gradlew :serializer:test`
- `./gradlew ktlintFormat build`

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run
