### PR TITLE
docs(core): render KDoc examples via @sample

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Run build, tests, coverage, and formatting checks
-        run: ./gradlew build koverXmlReport koverHtmlReport spotlessCheck ktlintCheck --no-daemon
+        run: ./gradlew build dokkaGenerate koverXmlReport koverHtmlReport spotlessCheck ktlintCheck --no-daemon
 
       - name: Publish JUnit test report
         if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    alias(libs.plugins.dokka) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotest) apply false
     alias(libs.plugins.spotless) apply false
@@ -19,6 +20,7 @@ subprojects {
     if (libraryModule) {
         apply plugin: 'java-library'
         apply plugin: 'org.jetbrains.kotlin.jvm'
+        apply plugin: 'org.jetbrains.dokka'
         apply plugin: 'io.kotest'
         apply plugin: 'com.diffplug.spotless'
         apply plugin: 'org.jetbrains.kotlinx.kover'
@@ -51,6 +53,7 @@ subprojects {
 
     if (libraryModule) {
         apply from: rootProject.file('gradle/spotless.gradle')
+        apply from: rootProject.file('gradle/samples.gradle')
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,5 @@ kotlin.code.style=official
 # Build performance (safe defaults; behaviour-neutral).
 org.gradle.parallel=true
 org.gradle.caching=true
+# Dokka V2 plugin API.
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 project = "0.4.1"
 adventureApi = "5.1.1"
+dokka = "2.2.0"
 kctfork = "0.13.0"
 kotest = "6.2.1"
 kotestPlugin = "6.2.1"
@@ -27,6 +28,7 @@ kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref 
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [plugins]
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotest = { id = "io.kotest", version.ref = "kotestPlugin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/gradle/samples.gradle
+++ b/gradle/samples.gradle
@@ -25,6 +25,9 @@ tasks.named('check') {
 }
 
 dokka {
+    dokkaPublications.configureEach {
+        failOnWarning.set(true)
+    }
     dokkaSourceSets.configureEach {
         samples.from(file('src/samples/kotlin'))
     }

--- a/gradle/samples.gradle
+++ b/gradle/samples.gradle
@@ -20,6 +20,10 @@ tasks.named('compileSamplesKotlin') {
     }
 }
 
+tasks.named('check') {
+    dependsOn('compileSamplesKotlin')
+}
+
 dokka {
     dokkaSourceSets.configureEach {
         samples.from(file('src/samples/kotlin'))

--- a/gradle/samples.gradle
+++ b/gradle/samples.gradle
@@ -1,0 +1,35 @@
+sourceSets {
+    samples {
+        kotlin {
+            srcDir 'src/samples/kotlin'
+        }
+    }
+}
+
+configurations {
+    samplesImplementation.extendsFrom(implementation, api)
+}
+
+dependencies {
+    samplesImplementation sourceSets.main.output
+}
+
+tasks.named('compileSamplesKotlin') {
+    compilerOptions {
+        freeCompilerArgs.add('-Xexplicit-api=disable')
+    }
+}
+
+dokka {
+    dokkaSourceSets.configureEach {
+        samples.from(file('src/samples/kotlin'))
+    }
+}
+
+kover {
+    currentProject {
+        sources {
+            excludedSourceSets.add('samples')
+        }
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Color.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Color.kt
@@ -9,9 +9,7 @@ private val hexColorPattern: Regex = Regex("#[0-9A-Fa-f]{6}")
 /**
  * Creates a [TextColor] from an exact `#RRGGBB` hex string.
  *
- * ```kotlin
- * val gold = hex("#FFAA00")
- * ```
+ * @sample io.github.lmliam.kotventure.core.color.hexColorSample
  *
  * @param value a six-digit hex string with a leading `#`, e.g. `"#FF0000"`.
  * @throws IllegalArgumentException if [value] is not exactly `#RRGGBB`.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
@@ -43,9 +43,7 @@ public class ColorGradient public constructor(
 /**
  * Creates a [ColorGradient] from two or more color stops.
  *
- * ```kotlin
- * val fire = gradient(hex("#FF0000"), hex("#FFAA00"), hex("#FFFF00"))
- * ```
+ * @sample io.github.lmliam.kotventure.core.color.gradientSample
  *
  * @throws IllegalArgumentException if fewer than two stops are supplied.
  */
@@ -61,9 +59,7 @@ public fun gradient(stops: Iterable<TextColor>): ColorGradient = ColorGradient(s
 /**
  * Builds a component that spreads [stops] across [value], coloring one child per code point.
  *
- * ```kotlin
- * val title = gradientText("Kotventure", hex("#FF0000"), hex("#0000FF"))
- * ```
+ * @sample io.github.lmliam.kotventure.core.color.gradientTextSample
  *
  * @param value the text to color; its code points (not chars) are colored so surrogate pairs stay intact.
  * @throws IllegalArgumentException if fewer than two stops are supplied.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/ComponentScope.kt
@@ -14,12 +14,7 @@ import net.kyori.adventure.text.format.Style
  * [StyleScope], so a component's own style and its
  * children are configured in one place.
  *
- * ```kotlin
- * component {
- *     text("Hello ") { color(aqua) }
- *     keybind("key.jump")
- * }
- * ```
+ * @sample io.github.lmliam.kotventure.core.component.componentScopeSample
  */
 @KotventureDslMarker
 public interface ComponentScope : StyleScope {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ClickActionScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ClickActionScope.kt
@@ -9,10 +9,7 @@ import kotlin.time.Duration as KotlinDuration
  * Selects the single action a click event performs. Exactly one action must be chosen per `click { }` block;
  * choosing none or more than one fails when the event is built.
  *
- * ```kotlin
- * click { openUrl("https://example.com") }
- * click { run("/spawn") }
- * ```
+ * @sample io.github.lmliam.kotventure.core.event.clickActionScopeSample
  */
 @KotventureDslMarker
 public interface ClickActionScope {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ClickEvent.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ClickEvent.kt
@@ -6,9 +6,7 @@ import net.kyori.adventure.text.event.ClickEvent
  * Builds a reusable click event. Choose exactly one action inside [init] — [ClickActionScope.openUrl], [ClickActionScope.openFile], [ClickActionScope.run],
  * [ClickActionScope.suggest], [ClickActionScope.changePage], [ClickActionScope.copy], or [ClickActionScope.callback].
  *
- * ```kotlin
- * val link = click { openUrl("https://example.com") }
- * ```
+ * @sample io.github.lmliam.kotventure.core.event.clickSample
  *
  * @throws IllegalStateException when [init] does not choose exactly one click action.
  * @throws IllegalArgumentException when Adventure rejects the selected action payload.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverEvent.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverEvent.kt
@@ -5,9 +5,7 @@ import net.kyori.adventure.text.event.HoverEvent
 /**
  * Builds a reusable hover event. Choose exactly one payload inside [init] — [HoverContentScope.text], [HoverContentScope.item], or [HoverContentScope.entity].
  *
- * ```kotlin
- * val tooltip = hover { text("Click to teleport") }
- * ```
+ * @sample io.github.lmliam.kotventure.core.event.hoverSample
  *
  * @throws IllegalStateException when [init] does not choose exactly one hover payload.
  * @throws IllegalArgumentException when a payload value is rejected before reaching Adventure.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/keybind/Keybind.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/keybind/Keybind.kt
@@ -8,9 +8,7 @@ import net.kyori.adventure.text.KeybindComponent
 /**
  * Builds a keybind [Component] — text the client renders as the player's current binding for a game action.
  *
- * ```kotlin
- * val jump = keybind("key.jump") { color(aqua) }
- * ```
+ * @sample io.github.lmliam.kotventure.core.keybind.keybindSample
  *
  * @param keybind the Minecraft keybind identifier, such as `"key.jump"`.
  * @param init styles the component and appends any children.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockNbt.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/BlockNbt.kt
@@ -7,9 +7,7 @@ import net.kyori.adventure.text.Component
 /**
  * Builds a block-NBT [Component] — text the client resolves from a block entity's NBT data at a position.
  *
- * ```kotlin
- * val sign = blockNbt(blockPos(0, 64, 0), nbtPath("front_text")["messages"][0])
- * ```
+ * @sample io.github.lmliam.kotventure.core.nbt.blockNbtSample
  *
  * @param pos the block position to read, e.g. from [blockPos].
  * @param nbtPath the NBT path within the block entity, constructed via [nbtPath].

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/EntityNbt.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/EntityNbt.kt
@@ -8,9 +8,7 @@ import net.kyori.adventure.text.EntityNBTComponent
 /**
  * Builds an entity-NBT [Component] — text the client resolves from the NBT of entities matched by a selector.
  *
- * ```kotlin
- * val health = entityNbt(self(), nbtPath("Health"))
- * ```
+ * @sample io.github.lmliam.kotventure.core.nbt.entityNbtSample
  *
  * @param selector the entity selector whose NBT is read, constructed via [io.github.lmliam.kotventure.core.selector.self] or friends.
  * @param nbtPath the NBT path within each entity, constructed via [nbtPath].

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtPath.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtPath.kt
@@ -4,17 +4,11 @@ package io.github.lmliam.kotventure.core.nbt
  * A typed NBT path supporting indexed traversal, all-elements selection, and compound filters.
  *
  * Construct via [nbtPath] and chain the indexing operators:
- * ```kotlin
- * nbtPath("Items")[0]["tag"]["display"]["Name"]
- * nbtPath("Inventory")[all]["id"]
- * nbtPath("Items")[matching { "id" eq "minecraft:diamond" }]["Count"]
- * ```
+ * @sample io.github.lmliam.kotventure.core.nbt.nbtPathSample
  *
  * For syntax not covered by the typed API, pass a pre-formed path string to [nbtPath]; it is used
  * verbatim as the first segment:
- * ```kotlin
- * nbtPath("Items[{id:\"minecraft:diamond\"}].Count")
- * ```
+ * @sample io.github.lmliam.kotventure.core.nbt.nbtPathVerbatimSample
  */
 public class NbtPath internal constructor(
     internal val nodes: List<NbtPathNode>,
@@ -22,28 +16,21 @@ public class NbtPath internal constructor(
     /**
      * Navigates into a compound key.
      *
-     * ```kotlin
-     * nbtPath("tag")["display"]["Name"]
-     * ```
+     * @sample io.github.lmliam.kotventure.core.nbt.nbtPathKeySample
      */
     public operator fun get(key: String): NbtPath = NbtPath(nodes + NbtPathNode.Key(key))
 
     /**
      * Navigates into a list element by index.
      *
-     * ```kotlin
-     * nbtPath("Items")[0]["id"]
-     * ```
+     * @sample io.github.lmliam.kotventure.core.nbt.nbtPathIndexSample
      */
     public operator fun get(index: Int): NbtPath = NbtPath(nodes + NbtPathNode.Index(index))
 
     /**
      * Applies an [all]-elements or [matching] compound-filter selection.
      *
-     * ```kotlin
-     * nbtPath("Inventory")[all]["id"]
-     * nbtPath("Items")[matching { "id" eq "minecraft:diamond" }]["Count"]
-     * ```
+     * @sample io.github.lmliam.kotventure.core.nbt.nbtPathSelectionSample
      */
     public operator fun get(selection: NbtSelection): NbtPath = NbtPath(nodes + selection.node)
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtPathFactory.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtPathFactory.kt
@@ -6,13 +6,7 @@ package io.github.lmliam.kotventure.core.nbt
  * The key is used verbatim as the first segment, so a pre-formed path string works as a string
  * escape hatch — chaining the indexing operators simply appends to it:
  *
- * ```kotlin
- * // Structured
- * nbtPath("Items")[0]["id"]
- *
- * // Pre-formed string, still chainable
- * nbtPath("Items[0]")["tag"]
- * ```
+ * @sample io.github.lmliam.kotventure.core.nbt.nbtPathFactorySample
  */
 public fun nbtPath(key: String): NbtPath = NbtPath(listOf(NbtPathNode.Key(key)))
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtPredicateScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtPredicateScope.kt
@@ -9,13 +9,7 @@ import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
  * literal form (e.g. a [Byte] renders as `1b`, a [Long] as `1L`). Nest a compound with the lambda
  * overload of [eq]:
  *
- * ```kotlin
- * matching {
- *     "id" eq "minecraft:diamond"
- *     "Count" eq 1.toByte()
- *     "tag" eq { "Unbreakable" eq 1.toByte() }
- * }
- * ```
+ * @sample io.github.lmliam.kotventure.core.nbt.nbtPredicateScopeSample
  */
 @KotventureDslMarker
 public interface NbtPredicateScope {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtSelection.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtSelection.kt
@@ -10,18 +10,14 @@ public class NbtSelection internal constructor(
 /**
  * Selects all elements in a list (`[]`).
  *
- * ```kotlin
- * nbtPath("Passengers")[all]["CustomName"]
- * ```
+ * @sample io.github.lmliam.kotventure.core.nbt.allSample
  */
 public val all: NbtSelection = NbtSelection(NbtPathNode.AllElements)
 
 /**
  * Selects list elements matching a compound predicate (`[{...}]`).
  *
- * ```kotlin
- * nbtPath("Items")[matching { "id" eq "minecraft:diamond" }]["Count"]
- * ```
+ * @sample io.github.lmliam.kotventure.core.nbt.matchingSample
  */
 public fun matching(init: NbtPredicateScope.() -> Unit): NbtSelection {
     val builder = NbtPredicateBuilder()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/StorageNbt.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/StorageNbt.kt
@@ -8,9 +8,7 @@ import net.kyori.adventure.text.StorageNBTComponent
 /**
  * Builds a storage-NBT [Component] — text the client resolves from command-storage NBT under a key.
  *
- * ```kotlin
- * val score = storageNbt(key("myplugin", "scores"), nbtPath("top.player"))
- * ```
+ * @sample io.github.lmliam.kotventure.core.nbt.storageNbtSample
  *
  * @param storage the command-storage key to read, e.g. from `key(...)`.
  * @param nbtPath the NBT path within that storage, constructed via [nbtPath].

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/Display.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/Display.kt
@@ -7,9 +7,7 @@ import net.kyori.adventure.text.`object`.ObjectContents
 /**
  * Builds an object [Component] — an inline rendered object such as a player head or atlas sprite.
  *
- * ```kotlin
- * val head = display(head(uuid)) { fallback(component { text("?") }) }
- * ```
+ * @sample io.github.lmliam.kotventure.core.objectcomponent.displaySample
  *
  * @param contents what to render, built with the object-contents helpers (`sprite(...)`, `head(...)`).
  * @param init sets a fallback, styles the component, and appends any children.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/score/Score.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/score/Score.kt
@@ -8,9 +8,7 @@ import net.kyori.adventure.text.ScoreComponent
 /**
  * Builds a score [Component] — text the client resolves to a scoreboard value at display time.
  *
- * ```kotlin
- * val kills = score(name = "@s", objective = "kills")
- * ```
+ * @sample io.github.lmliam.kotventure.core.score.scoreSample
  *
  * @param name the scoreholder, e.g. a player name or selector like `"@s"`.
  * @param objective the scoreboard objective to read.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorFactory.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorFactory.kt
@@ -8,9 +8,7 @@ public fun self(): EntitySelector = EntitySelector("@s")
 /**
  * Builds a `@p` selector targeting the nearest player, with optional arguments.
  *
- * ```kotlin
- * nearestPlayer { distance(atMost(10.0)) }
- * ```
+ * @sample io.github.lmliam.kotventure.core.selector.nearestPlayerSample
  */
 public fun nearestPlayer(init: EntitySelectorScope.() -> Unit = {}): EntitySelector =
     EntitySelectorBuilder("@p").apply(init).build()
@@ -18,9 +16,7 @@ public fun nearestPlayer(init: EntitySelectorScope.() -> Unit = {}): EntitySelec
 /**
  * Builds an `@a` selector targeting all players, with optional arguments.
  *
- * ```kotlin
- * allPlayers { tag("admin") }
- * ```
+ * @sample io.github.lmliam.kotventure.core.selector.allPlayersSample
  */
 public fun allPlayers(init: EntitySelectorScope.() -> Unit = {}): EntitySelector =
     EntitySelectorBuilder("@a").apply(init).build()
@@ -34,15 +30,7 @@ public fun randomPlayer(init: EntitySelectorScope.() -> Unit = {}): EntitySelect
 /**
  * Builds an `@e` selector targeting all entities, with optional arguments.
  *
- * ```kotlin
- * entities {
- *     type("armor_stand")
- *     distance(atMost(10.0))
- *     sort(nearest)
- *     limit(1)
- *     tag("display")
- * }
- * ```
+ * @sample io.github.lmliam.kotventure.core.selector.entitiesSample
  */
 public fun entities(init: EntitySelectorScope.() -> Unit = {}): EntitySelector =
     EntitySelectorBuilder("@e").apply(init).build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorScope.kt
@@ -6,15 +6,7 @@ import net.kyori.adventure.key.Key
 /**
  * Scope for configuring entity selector arguments.
  *
- * ```kotlin
- * entities {
- *     type("armor_stand")
- *     distance(atMost(10.0))
- *     sort(nearest)
- *     limit(1)
- *     tag("display")
- * }
- * ```
+ * @sample io.github.lmliam.kotventure.core.selector.entitySelectorScopeSample
  */
 @KotventureDslMarker
 public interface EntitySelectorScope {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/Selector.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/Selector.kt
@@ -6,9 +6,7 @@ import net.kyori.adventure.text.Component
 /**
  * Builds a selector [Component] — text the client expands to the names matched by an entity selector.
  *
- * ```kotlin
- * val nearby = selector(entities { distance(atMost(10.0)) }) { separator { content(", ") } }
- * ```
+ * @sample io.github.lmliam.kotventure.core.selector.selectorSample
  *
  * @param selector the entity selector, constructed via [self], [entities], or friends.
  * @param init configures the selector (e.g. its separator) and appends any children.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/Style.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/Style.kt
@@ -5,13 +5,7 @@ import net.kyori.adventure.text.format.Style
 /**
  * Builds a reusable [Style] that can be applied to many components.
  *
- * ```kotlin
- * val heading = style {
- *     color(gold)
- *     bold()
- * }
- * val title = text("Welcome") { style(heading) }
- * ```
+ * @sample io.github.lmliam.kotventure.core.style.styleSample
  */
 public fun style(init: StyleScope.() -> Unit): Style =
     Style

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/StyleScope.kt
@@ -17,13 +17,7 @@ import net.kyori.adventure.text.format.TextDecoration.State
  * it (`bold(false)`, `bold(null)`), and an explicit [State] setter — so styles can both set and unset
  * attributes when composed.
  *
- * ```kotlin
- * style {
- *     color(gold)
- *     bold()
- *     italic(false)
- * }
- * ```
+ * @sample io.github.lmliam.kotventure.core.style.styleScopeSample
  */
 @KotventureDslMarker
 public interface StyleScope :

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/Styled.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/style/Styled.kt
@@ -7,8 +7,6 @@ import net.kyori.adventure.text.format.Style
 /**
  * Returns a copy of this component with [style] applied, replacing any existing style.
  *
- * ```kotlin
- * val highlighted = component { text("important") } styled heading
- * ```
+ * @sample io.github.lmliam.kotventure.core.style.styledSample
  */
 public infix fun <T : ComponentLike> T.styled(style: Style): Component = asComponent().style(style)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/ComponentSequence.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/ComponentSequence.kt
@@ -11,9 +11,7 @@ import net.kyori.adventure.text.ComponentIteratorType
  * Being a [Sequence], it composes with the standard library and stays lazy, so short-circuiting terminals stop
  * walking as early as they can:
  *
- * ```kotlin
- * val mentionsAlex = root.asSequence().any { it is TextComponent && "Alex" in it.content() }
- * ```
+ * @sample io.github.lmliam.kotventure.core.text.componentSequenceSample
  *
  * Traversal follows Adventure's own [Component.iterable], visiting every node in the tree (including object
  * components). Translatable arguments and hover contents are not children and are not visited; pass the relevant

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Join.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Join.kt
@@ -6,9 +6,7 @@ import net.kyori.adventure.text.ComponentLike
 /**
  * Joins these components into one, with the separators and prefix/suffix configured by [init].
  *
- * ```kotlin
- * val list = arrayOf(text("a"), text("b"), text("c")).join { separator(text(", ")) }
- * ```
+ * @sample io.github.lmliam.kotventure.core.text.joinArraySample
  *
  * @param init configures the separators (including last-element and empty-list cases) and prefix/suffix.
  */
@@ -17,9 +15,7 @@ public fun <T : ComponentLike> Array<T>.join(init: JoinScope.() -> Unit = {}): C
 /**
  * Joins these components into one, with the separators and prefix/suffix configured by [init].
  *
- * ```kotlin
- * val list = listOf(text("a"), text("b")).join { separator(text(", ")) }
- * ```
+ * @sample io.github.lmliam.kotventure.core.text.joinIterableSample
  *
  * @param init configures the separators (including last-element and empty-list cases) and prefix/suffix.
  */

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Text.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Text.kt
@@ -6,12 +6,7 @@ import net.kyori.adventure.text.Component
 /**
  * Builds a text [Component] with [value] as its literal content.
  *
- * ```kotlin
- * val greeting = text("Hello") {
- *     color(gold)
- *     bold()
- * }
- * ```
+ * @sample io.github.lmliam.kotventure.core.text.textSample
  *
  * @param value the literal text content.
  * @param init styles the component and appends any children.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/Theme.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/Theme.kt
@@ -14,16 +14,7 @@ import io.github.lmliam.kotventure.core.style.style as buildStyle
  * [ThemeProvider.style] lookup. Styles are recorded in declaration order during object
  * initialization, so palette properties must be declared before the styles that use them.
  *
- * ```kotlin
- * object Brand : Theme("brand") {
- *     val primary = hex("#5865F2")
- *
- *     val header: Style by style {
- *         color(primary)
- *         bold()
- *     }
- * }
- * ```
+ * @sample io.github.lmliam.kotventure.core.theme.themeSample
  *
  * Runtime lookups require explicit registration: add the theme to a [ThemeRegistry] during
  * startup. Declaring a theme does not register it.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/Translatable.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/translatable/Translatable.kt
@@ -6,12 +6,7 @@ import net.kyori.adventure.text.Component
 /**
  * Builds a translatable [Component] — text the client renders from a translation key in the player's locale.
  *
- * ```kotlin
- * val died = translatable("death.attack.player") {
- *     arg { content("Alex") }
- *     fallback("Alex was slain")
- * }
- * ```
+ * @sample io.github.lmliam.kotventure.core.translatable.translatableSample
  *
  * @param key the translation key, such as `"item.minecraft.diamond"`.
  * @param init supplies translation arguments and an optional fallback, and appends any children.

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/color/ColorSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/color/ColorSamples.kt
@@ -1,0 +1,5 @@
+package io.github.lmliam.kotventure.core.color
+
+internal fun hexColorSample() {
+    val gold = hex("#FFAA00")
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/color/GradientSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/color/GradientSamples.kt
@@ -1,0 +1,9 @@
+package io.github.lmliam.kotventure.core.color
+
+internal fun gradientSample() {
+    val fire = gradient(hex("#FF0000"), hex("#FFAA00"), hex("#FFFF00"))
+}
+
+internal fun gradientTextSample() {
+    val title = gradientText("Kotventure", hex("#FF0000"), hex("#0000FF"))
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/component/ComponentScopeSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/component/ComponentScopeSamples.kt
@@ -1,0 +1,12 @@
+package io.github.lmliam.kotventure.core.component
+
+import io.github.lmliam.kotventure.core.color.aqua
+import io.github.lmliam.kotventure.core.keybind.keybind
+import io.github.lmliam.kotventure.core.text.text
+
+internal fun componentScopeSample() {
+    component {
+        text("Hello ") { color(aqua) }
+        keybind("key.jump")
+    }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/event/EventSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/event/EventSamples.kt
@@ -1,0 +1,14 @@
+package io.github.lmliam.kotventure.core.event
+
+internal fun clickSample() {
+    val link = click { openUrl("https://example.com") }
+}
+
+internal fun clickActionScopeSample() {
+    click { openUrl("https://example.com") }
+    click { run("/spawn") }
+}
+
+internal fun hoverSample() {
+    val tooltip = hover { text("Click to teleport") }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/keybind/KeybindSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/keybind/KeybindSamples.kt
@@ -1,0 +1,7 @@
+package io.github.lmliam.kotventure.core.keybind
+
+import io.github.lmliam.kotventure.core.color.aqua
+
+internal fun keybindSample() {
+    val jump = keybind("key.jump") { color(aqua) }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/nbt/NbtSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/nbt/NbtSamples.kt
@@ -1,0 +1,63 @@
+package io.github.lmliam.kotventure.core.nbt
+
+import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.selector.self
+
+internal fun nbtPathSample() {
+    nbtPath("Items")[0]["tag"]["display"]["Name"]
+    nbtPath("Inventory")[all]["id"]
+    nbtPath("Items")[matching { "id" eq "minecraft:diamond" }]["Count"]
+}
+
+internal fun nbtPathVerbatimSample() {
+    nbtPath("Items[{id:\"minecraft:diamond\"}].Count")
+}
+
+internal fun nbtPathKeySample() {
+    nbtPath("tag")["display"]["Name"]
+}
+
+internal fun nbtPathIndexSample() {
+    nbtPath("Items")[0]["id"]
+}
+
+internal fun nbtPathSelectionSample() {
+    nbtPath("Inventory")[all]["id"]
+    nbtPath("Items")[matching { "id" eq "minecraft:diamond" }]["Count"]
+}
+
+internal fun nbtPathFactorySample() {
+    // Structured
+    nbtPath("Items")[0]["id"]
+
+    // Pre-formed string, still chainable
+    nbtPath("Items[0]")["tag"]
+}
+
+internal fun allSample() {
+    nbtPath("Passengers")[all]["CustomName"]
+}
+
+internal fun matchingSample() {
+    nbtPath("Items")[matching { "id" eq "minecraft:diamond" }]["Count"]
+}
+
+internal fun nbtPredicateScopeSample() {
+    matching {
+        "id" eq "minecraft:diamond"
+        "Count" eq 1.toByte()
+        "tag" eq { "Unbreakable" eq 1.toByte() }
+    }
+}
+
+internal fun blockNbtSample() {
+    val sign = blockNbt(blockPos(0, 64, 0), nbtPath("front_text")["messages"][0])
+}
+
+internal fun entityNbtSample() {
+    val health = entityNbt(self(), nbtPath("Health"))
+}
+
+internal fun storageNbtSample() {
+    val score = storageNbt(key("myplugin", "scores"), nbtPath("top.player"))
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/objectcomponent/DisplaySamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/objectcomponent/DisplaySamples.kt
@@ -1,0 +1,8 @@
+package io.github.lmliam.kotventure.core.objectcomponent
+
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.text.text
+
+internal fun displaySample() {
+    val head = display(head("Alex")) { fallback(component { text("?") }) }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/score/ScoreSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/score/ScoreSamples.kt
@@ -1,0 +1,5 @@
+package io.github.lmliam.kotventure.core.score
+
+internal fun scoreSample() {
+    val kills = score(name = "@s", objective = "kills")
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSamples.kt
@@ -1,0 +1,33 @@
+package io.github.lmliam.kotventure.core.selector
+
+internal fun selectorSample() {
+    val nearby = selector(entities { distance(atMost(10.0)) }) { separator { content(", ") } }
+}
+
+internal fun nearestPlayerSample() {
+    nearestPlayer { distance(atMost(10.0)) }
+}
+
+internal fun allPlayersSample() {
+    allPlayers { tag("admin") }
+}
+
+internal fun entitiesSample() {
+    entities {
+        type("armor_stand")
+        distance(atMost(10.0))
+        sort(nearest)
+        limit(1)
+        tag("display")
+    }
+}
+
+internal fun entitySelectorScopeSample() {
+    entities {
+        type("armor_stand")
+        distance(atMost(10.0))
+        sort(nearest)
+        limit(1)
+        tag("display")
+    }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/style/StyleSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/style/StyleSamples.kt
@@ -1,0 +1,32 @@
+package io.github.lmliam.kotventure.core.style
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.text.text
+import net.kyori.adventure.text.format.Style
+
+internal fun styleSample() {
+    val heading =
+        style {
+        color(gold)
+        bold()
+    }
+    val title = text("Welcome") { style(heading) }
+}
+
+internal fun styledSample() {
+    val heading =
+        style {
+        color(gold)
+        bold()
+    }
+    val highlighted = component { text("important") } styled heading
+}
+
+internal fun styleScopeSample() {
+    style {
+        color(gold)
+        bold()
+        italic(false)
+    }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/style/StyleSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/style/StyleSamples.kt
@@ -8,18 +8,18 @@ import net.kyori.adventure.text.format.Style
 internal fun styleSample() {
     val heading =
         style {
-        color(gold)
-        bold()
-    }
+            color(gold)
+            bold()
+        }
     val title = text("Welcome") { style(heading) }
 }
 
 internal fun styledSample() {
     val heading =
         style {
-        color(gold)
-        bold()
-    }
+            color(gold)
+            bold()
+        }
     val highlighted = component { text("important") } styled heading
 }
 

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/text/ComponentSequenceSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/text/ComponentSequenceSamples.kt
@@ -1,0 +1,8 @@
+package io.github.lmliam.kotventure.core.text
+
+import net.kyori.adventure.text.TextComponent
+
+internal fun componentSequenceSample() {
+    val root = text("Hello")
+    val mentionsAlex = root.asSequence().any { it is TextComponent && "Alex" in it.content() }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/text/JoinSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/text/JoinSamples.kt
@@ -1,0 +1,9 @@
+package io.github.lmliam.kotventure.core.text
+
+internal fun joinArraySample() {
+    val list = arrayOf(text("a"), text("b"), text("c")).join { separator(text(", ")) }
+}
+
+internal fun joinIterableSample() {
+    val list = listOf(text("a"), text("b")).join { separator(text(", ")) }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/text/TextSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/text/TextSamples.kt
@@ -1,0 +1,11 @@
+package io.github.lmliam.kotventure.core.text
+
+import io.github.lmliam.kotventure.core.color.gold
+
+internal fun textSample() {
+    val greeting =
+        text("Hello") {
+        color(gold)
+        bold()
+    }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/text/TextSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/text/TextSamples.kt
@@ -5,7 +5,7 @@ import io.github.lmliam.kotventure.core.color.gold
 internal fun textSample() {
     val greeting =
         text("Hello") {
-        color(gold)
-        bold()
-    }
+            color(gold)
+            bold()
+        }
 }

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/theme/ThemeSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/theme/ThemeSamples.kt
@@ -1,0 +1,15 @@
+package io.github.lmliam.kotventure.core.theme
+
+import io.github.lmliam.kotventure.core.color.hex
+import net.kyori.adventure.text.format.Style
+
+internal fun themeSample() {
+    object : Theme("brand") {
+        val primary = hex("#5865F2")
+
+        val header: Style by style {
+            color(primary)
+            bold()
+        }
+    }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableSamples.kt
@@ -3,7 +3,7 @@ package io.github.lmliam.kotventure.core.translatable
 internal fun translatableSample() {
     val died =
         translatable("death.attack.player") {
-        arg { content("Alex") }
-        fallback("Alex was slain")
-    }
+            arg { content("Alex") }
+            fallback("Alex was slain")
+        }
 }

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/translatable/TranslatableSamples.kt
@@ -1,0 +1,9 @@
+package io.github.lmliam.kotventure.core.translatable
+
+internal fun translatableSample() {
+    val died =
+        translatable("death.attack.player") {
+        arg { content("Alex") }
+        fallback("Alex was slain")
+    }
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
@@ -8,9 +8,7 @@ import net.kyori.adventure.text.Component
 /**
  * Parses MiniMessage markup into a component with Adventure's default parser.
  *
- * ```kotlin
- * val greeting = mini("<gold>Welcome <bold>back</bold>!")
- * ```
+ * @sample io.github.lmliam.kotventure.minimessage.miniSample
  *
  * @param input the MiniMessage string to parse.
  */
@@ -33,12 +31,7 @@ public fun miniToDsl(input: String): String = MiniMessageToDslWriter.write(mini(
 /**
  * Parses MiniMessage markup into a component, resolving custom placeholder tags configured in [init].
  *
- * ```kotlin
- * val line = mini("<greeting> <player>!") {
- *     parsed("greeting", "<gold>Welcome")
- *     unparsed("player", playerName)
- * }
- * ```
+ * @sample io.github.lmliam.kotventure.minimessage.miniWithPlaceholdersSample
  *
  * @param input the MiniMessage string to parse.
  * @param init registers the placeholder resolvers the markup may reference.

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/template/MiniTemplate.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/template/MiniTemplate.kt
@@ -14,17 +14,7 @@ import io.github.lmliam.kotventure.minimessage.placeholder.placeholder as create
  * Subclass and declare each placeholder as a property; rendering invokes the template and binds every
  * placeholder with the [bind][MiniTemplateBindingScope.bind] infix function:
  *
- * ```kotlin
- * object WelcomeTemplate : MiniTemplate("<gold>Welcome <player>, <count> new messages</gold>") {
- *     val player = placeholder<Component>("player")
- *     val count = placeholder<Int>("count")
- * }
- *
- * val forAlex = WelcomeTemplate {
- *     player bind component { text("Alex") }
- *     count bind 3
- * }
- * ```
+ * @sample io.github.lmliam.kotventure.minimessage.template.miniTemplateRenderSample
  *
  * @param markup the MiniMessage markup string this template renders; must not be blank.
  * @throws IllegalArgumentException when [markup] is blank.

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/MiniMessageDiagnostic.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/MiniMessageDiagnostic.kt
@@ -1,5 +1,6 @@
 package io.github.lmliam.kotventure.minimessage.validation
 
+import io.github.lmliam.kotventure.minimessage.validate
 import net.kyori.adventure.text.minimessage.ParsingException
 
 /**
@@ -13,7 +14,7 @@ public sealed interface MiniMessageDiagnostic {
      *
      * @property message Human-readable description from Adventure's parser. Prefers
      *   [ParsingException.detailMessage] (no location noise); falls back to
-     *   [ParsingException.getMessage] if `detailMessage` is null.
+     *   [ParsingException.message] if `detailMessage` is null.
      * @property startIndex Start index into the original input string, or [LOCATION_UNKNOWN] when
      *   Adventure did not report a source position.
      * @property endIndex End index into the original input string, or [LOCATION_UNKNOWN] when

--- a/modules/minimessage/src/samples/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageSamples.kt
+++ b/modules/minimessage/src/samples/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageSamples.kt
@@ -8,7 +8,7 @@ internal fun miniWithPlaceholdersSample() {
     val playerName = "Alex"
     val line =
         mini("<greeting> <player>!") {
-        parsed("greeting", "<gold>Welcome")
-        unparsed("player", playerName)
-    }
+            parsed("greeting", "<gold>Welcome")
+            unparsed("player", playerName)
+        }
 }

--- a/modules/minimessage/src/samples/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageSamples.kt
+++ b/modules/minimessage/src/samples/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageSamples.kt
@@ -1,0 +1,14 @@
+package io.github.lmliam.kotventure.minimessage
+
+internal fun miniSample() {
+    val greeting = mini("<gold>Welcome <bold>back</bold>!")
+}
+
+internal fun miniWithPlaceholdersSample() {
+    val playerName = "Alex"
+    val line =
+        mini("<greeting> <player>!") {
+        parsed("greeting", "<gold>Welcome")
+        unparsed("player", playerName)
+    }
+}

--- a/modules/minimessage/src/samples/kotlin/io/github/lmliam/kotventure/minimessage/template/MiniTemplateSamples.kt
+++ b/modules/minimessage/src/samples/kotlin/io/github/lmliam/kotventure/minimessage/template/MiniTemplateSamples.kt
@@ -1,0 +1,19 @@
+package io.github.lmliam.kotventure.minimessage.template
+
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.text.text
+import net.kyori.adventure.text.Component
+
+internal fun miniTemplateRenderSample() {
+    val template =
+        object : MiniTemplate("<gold>Welcome <player>, <count> new messages</gold>") {
+        val player = placeholder<Component>("player")
+        val count = placeholder<Int>("count")
+    }
+
+    val forAlex =
+        template {
+        player bind component { text("Alex") }
+        count bind 3
+    }
+}

--- a/modules/minimessage/src/samples/kotlin/io/github/lmliam/kotventure/minimessage/template/MiniTemplateSamples.kt
+++ b/modules/minimessage/src/samples/kotlin/io/github/lmliam/kotventure/minimessage/template/MiniTemplateSamples.kt
@@ -7,13 +7,13 @@ import net.kyori.adventure.text.Component
 internal fun miniTemplateRenderSample() {
     val template =
         object : MiniTemplate("<gold>Welcome <player>, <count> new messages</gold>") {
-        val player = placeholder<Component>("player")
-        val count = placeholder<Int>("count")
-    }
+            val player = placeholder<Component>("player")
+            val count = placeholder<Int>("count")
+        }
 
     val forAlex =
         template {
-        player bind component { text("Alex") }
-        count bind 3
-    }
+            player bind component { text("Alex") }
+            count bind 3
+        }
 }

--- a/modules/serializer/build.gradle
+++ b/modules/serializer/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     implementation kotventureDependencies."adventure-text-serializer-legacy"
     implementation kotventureDependencies."adventure-text-serializer-plain"
 
+    samplesImplementation project(':core')
+
     testImplementation project(':core')
     testImplementation project(':test')
 }

--- a/modules/serializer/src/main/kotlin/io/github/lmliam/kotventure/serializer/MiniMessageSerializer.kt
+++ b/modules/serializer/src/main/kotlin/io/github/lmliam/kotventure/serializer/MiniMessageSerializer.kt
@@ -6,9 +6,7 @@ import net.kyori.adventure.text.minimessage.MiniMessage
 /**
  * Serializes this component to MiniMessage markup using Adventure's default serializer.
  *
- * ```kotlin
- * val markup = component.toMiniMessage() // e.g. "<gold>Welcome"
- * ```
+ * @sample io.github.lmliam.kotventure.serializer.toMiniMessageSample
  *
  * The inverse of `mini(...)`. Note the round trip is not always identical, as distinct components can
  * serialize to equivalent markup.

--- a/modules/serializer/src/samples/kotlin/io/github/lmliam/kotventure/serializer/SerializerSamples.kt
+++ b/modules/serializer/src/samples/kotlin/io/github/lmliam/kotventure/serializer/SerializerSamples.kt
@@ -1,0 +1,9 @@
+package io.github.lmliam.kotventure.serializer
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.text.text
+
+internal fun toMiniMessageSample() {
+    val component = text("Welcome") { color(gold) }
+    val markup = component.toMiniMessage()
+}

--- a/modules/test-snapshot/build.gradle
+++ b/modules/test-snapshot/build.gradle
@@ -6,4 +6,6 @@ dependencies {
 
     implementation project(':serializer')
     implementation kotventureDependencies."adventure-text-serializer-gson"
+
+    samplesImplementation project(':core')
 }

--- a/modules/test-snapshot/src/main/kotlin/io/github/lmliam/kotventure/test/snapshot/SnapshotAssertions.kt
+++ b/modules/test-snapshot/src/main/kotlin/io/github/lmliam/kotventure/test/snapshot/SnapshotAssertions.kt
@@ -11,9 +11,7 @@ import net.kyori.adventure.text.Component
  * environment variable — it instead writes the current component as the snapshot and passes, so a new or
  * intentionally-changed snapshot can be regenerated. Only this assertion writes; [matchSnapshot] never does.
  *
- * ```kotlin
- * component shouldMatchSnapshot "welcome-message"
- * ```
+ * @sample io.github.lmliam.kotventure.test.snapshot.shouldMatchSnapshotSample
  */
 public infix fun Component.shouldMatchSnapshot(name: String): Component = assertSnapshot(name, compact = false)
 

--- a/modules/test-snapshot/src/samples/kotlin/io/github/lmliam/kotventure/test/snapshot/SnapshotSamples.kt
+++ b/modules/test-snapshot/src/samples/kotlin/io/github/lmliam/kotventure/test/snapshot/SnapshotSamples.kt
@@ -1,0 +1,9 @@
+package io.github.lmliam.kotventure.test.snapshot
+
+import io.github.lmliam.kotventure.core.text.text
+import net.kyori.adventure.text.Component
+
+internal fun shouldMatchSnapshotSample() {
+    val component: Component = text("Welcome")
+    component shouldMatchSnapshot "welcome-message"
+}


### PR DESCRIPTION
## Summary
- Adds Dokka 2.2.0 with a shared `samples` source set per module (`gradle/samples.gradle`) so `@sample` KDoc tags resolve to compiled functions
- Converts all fenced ` ```kotlin ` KDoc examples across core, minimessage, serializer, and test-snapshot into compiled sample functions, ensuring examples are type-checked and can't drift from the API
- Samples compile against `main` output but are excluded from publication and Kover instrumentation

## Test plan
- [x] `./gradlew build` passes (compile + test + lint + coverage)
- [x] `./gradlew :core:dokkaGenerate` succeeds with no unresolved `@sample` warnings
- [x] Generated HTML contains rendered sample content (spot-checked `hex.html`)
- [x] No fenced ` ```kotlin ` blocks remain in any module's main source
- [x] Coverage thresholds still met (samples excluded from Kover)

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)