### PR TITLE
feat(core): add a string-literal text overload in component scope

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -96,7 +96,8 @@ driver schedules/executes frames**.
 // ── Construction ───────────────────────────────────────────────
 val msg = component {
     text("Hello ") { color(AQUA); bold() }
-    text("world") { color(hex("#FF00AA")) }
+    "world" { color(hex("#FF00AA")) }        // string-literal sugar for text("world") { … }
+    +"!"                                      // bare literal → plain text child
     newline()
     translatable("item.minecraft.diamond") { fallback("Diamond") }
     keybind("key.jump") { color(YELLOW) }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Text.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/Text.kt
@@ -52,3 +52,33 @@ public fun ComponentScope.text(
 public fun ComponentScope.text(init: TextScope.() -> Unit) {
     append(buildTextComponent(init))
 }
+
+/**
+ * Appends a styled text child to the surrounding component, using the string literal as its content.
+ *
+ * This is the string-literal shorthand for [text]: `"Hello" { color(gold) }` is exactly
+ * `text("Hello") { color(gold) }`, letting the content lead the call inside a `component { }` block. For plain
+ * text with no styling, prefer the [unaryPlus] form (`+"Hello"`); [init] is required here, so `"Hello"()` does
+ * not compile.
+ *
+ * @sample io.github.lmliam.kotventure.core.text.stringInvokeSample
+ *
+ * @param init styles the child and appends any of its own children.
+ */
+context(scope: ComponentScope)
+public operator fun String.invoke(init: TextScope.() -> Unit) {
+    scope.text(this, init)
+}
+
+/**
+ * Appends a plain text child to the surrounding component, using the string literal as its content.
+ *
+ * This is the documented shorthand for an unstyled text child inside a `component { }` block: `+"Hello"` is
+ * exactly `text("Hello")`. Reach for the [invoke] form (`"Hello" { ... }`) when the child needs styling.
+ *
+ * @sample io.github.lmliam.kotventure.core.text.stringUnaryPlusSample
+ */
+context(scope: ComponentScope)
+public operator fun String.unaryPlus() {
+    scope.text(this)
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/text/TextSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/text/TextSamples.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.kotventure.core.text
 
 import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.component.component
 
 internal fun textSample() {
     val greeting =
@@ -8,4 +9,19 @@ internal fun textSample() {
             color(gold)
             bold()
         }
+}
+
+internal fun stringInvokeSample() {
+    component {
+        "Hello" {
+            color(gold)
+            bold()
+        }
+    }
+}
+
+internal fun stringUnaryPlusSample() {
+    component {
+        +"Hello"
+    }
 }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/StringLiteralTextDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/StringLiteralTextDslTest.kt
@@ -1,0 +1,104 @@
+package io.github.lmliam.kotventure.core.text
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+
+// The string-literal operators are built here, outside the StringSpec lambda, because Kotest's own
+// `String.invoke` test-declaration operator would otherwise shadow the `"text" { }` sugar at the call site.
+// This is a test-harness collision only; production call sites have no competing `String.invoke`.
+private fun styledChild(): Component =
+    component {
+        "Hello" {
+            color(gold)
+        }
+    }
+
+private fun plainChild(): Component =
+    component {
+        +"Hello"
+    }
+
+private fun nestedChildren(): Component =
+    component {
+        "outer" {
+            +"inner"
+        }
+    }
+
+private fun siblingChildren(): Component =
+    component {
+        +"first"
+        "second" {
+            color(gold)
+        }
+    }
+
+private fun styledViaSugar(): Component = component { "Hello" { color(gold) } }
+
+private fun styledViaText(): Component = component { text("Hello") { color(gold) } }
+
+class StringLiteralTextDslTest :
+    StringSpec(
+        {
+            "invoke appends a styled text child" {
+                val message = styledChild()
+
+                message shouldHaveChildCount 1
+                message.childAt(0) shouldContainText "Hello"
+                message.childAt(0) shouldHaveColor gold
+            }
+
+            "unary plus appends a plain text child" {
+                val message = plainChild()
+
+                message shouldHaveChildCount 1
+                message.childAt(0) shouldContainText "Hello"
+            }
+
+            "invoke nests further children under the styled child's scope" {
+                val message = nestedChildren()
+
+                message shouldHaveChildCount 1
+                val outer = message.childAt(0)
+                outer shouldContainText "outer"
+                outer shouldHaveChildCount 1
+                outer.childAt(0) shouldContainText "inner"
+            }
+
+            "the sugar appends siblings in declaration order" {
+                val message = siblingChildren()
+
+                message shouldHaveChildCount 2
+                message.childAt(0) shouldContainText "first"
+                message.childAt(1) shouldContainText "second"
+                message.childAt(1) shouldHaveColor gold
+            }
+
+            "invoke is exactly the text(value) child entry point" {
+                styledViaSugar() shouldBe styledViaText()
+            }
+
+            "the string-literal sugar is unavailable outside a component scope" {
+                assertDoesNotCompile(
+                    fileName = "StringSugarScopeTest.kt",
+                    source =
+                        """
+                        import io.github.lmliam.kotventure.core.text.unaryPlus
+
+                        fun shouldNotCompile() {
+                            +"orphaned"
+                        }
+                        """.trimIndent(),
+                    "No context argument for 'scope: ComponentScope' found.",
+                )
+            }
+        },
+    )


### PR DESCRIPTION
## Summary

Adds string-literal sugar so a bare string can open a text child inside a `component { }` block, layered over the existing `ComponentScope.text(...)` entry point with no duplicate logic.

```kotlin
component {
    "Hello" { color(gold) }   // styled child
    +"world"                  // plain child
}
```

## Related Issues

Closes #174

## DSL Impact

Two new `context(ComponentScope)` operators in the `core.text` feature package:

- `operator fun String.invoke(init: TextScope.() -> Unit)` — appends a **styled** text child; exactly `text("…") { … }`.
- `operator fun String.unaryPlus()` — appends a **plain** text child; exactly `text("…")`.

Both forward straight through `ComponentScope.text(...)`. Because they are `context(ComponentScope)` extensions, the sugar is available in **every** component scope (root, nested `text { }`, hover content, etc.) — consistent with the existing `ComponentScope.text` extension — and is a compile error outside one.

## Rationale

`"text" { … }` lets the content lead the call, which reads more naturally than `text("text") { … }` for the common case of a literal child. Keeping it a thin forward over `text(...)` means there is one implementation and one mental model.

**No-block shape — the single chosen way:** `invoke` requires its block, so `"…"()` does not compile; the documented form for an unstyled child is `+"…"` (the kotlinx.html convention). One syntax per use case: `+"…"` for plain, `"…" { … }` for styled.

**Why `context(...)` and not a member on `ComponentScope`:** the context-parameter extension keeps the clean `text → component` layering (no `component → text` back-coupling) and is the more idiomatic Kotlin. A member operator would win overload resolution against Kotest's own `String.invoke` inside a `StringSpec` lambda, but that is a test-harness collision, not a production concern — so the tests build their components in private helpers rather than bending the API around the harness.

## Testing

New `StringLiteralTextDslTest` (Kotest, dogfooding the component matchers) covering:

- `invoke` appends a styled child; `unaryPlus` appends a plain child.
- `invoke` nests further children under the styled child's scope.
- Siblings append in declaration order.
- Parity: `"Hello" { color(gold) }` is structurally equal to `text("Hello") { color(gold) }`.
- Scoping: the sugar is a compile error outside a `ComponentScope` (asserted via `assertDoesNotCompile`, matching `No context argument for 'scope: ComponentScope' found.`).

`./gradlew build` is green (compile, tests, ktlint, spotless, kover ≥ 85%, dokka + `@sample` link checks).

## Checklist

- [x] Linked related issue
- [x] Updated relevant `/docs` pages (DESIGN.md canonical surface; KDoc + compiled `@sample`s)
- [x] Verified examples build and run
