### PR TITLE
ci(build): add code coverage gate with kover

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,15 +24,30 @@ in removal from the project's spaces.
 - Use the **Gradle wrapper** — no local Gradle install needed.
 
 ```bash
-./gradlew build          # compile + test + lint everything
-./gradlew test           # run the Kotest suites
-./gradlew spotlessApply  # auto-format
-./gradlew ktlintCheck    # lint check
+./gradlew build           # compile + test + lint + verify coverage
+./gradlew test            # run the Kotest suites
+./gradlew spotlessApply   # auto-format
+./gradlew ktlintCheck     # lint check
+./gradlew koverHtmlReport # generate the aggregated HTML coverage report
 ```
+
+After `koverHtmlReport`, open the aggregated report at `build/reports/kover/html/index.html` in a browser (e.g.
+`open build/reports/kover/html/index.html` on macOS) to inspect line coverage per module, package, and class.
 
 Dependency and plugin coordinates live in [`gradle/libs.versions.toml`](../gradle/libs.versions.toml). Add shared
 versions there first, then consume them through catalog aliases or the existing Gradle helper scripts that delegate to
 the catalog.
+
+### Coverage threshold policy
+
+We use [Kover](https://github.com/Kotlin/kotlinx-kover) for code coverage. `koverVerify` is wired into `check`, so
+`./gradlew build` fails when aggregated line coverage drops below the baseline.
+
+- **Current baseline:** 85% line coverage, defined in [`gradle/coverage.gradle`](../gradle/coverage.gradle).
+- **Rationale:** the project is pre-alpha, but every behavioural change ships with tests, so the gate sits a little below
+  current coverage — high enough to catch large untested slices, low enough that normal vertical slices don't trip CI.
+- **Tightening:** raise the threshold in 5–10% increments as coverage matures, and call the change out in the PR
+  description so reviewers aren't surprised by a CI failure.
 
 ## Project conventions
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
-      - name: Run build, tests, and formatting checks
-        run: ./gradlew build spotlessCheck ktlintCheck --no-daemon
+      - name: Run build, tests, coverage, and formatting checks
+        # `build` runs `koverVerify` (wired into `check`); the report tasks publish the
+        # aggregated coverage output uploaded below.
+        run: ./gradlew build koverXmlReport koverHtmlReport spotlessCheck ktlintCheck --no-daemon
 
       - name: Publish JUnit test report
         if: always()
@@ -60,6 +62,15 @@ jobs:
           path: |
             modules/*/build/test-results/test
             modules/*/build/reports/tests/test
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-report
+          path: build/reports/kover
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,6 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Run build, tests, coverage, and formatting checks
-        # `build` runs `koverVerify` (wired into `check`); the report tasks publish the
-        # aggregated coverage output uploaded below.
         run: ./gradlew build koverXmlReport koverHtmlReport spotlessCheck ktlintCheck --no-daemon
 
       - name: Publish JUnit test report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,13 +35,18 @@ MiniMessage, a component-testing toolkit, ANSI preview, and codegen.
 JDK **25** (provisioned via the Gradle toolchain). Always use the wrapper.
 
 ```bash
-./gradlew build          # compile + test + lint
+./gradlew build          # compile + test + lint + verify coverage
 ./gradlew test           # Kotest suites
 ./gradlew ktlintFormat    # auto-fix Kotlin style   (or: ./gradlew spotlessApply)
 ./gradlew ktlintCheck spotlessCheck   # verify style
+./gradlew koverHtmlReport   # aggregated coverage report → build/reports/kover/html/index.html
 ```
 
 Run formatting and the relevant tests **before** committing. CI must be green.
+
+Coverage is gated: `koverVerify` runs as part of `check`/`build` and fails if aggregated line coverage drops below the
+baseline in [`gradle/coverage.gradle`](gradle/coverage.gradle) (currently 85%). Don't lower the threshold to pass — add
+tests; see the threshold policy in [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 
 Shared dependency and plugin coordinates live in [`gradle/libs.versions.toml`](gradle/libs.versions.toml). Add shared
 versions there first, then consume them through catalog aliases or the existing Gradle helper scripts that delegate to

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.kotest) apply false
     alias(libs.plugins.spotless) apply false
     alias(libs.plugins.gradle.ktlint) apply false
-    // Applied to the root so it can aggregate per-module coverage into one report.
     alias(libs.plugins.kover)
     id 'base'
     id 'idea'

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ plugins {
     alias(libs.plugins.kotest) apply false
     alias(libs.plugins.spotless) apply false
     alias(libs.plugins.gradle.ktlint) apply false
+    // Applied to the root so it can aggregate per-module coverage into one report.
+    alias(libs.plugins.kover)
     id 'base'
     id 'idea'
 }
@@ -22,6 +24,7 @@ subprojects {
         apply plugin: 'io.kotest'
         apply plugin: 'com.diffplug.spotless'
         apply plugin: 'org.jlleitschuh.gradle.ktlint'
+        apply plugin: 'org.jetbrains.kotlinx.kover'
 
         kotlin {
             jvmToolchain(25)
@@ -54,4 +57,5 @@ subprojects {
     }
 }
 
+apply from: 'gradle/coverage.gradle'
 apply from: 'gradle/tasks.gradle'

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -14,8 +14,6 @@
 // any threshold change in the PR description so reviewers are not surprised by a CI failure.
 def coverageLineThreshold = 85
 
-// Aggregate coverage from every library module — the same set the root build script applies
-// the library plugins to (everything except the BOM) — so a new module is gated automatically.
 dependencies {
     subprojects
             .findAll { subproject -> subproject.name != 'bom' }
@@ -32,8 +30,6 @@ kover {
     }
 }
 
-// Make coverage a gate: `koverVerify` runs with `check` (and therefore with `build`), so a
-// regression below the baseline fails the build locally and in CI.
 tasks.named('check') {
     dependsOn tasks.named('koverVerify')
 }

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -1,0 +1,38 @@
+// Code coverage (Kover), aggregated across every library module.
+//
+// Kover is applied to each library module (see the root `subprojects {}` block) and to the
+// root project here so the root can merge per-module coverage into a single report. The
+// aggregated HTML/XML output lands in `build/reports/kover/`; `./gradlew koverHtmlReport`
+// generates it locally.
+//
+// Coverage threshold policy
+// -------------------------
+// Baseline: 85% line coverage. The project is pre-alpha, but every behavioural change ships
+// with tests (see AGENTS.md §6), so the gate is set a little below current coverage to catch
+// large untested slices without flagging normal vertical slices as noise.
+// Tightening: raise `coverageLineThreshold` in 5–10% increments as coverage matures. Call out
+// any threshold change in the PR description so reviewers are not surprised by a CI failure.
+def coverageLineThreshold = 85
+
+dependencies {
+    kover project(':core')
+    kover project(':minimessage')
+    kover project(':serializer')
+    kover project(':test')
+}
+
+kover {
+    reports {
+        verify {
+            rule {
+                minBound(coverageLineThreshold)
+            }
+        }
+    }
+}
+
+// Make coverage a gate: `koverVerify` runs with `check` (and therefore with `build`), so a
+// regression below the baseline fails the build locally and in CI.
+tasks.named('check') {
+    dependsOn tasks.named('koverVerify')
+}

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -14,11 +14,12 @@
 // any threshold change in the PR description so reviewers are not surprised by a CI failure.
 def coverageLineThreshold = 85
 
+// Aggregate coverage from every library module — the same set the root build script applies
+// the library plugins to (everything except the BOM) — so a new module is gated automatically.
 dependencies {
-    kover project(':core')
-    kover project(':minimessage')
-    kover project(':serializer')
-    kover project(':test')
+    subprojects
+            .findAll { subproject -> subproject.name != 'bom' }
+            .each { subproject -> kover subproject }
 }
 
 kover {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ kctfork = "0.13.0"
 kotest = "6.1.11"
 kotestPlugin = "6.2.0"
 kotlin = "2.4.0"
+kover = "0.9.8"
 spotless = "8.6.0"
 spotlessKtlint = "1.7.0"
 
@@ -26,4 +27,5 @@ kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref 
 gradle-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "gradleKtlintPlugin" }
 kotest = { id = "io.kotest", version.ref = "kotestPlugin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
## Summary

Adds a code coverage gate so correctness tooling includes measurable test coverage, not just build/lint checks. Uses [Kover](https://github.com/Kotlin/kotlinx-kover) (Kotlin-native, integrates cleanly with Kotest + Gradle multi-module builds):

- **Aggregated coverage** — Kover is applied to every library module and to the root project, which merges per-module coverage into one report at `build/reports/kover/` (`./gradlew koverHtmlReport`).
- **Enforced gate** — `koverVerify` is wired into `check` (and therefore `build`), failing at an **85% line coverage** baseline. Current aggregated coverage is ~92%, so the gate has headroom but still catches large untested slices.
- **CI artifact** — the aggregated HTML/XML report is uploaded as the `coverage-report` artifact (7-day retention, matching existing artifacts).
- **Threshold policy** — documented in `gradle/coverage.gradle`, `CONTRIBUTING.md`, and `AGENTS.md`, with guidance to tighten in 5–10% increments.

Root-level aggregation config lives in a dedicated `gradle/coverage.gradle`, mirroring the project's existing one-script-per-concern build layout.

## Related Issues

Closes #73

## Scope

- [x] Build tooling
- [x] GitHub Actions workflow
- [ ] Dependency bump
- [ ] Repo config (labels, CODEOWNERS, etc.)

## Notes for Reviewers

- **Threshold = 85%** was chosen over the CodeRabbit plan's 50%: at ~92% actual coverage, a 50% gate would never catch a realistic regression. 85% leaves ~7pts of headroom while still gating.
- **Gate verified to fail below threshold:** temporarily raising the bound to 99% produced `Rule violated: lines covered percentage is 92.33, but expected minimum is 99` — confirming it is a real gate, not a no-op.
- `registerSubprojectAggregateTask` (suggested in the plan for `koverHtmlReport`/`koverXmlReport`) is intentionally **not** used: the root Kover plugin already provides those task names via `kover(project(...))` aggregation, so re-registering them would collide.
- `build/reports/kover/` is gitignored (under `build/`), so no generated artifacts are committed.

## Checklist

- [x] Linked related issue (if applicable)
- [x] Verified build/test pass after change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
