### PR TITLE
feat(core): add component utility extensions

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -157,6 +157,13 @@ player.message(Welcome { player = name; count = 3 })
 // ── Typed catalog (KSP from messages.yml) ──────────────────────
 Messages.welcome(player = name, count = 3)   // generated, validated placeholders
 
+// ── Normalising & traversing ───────────────────────────────────
+val tidy = msg.compacted()                   // merge adjacent same-style runs, drop empty wrappers
+msg.count()                                  // nodes in the whole tree (root + descendants)
+msg.forEach { node -> log(node) }            // depth-first, pre-order visit
+msg.asSequence()                             // lazy Sequence<Component> → full stdlib over the tree
+    .filterIsInstance<ObjectComponent>()     // e.g. every object component, object components preserved
+
 // ── Testing / preview ──────────────────────────────────────────
 component shouldHaveColor AQUA
 component shouldContainText "world"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -162,7 +162,7 @@ val tidy = msg.compacted()                   // merge adjacent same-style runs, 
 msg.count()                                  // nodes in the whole tree (root + descendants)
 msg.forEach { node -> log(node) }            // depth-first, pre-order visit
 msg.asSequence()                             // lazy Sequence<Component> → full stdlib over the tree
-    .filterIsInstance<ObjectComponent>()     // e.g. every object component, object components preserved
+    .filterIsInstance<ObjectComponent>()     // object components are preserved, not dropped
 
 // ── Testing / preview ──────────────────────────────────────────
 component shouldHaveColor AQUA

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectContentsDsl.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectContentsDsl.kt
@@ -27,10 +27,10 @@ public fun head(
     hat: Boolean = PlayerHeadObjectContents.DEFAULT_HAT,
 ): PlayerHeadObjectContents =
     ObjectContents
-    .playerHead()
-    .name(name)
-    .hat(hat)
-    .build()
+        .playerHead()
+        .name(name)
+        .hat(hat)
+        .build()
 
 /**
  * Builds player-head object contents for the player with UUID [id], rendering the hat layer when [hat] is `true`.
@@ -40,10 +40,10 @@ public fun head(
     hat: Boolean = PlayerHeadObjectContents.DEFAULT_HAT,
 ): PlayerHeadObjectContents =
     ObjectContents
-    .playerHead()
-    .id(id)
-    .hat(hat)
-    .build()
+        .playerHead()
+        .id(id)
+        .hat(hat)
+        .build()
 
 /**
  * Builds player-head object contents drawn from the skin [texture] key, rendering the hat layer when [hat] is `true`.
@@ -53,7 +53,7 @@ public fun head(
     hat: Boolean = PlayerHeadObjectContents.DEFAULT_HAT,
 ): PlayerHeadObjectContents =
     ObjectContents
-    .playerHead()
-    .texture(texture)
-    .hat(hat)
-    .build()
+        .playerHead()
+        .texture(texture)
+        .hat(hat)
+        .build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Compacted.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Compacted.kt
@@ -10,8 +10,8 @@ import net.kyori.adventure.text.Component
  * serialising, snapshotting, or comparing components so that structurally different but visually identical trees
  * normalise to the same shape.
  *
- * This is a thin, past-tense alias of [Component.compact] (mirroring [styled][io.github.lmliam.kotventure.core.style.styled])
- * for call-site consistency with the rest of the DSL; it is functionally identical, so call [Component.compact]
- * directly if you prefer Adventure's own naming.
+ * This is a thin, past-tense alias of [Component.compact] (mirroring the DSL's `styled` extension) for call-site
+ * consistency with the rest of the DSL; it is functionally identical, so call [Component.compact] directly if you
+ * prefer Adventure's own naming.
  */
 public fun Component.compacted(): Component = compact()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Compacted.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Compacted.kt
@@ -1,0 +1,17 @@
+package io.github.lmliam.kotventure.core.text
+
+import net.kyori.adventure.text.Component
+
+/**
+ * Returns a normalised copy of this component tree, delegating to Adventure's [Component.compact].
+ *
+ * Compaction merges adjacent children that share the same style, pushes redundant parent styling down onto its
+ * children, and drops empty wrapper components — all without changing how the tree renders. Reach for it before
+ * serialising, snapshotting, or comparing components so that structurally different but visually identical trees
+ * normalise to the same shape.
+ *
+ * This is a thin, past-tense alias of [Component.compact] (mirroring [styled][io.github.lmliam.kotventure.core.style.styled])
+ * for call-site consistency with the rest of the DSL; it is functionally identical, so call [Component.compact]
+ * directly if you prefer Adventure's own naming.
+ */
+public fun Component.compacted(): Component = compact()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/ComponentSequence.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/ComponentSequence.kt
@@ -1,0 +1,38 @@
+package io.github.lmliam.kotventure.core.text
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentIteratorType
+
+/**
+ * Returns a lazy depth-first sequence over this component and all of its descendants.
+ *
+ * The sequence yields this component first, then walks each child in declaration order, descending into a child's
+ * own subtree before moving on to its siblings (depth-first, pre-order). It delegates to Adventure's own
+ * [Component.iterable] traversal, so it preserves Adventure's component semantics and child ordering and visits
+ * every node in the tree — including [net.kyori.adventure.text.ObjectComponent]s — rather than silently dropping
+ * any. Translatable arguments and hover contents are not children, so they are not traversed; use
+ * [Component.iterable] directly with the relevant `ComponentIteratorFlag`s if you need them.
+ *
+ * Because the result is a [Sequence], the whole Kotlin standard library is available for traversal and reduction —
+ * `fold`, `map`, `filter`, `filterIsInstance`, `any`, `firstOrNull`, `sumOf`, and so on. Operations are lazy, so
+ * short-circuiting terminals such as [Sequence.any] or [Sequence.firstOrNull] stop walking as soon as they can.
+ */
+public fun Component.asSequence(): Sequence<Component> = iterable(ComponentIteratorType.DEPTH_FIRST).asSequence()
+
+/**
+ * Counts this component and every descendant in its tree.
+ *
+ * A convenience for `asSequence().count()`: it counts all nodes, including this root and every nested child, of
+ * any component type. Use [asSequence] with a predicate (for example `asSequence().count { … }`) to count a subset.
+ */
+public fun Component.count(): Int = asSequence().count()
+
+/**
+ * Applies [action] to this component and every descendant, depth-first and pre-order.
+ *
+ * A convenience for `asSequence().forEach(action)`, intended for side-effecting walks such as logging or
+ * validation. Use [asSequence] directly when you need to transform, filter, or reduce the tree instead.
+ */
+public fun Component.forEach(action: (Component) -> Unit) {
+    asSequence().forEach(action)
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectComponentDslTest.kt
@@ -52,11 +52,11 @@ class ObjectComponentDslTest :
 
             "toggles the player-head hat layer" {
                 head("Steve", hat = false) shouldBe
-                    ObjectContents
-                    .playerHead()
-                    .name("Steve")
-                    .hat(false)
-                    .build()
+                        ObjectContents
+                            .playerHead()
+                            .name("Steve")
+                            .hat(false)
+                            .build()
             }
 
             "builds a player-head object component with fallback" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/CompactedTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/CompactedTest.kt
@@ -1,0 +1,72 @@
+package io.github.lmliam.kotventure.core.text
+
+import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.objectcomponent.display
+import io.github.lmliam.kotventure.core.objectcomponent.sprite
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.ObjectComponent
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+class CompactedTest :
+    StringSpec(
+        {
+            "merges adjacent same-style text while preserving its content" {
+                val message =
+                    component {
+                        text("Hello, ")
+                        text("world")
+                    }
+
+                val compacted = message.compacted()
+
+                compacted.count() shouldBeLessThan message.count()
+                compacted shouldContainText "Hello, world"
+            }
+
+            "preserves styling through compaction" {
+                val message =
+                    component {
+                        text("warn") {
+                            color(NamedTextColor.RED)
+                            bold()
+                        }
+                    }
+
+                val compacted = message.compacted()
+
+                compacted shouldContainText "warn"
+                compacted shouldHaveColor NamedTextColor.RED
+                compacted shouldHaveDecoration TextDecoration.BOLD
+            }
+
+            "handles an empty component gracefully" {
+                val compacted = component {}.compacted()
+
+                compacted.count() shouldBe 1
+                (compacted as TextComponent).content() shouldBe ""
+            }
+
+            "preserves object components rather than dropping them" {
+                val message =
+                    component {
+                        text("Block: ")
+                        display(sprite(key("minecraft", "block/stone"))) {
+                            fallback { text("[stone]") }
+                        }
+                    }
+
+                val compacted = message.compacted()
+
+                compacted shouldContainText "Block: "
+                compacted.asSequence().filterIsInstance<ObjectComponent>().toList() shouldHaveSize 1
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentSequenceTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentSequenceTest.kt
@@ -82,6 +82,22 @@ class ComponentSequenceTest :
                 message.asSequence().filterIsInstance<ObjectComponent>().toList() shouldHaveSize 1
             }
 
+            "asSequence descends into an object component's own children" {
+                val message =
+                    component {
+                        display(sprite(key("minecraft", "block/stone"))) {
+                            text("child-of-object")
+                        }
+                    }
+
+                val nodes = message.asSequence().toList()
+
+                nodes shouldHaveSize 3
+                nodes[0] shouldBe message
+                nodes[1].shouldBeObjectComponent()
+                (nodes[2] as TextComponent).content() shouldBe "child-of-object"
+            }
+
             "asSequence composes with standard-library search operators" {
                 val stone = sprite(key("minecraft", "block/stone"))
                 val message =

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentSequenceTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentSequenceTest.kt
@@ -1,0 +1,166 @@
+package io.github.lmliam.kotventure.core.text
+
+import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.objectcomponent.display
+import io.github.lmliam.kotventure.core.objectcomponent.sprite
+import io.github.lmliam.kotventure.test.text.shouldBeObjectComponent
+import io.github.lmliam.kotventure.test.text.shouldHaveObjectContents
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ObjectComponent
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.TranslatableComponent
+
+class ComponentSequenceTest :
+    StringSpec(
+        {
+            fun Sequence<Component>.textContents(): List<String> =
+                mapNotNull { (it as? TextComponent)?.content()?.takeIf(String::isNotEmpty) }.toList()
+
+            "asSequence yields the root first, then children depth-first in declaration order" {
+                val message =
+                    component {
+                        text("A") {
+                            text("B")
+                            text("C")
+                        }
+                        text("D")
+                    }
+
+                message.asSequence().first() shouldBe message
+                message.asSequence().textContents() shouldContainExactly listOf("A", "B", "C", "D")
+            }
+
+            "asSequence visits a single leaf component exactly once" {
+                val solo = text("solo")
+
+                solo.asSequence().toList() shouldContainExactly listOf(solo)
+            }
+
+            "asSequence visits an empty-content root together with its children" {
+                val message =
+                    component {
+                        text("only-child")
+                    }
+
+                val nodes = message.asSequence().toList()
+
+                nodes shouldHaveSize 2
+                nodes.first() shouldBe message
+                (nodes.first() as TextComponent).content() shouldBe ""
+                message.asSequence().textContents() shouldContainExactly listOf("only-child")
+            }
+
+            "asSequence descends every level of a deeply nested tree" {
+                val message =
+                    component {
+                        text("one") {
+                            text("two") {
+                                text("three") {
+                                    text("four")
+                                }
+                            }
+                        }
+                    }
+
+                message.asSequence().textContents() shouldContainExactly listOf("one", "two", "three", "four")
+            }
+
+            "asSequence preserves object components rather than dropping them" {
+                val stone = sprite(key("minecraft", "block/stone"))
+                val message =
+                    component {
+                        text("Block: ")
+                        display(stone) {
+                            fallback { text("[stone]") }
+                        }
+                    }
+
+                message.asSequence().filterIsInstance<ObjectComponent>().toList() shouldHaveSize 1
+            }
+
+            "asSequence composes with standard-library search operators" {
+                val stone = sprite(key("minecraft", "block/stone"))
+                val message =
+                    component {
+                        display(stone)
+                        text("trailing")
+                    }
+
+                message.asSequence().any { it is ObjectComponent } shouldBe true
+                checkNotNull(message.asSequence().firstOrNull { it is ObjectComponent })
+                    .shouldBeObjectComponent() shouldHaveObjectContents stone
+            }
+
+            "count returns one for a single leaf component" {
+                text("solo").count() shouldBe 1
+            }
+
+            "count includes the root and every nested child of a deep tree" {
+                val message =
+                    component {
+                        text("one") {
+                            text("two") {
+                                text("three")
+                            }
+                        }
+                    }
+
+                message.count() shouldBe 4
+            }
+
+            "count includes the root and every child of a wide tree" {
+                val message =
+                    component {
+                        text("a")
+                        text("b")
+                        text("c")
+                    }
+
+                message.count() shouldBe 4
+            }
+
+            "count tallies text, translatable, and object nodes alike" {
+                val message =
+                    component {
+                        text("hi")
+                        translatable("item.minecraft.diamond") { fallback("Diamond") }
+                        display(sprite(key("minecraft", "block/stone")))
+                    }
+
+                message.count() shouldBe 4
+                message.asSequence().filterIsInstance<TranslatableComponent>().toList() shouldHaveSize 1
+                message.asSequence().filterIsInstance<ObjectComponent>().toList() shouldHaveSize 1
+            }
+
+            "forEach visits every node in the same order as asSequence" {
+                val message =
+                    component {
+                        text("A") {
+                            text("B")
+                        }
+                        display(sprite(key("minecraft", "block/stone")))
+                    }
+
+                val visited = buildList { message.forEach { add(it) } }
+
+                visited shouldContainExactly message.asSequence().toList()
+            }
+
+            "forEach visits object components" {
+                val message =
+                    component {
+                        text("Block: ")
+                        display(sprite(key("minecraft", "block/stone")))
+                    }
+
+                var sawObject = false
+                message.forEach { if (it is ObjectComponent) sawObject = true }
+
+                sawObject shouldBe true
+            }
+        },
+    )

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslLiterals.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslLiterals.kt
@@ -23,11 +23,11 @@ internal fun colorLiteral(color: TextColor): String =
 internal fun shadowColorLiteral(color: ShadowColor): String {
     val argb =
         color
-        .value()
-        .toUInt()
-        .toString(16)
-        .uppercase(Locale.ROOT)
-        .padStart(8, '0')
+            .value()
+            .toUInt()
+            .toString(16)
+            .uppercase(Locale.ROOT)
+            .padStart(8, '0')
     return "ShadowColor.shadowColor(0x$argb.toInt())"
 }
 

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslWriter.kt
@@ -74,12 +74,12 @@ private val decorations: List<Pair<TextDecoration, String>> =
  */
 private fun hasDslOutput(style: Style): Boolean =
     style.color() != null ||
-        style.font() != null ||
-        style.insertion() != null ||
-        style.shadowColor() != null ||
-        style.clickEvent() != null ||
-        style.hoverEvent() != null ||
-        decorations.any { (decoration) -> style.decoration(decoration) != State.NOT_SET }
+            style.font() != null ||
+            style.insertion() != null ||
+            style.shadowColor() != null ||
+            style.clickEvent() != null ||
+            style.hoverEvent() != null ||
+            decorations.any { (decoration) -> style.decoration(decoration) != State.NOT_SET }
 
 /**
  * Dispatches to the emitter for [component]'s concrete type. Every emission is a self-contained call expression, so it

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTest.kt
@@ -1088,7 +1088,7 @@ class MiniMessageToDslTest :
                             .append(Component.text("bad").shadowColor(ShadowColor.shadowColor(0xFF112233.toInt())))
 
                     MiniMessageToDslWriter.write(nested) shouldBe
-                        """
+                            """
                         component {
                             text("ok") {
                                 text("bad") {
@@ -1108,7 +1108,7 @@ class MiniMessageToDslTest :
                             .build()
 
                     MiniMessageToDslWriter.write(translatable) shouldBe
-                        """
+                            """
                         component {
                             translatable("chat.type.text") {
                                 arg {
@@ -1126,7 +1126,7 @@ class MiniMessageToDslTest :
                     val selector = Component.selector("@e").separator(separator)
 
                     MiniMessageToDslWriter.write(selector) shouldBe
-                        """
+                            """
                         component {
                             selector("@e") {
                                 separator {
@@ -1144,7 +1144,7 @@ class MiniMessageToDslTest :
                     val component = Component.text("hover me").hoverEvent(HoverEvent.showText(payload))
 
                     MiniMessageToDslWriter.write(component) shouldBe
-                        """
+                            """
                         component {
                             text("hover me") {
                                 hover {
@@ -1179,7 +1179,7 @@ class MiniMessageToDslTest :
                             ).build()
 
                     MiniMessageToDslWriter.write(playerHead) shouldBe
-                        """
+                            """
                         component {
                             display(head(UUID.fromString("0d1630e2-fc7c-48ef-b7a0-8dfb9e57ec25")))
                         }
@@ -1196,7 +1196,7 @@ class MiniMessageToDslTest :
                     val playerHead = Component.`object`().contents(contents).build()
 
                     MiniMessageToDslWriter.write(playerHead) shouldBe
-                        """
+                            """
                         component {
                             display(head(key("minecraft", "entity/player/wide/steve"), hat = false))
                         }

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentUtilityRoundTripTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentUtilityRoundTripTest.kt
@@ -1,0 +1,68 @@
+package io.github.lmliam.kotventure.serializer
+
+import io.github.lmliam.kotventure.core.text.asSequence
+import io.github.lmliam.kotventure.core.text.compacted
+import io.github.lmliam.kotventure.core.text.component
+import io.github.lmliam.kotventure.core.text.count
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.TranslatableComponent
+import net.kyori.adventure.text.format.NamedTextColor
+
+/**
+ * Verifies the core component utilities ([compacted] + [asSequence]/[count]) interoperate with the serializers:
+ * compaction preserves rendered meaning, and both normalised and traversed trees survive a JSON round trip.
+ */
+class ComponentUtilityRoundTripTest :
+    StringSpec(
+        {
+            "compaction preserves rendered text and round-trips losslessly through json" {
+                val message =
+                    component {
+                        text("Hello, ") { color(NamedTextColor.GOLD) }
+                        text("world") { color(NamedTextColor.GOLD) }
+                    }
+
+                val compacted = message.compacted()
+
+                // Compaction never changes how the tree renders.
+                compacted.toPlain() shouldBe "Hello, world"
+                compacted.toPlain() shouldBe message.toPlain()
+
+                // The normalised tree survives a serialize/deserialize round trip unchanged.
+                val roundTripped = compacted.toJson().asJsonComponent()
+                roundTripped shouldBe compacted
+                roundTripped shouldContainText "Hello, world"
+            }
+
+            "a deeply nested tree keeps every node across a json round trip" {
+                val message =
+                    component {
+                        text("a") {
+                            text("b") {
+                                text("c")
+                            }
+                        }
+                    }
+
+                val roundTripped = message.toJson().asJsonComponent()
+
+                roundTripped.count() shouldBe message.count()
+            }
+
+            "a translatable node survives a json round trip" {
+                val message =
+                    component {
+                        text("You found ")
+                        translatable("item.minecraft.diamond") { fallback("Diamond") }
+                    }
+
+                val roundTripped = message.toJson().asJsonComponent()
+
+                roundTripped.count() shouldBe message.count()
+                roundTripped.asSequence().filterIsInstance<TranslatableComponent>().toList() shouldHaveSize 1
+            }
+        },
+    )


### PR DESCRIPTION
## Summary

Adds small, composable utilities for **normalising** and **traversing/reducing** Adventure component trees, in the `core.text` feature package:

- `Component.compacted()` — past-tense alias of Adventure's `compact()` (merges adjacent same-style runs, drops empty wrapper components, pushes redundant parent styling down) for call-site consistency with `styled`.
- `Component.asSequence(): Sequence<Component>` — a **lazy depth-first, pre-order** sequence over the component and all descendants. It delegates to Adventure's own `iterable(ComponentIteratorType.DEPTH_FIRST)`, so it preserves Adventure's semantics + child ordering and visits every node, including `ObjectComponent`s.
- `Component.count()` / `Component.forEach { }` — thin conveniences over `asSequence()` for the two most common walks.

## Related Issues

Closes #71

## DSL Impact

Two new public entry points (`compacted`, `asSequence`) plus two sugar functions (`count`, `forEach`), all explicit-API + KDoc. Because `asSequence()` returns a `Sequence<Component>`, the **whole Kotlin stdlib** is available over a component tree with no extra surface to maintain:

```kotlin
msg.compacted()                                       // normalise before send/serialize/compare
msg.count()                                           // nodes in the whole tree
msg.forEach { node -> log(node) }                     // depth-first visit
msg.asSequence().filterIsInstance<ObjectComponent>()  // object components preserved
msg.asSequence().any { it.color() == GOLD }           // lazy, short-circuits
```

> **Design note (for review):** the issue-tracked CodeRabbit plan sketched bespoke `fold`/`forEach`/`count`. Per the maintainer's choice and the project's `idiomatic-kotlin-dsl` skill + the issue's own "wrap Adventure, don't reimplement tree semantics" note, this PR instead exposes a single lazy `asSequence()` primitive (which gives `fold`/`map`/`filter`/`any`/… for free) **plus** the two requested named conveniences. Happy to drop the sugar or rename if you'd prefer.

## Rationale

Downstream authors building large messages need to normalise trees (for stable serialization/snapshots) and walk/reduce them (validation, metrics, transforms) without reaching into Adventure's traversal internals. Wrapping Adventure's own iterator keeps the helpers pure and allocation-conscious (lazy + short-circuiting), supporting the later performance work (#56) rather than fighting it, and sits naturally beside the serializer extensions (#30).

## Testing

- `ComponentSequenceTest` (core, 12 cases): depth-first pre-order ordering (root → children in declaration order), deep nesting, single leaf, empty-content root with children, **object-component preservation**, mixed text/translatable/object counting, `count` over flat/deep/wide trees, `forEach` order matches `asSequence`, stdlib `any`/`firstOrNull` composition.
- `CompactedTest` (core, 4 cases): adjacent same-style merge, style preservation, empty component, object-component preservation through compaction.
- `ComponentUtilityRoundTripTest` (serializer, 3 cases): compaction preserves rendered text and round-trips losslessly through JSON; nested + translatable trees keep every node across a JSON round trip. (Lives in `serializer` because `core` only depends on `adventure-api`.)

All green via `./gradlew build` (compile + tests + `ktlintCheck`/`spotlessCheck`); `explicitApi()` satisfied with KDoc on the new public API.

## Checklist

- [x] Linked related issue
- [x] Updated relevant `/docs` pages (`docs/DESIGN.md` §5 canonical surface; no README usage list to update)
- [x] Verified examples build and run (`./gradlew build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
