### PR TITLE
feat(core): item hover data-component DSL block

### DIFF
--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverBuilder.kt
@@ -5,7 +5,6 @@ import io.github.lmliam.kotventure.core.component.component
 import io.github.lmliam.kotventure.core.text.TextScope
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.ComponentLike
-import net.kyori.adventure.text.event.DataComponentValue
 import net.kyori.adventure.text.event.HoverEvent
 import java.util.UUID
 import io.github.lmliam.kotventure.core.text.text as textComponent
@@ -31,8 +30,9 @@ internal class HoverBuilder : HoverContentScope {
     override fun item(
         key: Key,
         count: Int,
-        dataComponents: Map<Key, DataComponentValue>,
+        components: ItemDataComponentScope.() -> Unit,
     ) {
+        val dataComponents = ItemDataComponentBuilder().apply(components).build()
         set(HoverEvent.showItem(key, requireShowItemCount(count), dataComponents))
     }
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverContentScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/HoverContentScope.kt
@@ -6,7 +6,6 @@ import io.github.lmliam.kotventure.core.text.TextScope
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.key.Keyed
 import net.kyori.adventure.text.ComponentLike
-import net.kyori.adventure.text.event.DataComponentValue
 import java.util.UUID
 
 /**
@@ -33,27 +32,27 @@ public interface HoverContentScope {
     public fun text(init: ComponentScope.() -> Unit)
 
     /**
-     * Selects an item hover payload from [key], [count], and typed [dataComponents].
+     * Selects an item hover payload from [key] and [count], with its data components declared by [components].
      *
      * @throws IllegalArgumentException when [count] is negative.
      */
     public fun item(
         key: Key,
         count: Int = 1,
-        dataComponents: Map<Key, DataComponentValue> = emptyMap(),
+        components: ItemDataComponentScope.() -> Unit = {},
     )
 
     /**
-     * Selects an item hover payload from [item], [count], and typed [dataComponents].
+     * Selects an item hover payload from [item] and [count], with its data components declared by [components].
      *
      * @throws IllegalArgumentException when [count] is negative.
      */
     public fun item(
         item: Keyed,
         count: Int = 1,
-        dataComponents: Map<Key, DataComponentValue> = emptyMap(),
+        components: ItemDataComponentScope.() -> Unit = {},
     ) {
-        item(item.key(), count, dataComponents)
+        item(item.key(), count, components)
     }
 
     /**

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ItemDataComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ItemDataComponentBuilder.kt
@@ -1,0 +1,30 @@
+package io.github.lmliam.kotventure.core.event
+
+import io.github.lmliam.kotventure.core.nbt.NbtCompoundScope
+import io.github.lmliam.kotventure.core.nbt.nbt
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.event.DataComponentValue
+
+internal class ItemDataComponentBuilder : ItemDataComponentScope {
+    private val components = LinkedHashMap<Key, DataComponentValue>()
+
+    override fun component(
+        key: Key,
+        init: NbtCompoundScope.() -> Unit,
+    ) {
+        components[key] = nbt(init)
+    }
+
+    override fun component(
+        key: Key,
+        value: DataComponentValue,
+    ) {
+        components[key] = value
+    }
+
+    override fun removed(key: Key) {
+        components[key] = DataComponentValue.removed()
+    }
+
+    internal fun build(): Map<Key, DataComponentValue> = components.toMap()
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ItemDataComponentScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/event/ItemDataComponentScope.kt
@@ -1,0 +1,36 @@
+package io.github.lmliam.kotventure.core.event
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.core.nbt.NbtCompoundScope
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.event.DataComponentValue
+
+/**
+ * Scope for declaring the data components carried by an item hover payload.
+ *
+ * Opened by the trailing lambda of [HoverContentScope.item]. Each call adds the component identified by
+ * its [Key]; a later call for the same key replaces the earlier one.
+ */
+@KotventureDslMarker
+public interface ItemDataComponentScope {
+    /**
+     * Adds the data component at [key], with its value authored as compound NBT via [init].
+     */
+    public fun component(
+        key: Key,
+        init: NbtCompoundScope.() -> Unit,
+    )
+
+    /**
+     * Adds the data component at [key] from a pre-built [value], such as a raw `nbt("...")` holder.
+     */
+    public fun component(
+        key: Key,
+        value: DataComponentValue,
+    )
+
+    /**
+     * Marks the data component at [key] for removal, mirroring the top-level `removed()` marker.
+     */
+    public fun removed(key: Key)
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/HoverEventDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/event/HoverEventDslTest.kt
@@ -2,6 +2,7 @@ package io.github.lmliam.kotventure.core.event
 
 import io.github.lmliam.kotventure.core.component.component
 import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.nbt.nbt
 import io.github.lmliam.kotventure.core.style.style
 import io.github.lmliam.kotventure.core.text.text
 import io.github.lmliam.kotventure.test.text.childAt
@@ -16,7 +17,6 @@ import io.github.lmliam.kotventure.test.text.shouldNotHaveHoverEvent
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import net.kyori.adventure.key.Key
 import net.kyori.adventure.key.Keyed
 import net.kyori.adventure.nbt.api.BinaryTagHolder
 import net.kyori.adventure.text.Component
@@ -42,23 +42,62 @@ class HoverEventDslTest :
                 value shouldHaveColor NamedTextColor.AQUA
             }
 
-            "builds reusable item hover events with typed data components" {
-                val dataComponents =
-                    mapOf<Key, DataComponentValue>(
-                        key("minecraft", "custom_data") to BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
-                    )
+            "builds reusable item hover events with data components from a block" {
                 val event =
                     hover {
-                        item(
-                            key = key("minecraft", "diamond_sword"),
-                            count = 2,
-                            dataComponents = dataComponents,
-                        )
+                        item(key("minecraft", "diamond_sword"), count = 2) {
+                            component(key("minecraft", "custom_data")) { "kotventure" eq 1.toByte() }
+                        }
                     }
 
                 event.action() shouldBe HoverEvent.Action.SHOW_ITEM
                 event.value() shouldBe
-                        HoverEvent.ShowItem.showItem(key("minecraft", "diamond_sword"), 2, dataComponents)
+                        HoverEvent.ShowItem.showItem(
+                            key("minecraft", "diamond_sword"),
+                            2,
+                            mapOf(
+                                key("minecraft", "custom_data") to BinaryTagHolder.binaryTagHolder("{kotventure:1b}"),
+                            ),
+                        )
+            }
+
+            "builds item hover data components from pre-built values and removal markers" {
+                val event =
+                    hover {
+                        item(key("minecraft", "diamond_sword")) {
+                            component(key("minecraft", "damage"), nbt("{value:5b}"))
+                            removed(key("minecraft", "enchantments"))
+                        }
+                    }
+
+                event.value() shouldBe
+                        HoverEvent.ShowItem.showItem(
+                            key("minecraft", "diamond_sword"),
+                            1,
+                            mapOf(
+                                key("minecraft", "damage") to BinaryTagHolder.binaryTagHolder("{value:5b}"),
+                                key("minecraft", "enchantments") to DataComponentValue.removed(),
+                            ),
+                        )
+            }
+
+            "replaces an item data component when its key is declared twice" {
+                val event =
+                    hover {
+                        item(key("minecraft", "diamond_sword")) {
+                            component(key("minecraft", "custom_data")) { "kotventure" eq 1.toByte() }
+                            component(key("minecraft", "custom_data")) { "kotventure" eq 2.toByte() }
+                        }
+                    }
+
+                event.value() shouldBe
+                        HoverEvent.ShowItem.showItem(
+                            key("minecraft", "diamond_sword"),
+                            1,
+                            mapOf(
+                                key("minecraft", "custom_data") to BinaryTagHolder.binaryTagHolder("{kotventure:2b}"),
+                            ),
+                        )
             }
 
             "builds reusable item hover events from keyed values and permits zero counts" {

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslEvents.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslEvents.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.kotventure.minimessage.conversion
 
 import net.kyori.adventure.key.Key
+import net.kyori.adventure.nbt.api.BinaryTagHolder
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.event.DataComponentValue
@@ -37,32 +38,54 @@ internal fun KotlinSourceBuilder.appendHoverEvent(event: HoverEvent<*>) {
 
 private fun KotlinSourceBuilder.appendShowItem(item: HoverEvent.ShowItem) {
     val itemKey = keyLiteral(item.item())
+    val components = item.dataComponents()
     val arguments =
         buildList {
             add { line("key = $itemKey") }
             if (item.count() != 1) add { line("count = ${item.count()}") }
-            if (item.dataComponents().isNotEmpty()) add { appendDataComponents(item.dataComponents()) }
         }
 
-    if (arguments.size == 1) {
-        line("item($itemKey)")
-        return
+    when {
+        components.isEmpty() && arguments.size == 1 -> line("item($itemKey)")
+        components.isEmpty() -> {
+            openArguments("item(", arguments)
+            line(")")
+        }
+        arguments.size == 1 -> block("item($itemKey)") { appendDataComponents(components) }
+        else -> {
+            openArguments("item(", arguments)
+            block(")") { appendDataComponents(components) }
+        }
     }
-
-    openArguments("item(", arguments)
-    line(")")
 }
 
-private fun KotlinSourceBuilder.appendDataComponents(dataComponents: Map<Key, DataComponentValue>) {
-    val entries: List<() -> Unit> =
-        dataComponents.entries
-            .sortedBy { (key, _) -> key.asString() }
-            .map { (key, value) ->
-                { line("${keyLiteral(key)} to ${dataComponentValueLiteral(value)}") }
-            }
+private fun KotlinSourceBuilder.appendDataComponents(components: Map<Key, DataComponentValue>) {
+    components.entries
+        .sortedBy { (key, _) -> key.asString() }
+        .forEach { (key, value) -> appendDataComponent(keyLiteral(key), value) }
+}
 
-    openArguments("dataComponents = mapOf(", entries)
-    line(")")
+private fun KotlinSourceBuilder.appendDataComponent(
+    keyLiteral: String,
+    value: DataComponentValue,
+) {
+    when (value) {
+        is DataComponentValue.Removed -> line("removed($keyLiteral)")
+        is BinaryTagHolder -> appendNbtComponent(keyLiteral, value.string())
+        is DataComponentValue.TagSerializable -> appendNbtComponent(keyLiteral, value.asBinaryTag().string())
+        else -> conversionError("miniToDsl cannot represent data component value ${value::class.qualifiedName}.")
+    }
+}
+
+private fun KotlinSourceBuilder.appendNbtComponent(
+    keyLiteral: String,
+    snbt: String,
+) {
+    when (val body = snbtToDslBody(snbt)) {
+        null -> line("component($keyLiteral, nbt(\"${escapeKotlinString(snbt)}\"))")
+        "" -> line("component($keyLiteral) { }")
+        else -> line("component($keyLiteral) { $body }")
+    }
 }
 
 private fun KotlinSourceBuilder.appendShowEntity(entity: HoverEvent.ShowEntity) {

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslLiterals.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslLiterals.kt
@@ -1,8 +1,6 @@
 package io.github.lmliam.kotventure.minimessage.conversion
 
 import net.kyori.adventure.key.Key
-import net.kyori.adventure.nbt.api.BinaryTagHolder
-import net.kyori.adventure.text.event.DataComponentValue
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.ShadowColor
 import net.kyori.adventure.text.format.TextColor
@@ -104,22 +102,6 @@ private fun playerHeadLiteral(contents: PlayerHeadObjectContents): String {
     val hat = if (contents.hat()) null else "hat = ${contents.hat()}"
     return "head(${(skinSources + listOfNotNull(hat)).joinToString(", ")})"
 }
-
-/** Renders [value] as the Kotlin DSL expression that reconstructs it. */
-internal fun dataComponentValueLiteral(value: DataComponentValue): String =
-    when (value) {
-        is BinaryTagHolder ->
-            snbtToDslExpression(value.string())
-                ?: "nbt(\"${escapeKotlinString(value.string())}\")"
-
-        is DataComponentValue.TagSerializable -> {
-            val snbt = value.asBinaryTag().string()
-            snbtToDslExpression(snbt) ?: "nbt(\"${escapeKotlinString(snbt)}\")"
-        }
-
-        is DataComponentValue.Removed -> "removed()"
-        else -> conversionError("miniToDsl cannot represent data component value ${value::class.qualifiedName}.")
-    }
 
 /** Escapes [value] for embedding inside a double-quoted Kotlin string literal. */
 internal fun escapeKotlinString(value: String): String =

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDsl.kt
@@ -17,7 +17,8 @@ import net.kyori.adventure.nbt.TagStringIO
 import java.io.IOException
 
 /**
- * Converts an SNBT compound string into a Kotlin DSL expression using `nbt { ... }`.
+ * Converts an SNBT compound string into the body of a Kotventure NBT DSL block: the `"key" eq value`
+ * calls that go inside `nbt { ... }` or `component(key) { ... }`. An empty compound renders to `""`.
  *
  * The SNBT is parsed with Adventure's [TagStringIO], then each entry is rendered to its DSL form.
  * Keys are emitted in alphabetical order so the output is deterministic and JDK-independent (NBT
@@ -27,15 +28,14 @@ import java.io.IOException
  * DSL cannot express (an empty `TAG_List`, which carries no element type), signalling the caller to
  * fall back to `nbt("raw")`.
  */
-internal fun snbtToDslExpression(snbt: String): String? {
+internal fun snbtToDslBody(snbt: String): String? {
     val compound =
         try {
             TagStringIO.tagStringIO().asCompound(snbt)
         } catch (e: IOException) {
             return null
         }
-    val body = renderCompoundBody(compound) ?: return null
-    return if (body.isEmpty()) "nbt { }" else "nbt { $body }"
+    return renderCompoundBody(compound)
 }
 
 private fun renderCompoundBody(compound: CompoundBinaryTag): String? {

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslEventRenderingTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslEventRenderingTest.kt
@@ -272,6 +272,39 @@ class MiniMessageToDslEventRenderingTest :
                     )
                 }
 
+                test("round-trips show item hover data components with a non-default count") {
+                    assertGoldenRoundTrip(
+                        expectedSource =
+                            """
+                        component {
+                            text("Loot data") {
+                                hover {
+                                    item(
+                                        key = key("minecraft", "diamond_sword"),
+                                        count = 2
+                                    ) {
+                                        component(key("minecraft", "custom_data")) { "kotventure" eq 1.toByte() }
+                                    }
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                        expectedComponent =
+                            component {
+                                text("Loot data") {
+                                    hover {
+                                        item(
+                                            key = key("minecraft", "diamond_sword"),
+                                            count = 2,
+                                        ) {
+                                            component(key("minecraft", "custom_data"), nbt("{kotventure:1b}"))
+                                        }
+                                    }
+                                }
+                            },
+                    )
+                }
+
                 test("emits show item data components in a stable key order") {
                     val loot =
                         component {

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslEventRenderingTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslEventRenderingTest.kt
@@ -3,7 +3,6 @@ package io.github.lmliam.kotventure.minimessage
 import io.github.lmliam.kotventure.core.color.aqua
 import io.github.lmliam.kotventure.core.color.gold
 import io.github.lmliam.kotventure.core.component.component
-import io.github.lmliam.kotventure.core.event.removed
 import io.github.lmliam.kotventure.core.key.key
 import io.github.lmliam.kotventure.core.nbt.nbt
 import io.github.lmliam.kotventure.core.text.text
@@ -253,12 +252,9 @@ class MiniMessageToDslEventRenderingTest :
                         component {
                             text("Loot data") {
                                 hover {
-                                    item(
-                                        key = key("minecraft", "diamond_sword"),
-                                        dataComponents = mapOf(
-                                            key("minecraft", "custom_data") to nbt { "kotventure" eq 1.toByte() }
-                                        )
-                                    )
+                                    item(key("minecraft", "diamond_sword")) {
+                                        component(key("minecraft", "custom_data")) { "kotventure" eq 1.toByte() }
+                                    }
                                 }
                             }
                         }
@@ -267,13 +263,9 @@ class MiniMessageToDslEventRenderingTest :
                             component {
                                 text("Loot data") {
                                     hover {
-                                        item(
-                                            key = key("minecraft", "diamond_sword"),
-                                            dataComponents =
-                                                mapOf(
-                                                    key("minecraft", "custom_data") to nbt("{kotventure:1b}"),
-                                                ),
-                                        )
+                                        item(key("minecraft", "diamond_sword")) {
+                                            component(key("minecraft", "custom_data"), nbt("{kotventure:1b}"))
+                                        }
                                     }
                                 }
                             },
@@ -285,14 +277,10 @@ class MiniMessageToDslEventRenderingTest :
                         component {
                             text("Loot data") {
                                 hover {
-                                    item(
-                                        key = key("minecraft", "diamond_sword"),
-                                        dataComponents =
-                                            mapOf(
-                                                key("minecraft", "damage") to nbt("{value:5b}"),
-                                                key("minecraft", "custom_data") to nbt("{kotventure:1b}"),
-                                            ),
-                                    )
+                                    item(key("minecraft", "diamond_sword")) {
+                                        component(key("minecraft", "damage"), nbt("{value:5b}"))
+                                        component(key("minecraft", "custom_data"), nbt("{kotventure:1b}"))
+                                    }
                                 }
                             }
                         }
@@ -302,13 +290,10 @@ class MiniMessageToDslEventRenderingTest :
                     component {
                         text("Loot data") {
                             hover {
-                                item(
-                                    key = key("minecraft", "diamond_sword"),
-                                    dataComponents = mapOf(
-                                        key("minecraft", "custom_data") to nbt { "kotventure" eq 1.toByte() },
-                                        key("minecraft", "damage") to nbt { "value" eq 5.toByte() }
-                                    )
-                                )
+                                item(key("minecraft", "diamond_sword")) {
+                                    component(key("minecraft", "custom_data")) { "kotventure" eq 1.toByte() }
+                                    component(key("minecraft", "damage")) { "value" eq 5.toByte() }
+                                }
                             }
                         }
                     }
@@ -322,12 +307,9 @@ class MiniMessageToDslEventRenderingTest :
                         component {
                             text("Edge data") {
                                 hover {
-                                    item(
-                                        key = key("minecraft", "diamond_sword"),
-                                        dataComponents = mapOf(
-                                            key("minecraft", "custom_data") to nbt { "big" eq Int.MIN_VALUE; "huge" eq Long.MIN_VALUE; "small" eq (-5).toShort(); "tiny" eq (-5).toByte() }
-                                        )
-                                    )
+                                    item(key("minecraft", "diamond_sword")) {
+                                        component(key("minecraft", "custom_data")) { "big" eq Int.MIN_VALUE; "huge" eq Long.MIN_VALUE; "small" eq (-5).toShort(); "tiny" eq (-5).toByte() }
+                                    }
                                 }
                             }
                         }
@@ -336,16 +318,12 @@ class MiniMessageToDslEventRenderingTest :
                             component {
                                 text("Edge data") {
                                     hover {
-                                        item(
-                                            key = key("minecraft", "diamond_sword"),
-                                            dataComponents =
-                                                mapOf(
-                                                    key("minecraft", "custom_data") to
-                                                            nbt(
-                                                                "{big:-2147483648,huge:-9223372036854775808L,small:-5s,tiny:-5b}",
-                                                            ),
-                                                ),
-                                        )
+                                        item(key("minecraft", "diamond_sword")) {
+                                            component(
+                                                key("minecraft", "custom_data"),
+                                                nbt("{big:-2147483648,huge:-9223372036854775808L,small:-5s,tiny:-5b}"),
+                                            )
+                                        }
                                     }
                                 }
                             },
@@ -359,12 +337,9 @@ class MiniMessageToDslEventRenderingTest :
                         component {
                             text("Book") {
                                 hover {
-                                    item(
-                                        key = key("minecraft", "written_book"),
-                                        dataComponents = mapOf(
-                                            key("minecraft", "custom_data") to nbt { "pages" eq list("a", "b") }
-                                        )
-                                    )
+                                    item(key("minecraft", "written_book")) {
+                                        component(key("minecraft", "custom_data")) { "pages" eq list("a", "b") }
+                                    }
                                 }
                             }
                         }
@@ -373,13 +348,9 @@ class MiniMessageToDslEventRenderingTest :
                             component {
                                 text("Book") {
                                     hover {
-                                        item(
-                                            key = key("minecraft", "written_book"),
-                                            dataComponents =
-                                                mapOf(
-                                                    key("minecraft", "custom_data") to nbt("{pages:[\"a\",\"b\"]}"),
-                                                ),
-                                        )
+                                        item(key("minecraft", "written_book")) {
+                                            component(key("minecraft", "custom_data"), nbt("{pages:[\"a\",\"b\"]}"))
+                                        }
                                     }
                                 }
                             },
@@ -393,12 +364,9 @@ class MiniMessageToDslEventRenderingTest :
                         component {
                             text("Loot data") {
                                 hover {
-                                    item(
-                                        key = key("minecraft", "diamond_sword"),
-                                        dataComponents = mapOf(
-                                            key("minecraft", "custom_data") to nbt { "Lore" eq list({ "text" eq "L1" }, { "text" eq "L2" }) }
-                                        )
-                                    )
+                                    item(key("minecraft", "diamond_sword")) {
+                                        component(key("minecraft", "custom_data")) { "Lore" eq list({ "text" eq "L1" }, { "text" eq "L2" }) }
+                                    }
                                 }
                             }
                         }
@@ -407,14 +375,12 @@ class MiniMessageToDslEventRenderingTest :
                             component {
                                 text("Loot data") {
                                     hover {
-                                        item(
-                                            key = key("minecraft", "diamond_sword"),
-                                            dataComponents =
-                                                mapOf(
-                                                    key("minecraft", "custom_data") to
-                                                            nbt("{Lore:[{text:\"L1\"},{text:\"L2\"}]}"),
-                                                ),
-                                        )
+                                        item(key("minecraft", "diamond_sword")) {
+                                            component(
+                                                key("minecraft", "custom_data"),
+                                                nbt("{Lore:[{text:\"L1\"},{text:\"L2\"}]}"),
+                                            )
+                                        }
                                     }
                                 }
                             },
@@ -428,12 +394,9 @@ class MiniMessageToDslEventRenderingTest :
                         component {
                             text("Loot data") {
                                 hover {
-                                    item(
-                                        key = key("minecraft", "diamond_sword"),
-                                        dataComponents = mapOf(
-                                            key("minecraft", "custom_data") to nbt("{items:[]}")
-                                        )
-                                    )
+                                    item(key("minecraft", "diamond_sword")) {
+                                        component(key("minecraft", "custom_data"), nbt("{items:[]}"))
+                                    }
                                 }
                             }
                         }
@@ -442,14 +405,9 @@ class MiniMessageToDslEventRenderingTest :
                             component {
                                 text("Loot data") {
                                     hover {
-                                        item(
-                                            key = key("minecraft", "diamond_sword"),
-                                            dataComponents =
-                                                mapOf(
-                                                    key("minecraft", "custom_data") to
-                                                            nbt("{items:[]}"),
-                                                ),
-                                        )
+                                        item(key("minecraft", "diamond_sword")) {
+                                            component(key("minecraft", "custom_data"), nbt("{items:[]}"))
+                                        }
                                     }
                                 }
                             },
@@ -464,13 +422,9 @@ class MiniMessageToDslEventRenderingTest :
                         component {
                             text("Loot data") {
                                 hover {
-                                    item(
-                                        key = key("minecraft", "diamond_sword"),
-                                        dataComponents =
-                                            mapOf(
-                                                key("minecraft", "custom_data") to removed(),
-                                            ),
-                                    )
+                                    item(key("minecraft", "diamond_sword")) {
+                                        removed(key("minecraft", "custom_data"))
+                                    }
                                 }
                             }
                         }
@@ -480,12 +434,9 @@ class MiniMessageToDslEventRenderingTest :
                     component {
                         text("Loot data") {
                             hover {
-                                item(
-                                    key = key("minecraft", "diamond_sword"),
-                                    dataComponents = mapOf(
-                                        key("minecraft", "custom_data") to removed()
-                                    )
-                                )
+                                item(key("minecraft", "diamond_sword")) {
+                                    removed(key("minecraft", "custom_data"))
+                                }
                             }
                         }
                     }

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslStructuredComponentTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslStructuredComponentTest.kt
@@ -588,10 +588,9 @@ class MiniMessageToDslStructuredComponentTest :
                         component {
                             text("Loot") {
                                 hover {
-                                    item(
-                                        key = key("minecraft", "diamond_sword"),
-                                        dataComponents = mapOf(key("minecraft", "custom_data") to unsupportedValue),
-                                    )
+                                    item(key("minecraft", "diamond_sword")) {
+                                        component(key("minecraft", "custom_data"), unsupportedValue)
+                                    }
                                 }
                             }
                         }

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDslTest.kt
@@ -8,194 +8,194 @@ class SnbtToDslTest :
     StringSpec(
         {
             "parses a single byte entry" {
-                snbtToDslExpression("{kotventure:1b}") shouldBe
-                        "nbt { \"kotventure\" eq 1.toByte() }"
+                snbtToDslBody("{kotventure:1b}") shouldBe
+                        "\"kotventure\" eq 1.toByte()"
             }
 
             "parenthesises a negative byte so it keeps the Byte type" {
-                snbtToDslExpression("{val:-5b}") shouldBe
-                        "nbt { \"val\" eq (-5).toByte() }"
+                snbtToDslBody("{val:-5b}") shouldBe
+                        "\"val\" eq (-5).toByte()"
             }
 
             "renders the minimum byte" {
-                snbtToDslExpression("{val:-128b}") shouldBe
-                        "nbt { \"val\" eq (-128).toByte() }"
+                snbtToDslBody("{val:-128b}") shouldBe
+                        "\"val\" eq (-128).toByte()"
             }
 
             "parses a single short entry" {
-                snbtToDslExpression("{slot:3s}") shouldBe
-                        "nbt { \"slot\" eq 3.toShort() }"
+                snbtToDslBody("{slot:3s}") shouldBe
+                        "\"slot\" eq 3.toShort()"
             }
 
             "parenthesises a negative short so it keeps the Short type" {
-                snbtToDslExpression("{slot:-3s}") shouldBe
-                        "nbt { \"slot\" eq (-3).toShort() }"
+                snbtToDslBody("{slot:-3s}") shouldBe
+                        "\"slot\" eq (-3).toShort()"
             }
 
             "parses a single int entry" {
-                snbtToDslExpression("{count:64}") shouldBe
-                        "nbt { \"count\" eq 64 }"
+                snbtToDslBody("{count:64}") shouldBe
+                        "\"count\" eq 64"
             }
 
             "renders the minimum int as a constant" {
-                snbtToDslExpression("{count:-2147483648}") shouldBe
-                        "nbt { \"count\" eq Int.MIN_VALUE }"
+                snbtToDslBody("{count:-2147483648}") shouldBe
+                        "\"count\" eq Int.MIN_VALUE"
             }
 
             "parses a single long entry" {
-                snbtToDslExpression("{time:1000L}") shouldBe
-                        "nbt { \"time\" eq 1000L }"
+                snbtToDslBody("{time:1000L}") shouldBe
+                        "\"time\" eq 1000L"
             }
 
             "renders the minimum long as a constant" {
-                snbtToDslExpression("{time:-9223372036854775808L}") shouldBe
-                        "nbt { \"time\" eq Long.MIN_VALUE }"
+                snbtToDslBody("{time:-9223372036854775808L}") shouldBe
+                        "\"time\" eq Long.MIN_VALUE"
             }
 
             "parses a single float entry" {
-                snbtToDslExpression("{speed:1.5f}") shouldBe
-                        "nbt { \"speed\" eq 1.5f }"
+                snbtToDslBody("{speed:1.5f}") shouldBe
+                        "\"speed\" eq 1.5f"
             }
 
             "parses a single double entry with suffix" {
-                snbtToDslExpression("{health:20.0d}") shouldBe
-                        "nbt { \"health\" eq 20.0 }"
+                snbtToDslBody("{health:20.0d}") shouldBe
+                        "\"health\" eq 20.0"
             }
 
             "parses a bare decimal as double" {
-                snbtToDslExpression("{rate:0.5}") shouldBe
-                        "nbt { \"rate\" eq 0.5 }"
+                snbtToDslBody("{rate:0.5}") shouldBe
+                        "\"rate\" eq 0.5"
             }
 
             "parses a string value" {
-                snbtToDslExpression("{id:\"minecraft:diamond\"}") shouldBe
-                        "nbt { \"id\" eq \"minecraft:diamond\" }"
+                snbtToDslBody("{id:\"minecraft:diamond\"}") shouldBe
+                        "\"id\" eq \"minecraft:diamond\""
             }
 
             "parses a nested compound" {
-                snbtToDslExpression("{display:{Name:\"Sword\"}}") shouldBe
-                        "nbt { \"display\" eq { \"Name\" eq \"Sword\" } }"
+                snbtToDslBody("{display:{Name:\"Sword\"}}") shouldBe
+                        "\"display\" eq { \"Name\" eq \"Sword\" }"
             }
 
             "emits compound keys in alphabetical order" {
-                snbtToDslExpression("{id:\"minecraft:diamond\",Count:64b}") shouldBe
-                        "nbt { \"Count\" eq 64.toByte(); \"id\" eq \"minecraft:diamond\" }"
+                snbtToDslBody("{id:\"minecraft:diamond\",Count:64b}") shouldBe
+                        "\"Count\" eq 64.toByte(); \"id\" eq \"minecraft:diamond\""
             }
 
             "parses a byte array" {
-                snbtToDslExpression("{Data:[B;1b,2b,3b]}") shouldBe
-                        "nbt { \"Data\" eq byteArrayOf(1, 2, 3) }"
+                snbtToDslBody("{Data:[B;1b,2b,3b]}") shouldBe
+                        "\"Data\" eq byteArrayOf(1, 2, 3)"
             }
 
             "parses an int array" {
-                snbtToDslExpression("{UUID:[I;1,2,3,4]}") shouldBe
-                        "nbt { \"UUID\" eq intArrayOf(1, 2, 3, 4) }"
+                snbtToDslBody("{UUID:[I;1,2,3,4]}") shouldBe
+                        "\"UUID\" eq intArrayOf(1, 2, 3, 4)"
             }
 
             "renders the minimum int inside an int array as a constant" {
-                snbtToDslExpression("{UUID:[I;-2147483648]}") shouldBe
-                        "nbt { \"UUID\" eq intArrayOf(Int.MIN_VALUE) }"
+                snbtToDslBody("{UUID:[I;-2147483648]}") shouldBe
+                        "\"UUID\" eq intArrayOf(Int.MIN_VALUE)"
             }
 
             "parses a long array" {
-                snbtToDslExpression("{Times:[L;10L,20L]}") shouldBe
-                        "nbt { \"Times\" eq longArrayOf(10L, 20L) }"
+                snbtToDslBody("{Times:[L;10L,20L]}") shouldBe
+                        "\"Times\" eq longArrayOf(10L, 20L)"
             }
 
             "renders the minimum long inside a long array as a constant" {
-                snbtToDslExpression("{Times:[L;-9223372036854775808L]}") shouldBe
-                        "nbt { \"Times\" eq longArrayOf(Long.MIN_VALUE) }"
+                snbtToDslBody("{Times:[L;-9223372036854775808L]}") shouldBe
+                        "\"Times\" eq longArrayOf(Long.MIN_VALUE)"
             }
 
             "parses a list of strings" {
-                snbtToDslExpression("{pages:[\"a\",\"b\"]}") shouldBe
-                        "nbt { \"pages\" eq list(\"a\", \"b\") }"
+                snbtToDslBody("{pages:[\"a\",\"b\"]}") shouldBe
+                        "\"pages\" eq list(\"a\", \"b\")"
             }
 
             "parses a list of ints" {
-                snbtToDslExpression("{nums:[1,2,3]}") shouldBe
-                        "nbt { \"nums\" eq list(1, 2, 3) }"
+                snbtToDslBody("{nums:[1,2,3]}") shouldBe
+                        "\"nums\" eq list(1, 2, 3)"
             }
 
             "parses a list of bytes" {
-                snbtToDslExpression("{flags:[1b,2b]}") shouldBe
-                        "nbt { \"flags\" eq list(1.toByte(), 2.toByte()) }"
+                snbtToDslBody("{flags:[1b,2b]}") shouldBe
+                        "\"flags\" eq list(1.toByte(), 2.toByte())"
             }
 
             "parses a list of shorts" {
-                snbtToDslExpression("{slots:[3s,4s]}") shouldBe
-                        "nbt { \"slots\" eq list(3.toShort(), 4.toShort()) }"
+                snbtToDslBody("{slots:[3s,4s]}") shouldBe
+                        "\"slots\" eq list(3.toShort(), 4.toShort())"
             }
 
             "parses a list of longs" {
-                snbtToDslExpression("{times:[10L,20L]}") shouldBe
-                        "nbt { \"times\" eq list(10L, 20L) }"
+                snbtToDslBody("{times:[10L,20L]}") shouldBe
+                        "\"times\" eq list(10L, 20L)"
             }
 
             "parses a list of floats" {
-                snbtToDslExpression("{speeds:[1.5f,2.5f]}") shouldBe
-                        "nbt { \"speeds\" eq list(1.5f, 2.5f) }"
+                snbtToDslBody("{speeds:[1.5f,2.5f]}") shouldBe
+                        "\"speeds\" eq list(1.5f, 2.5f)"
             }
 
             "parses a list of doubles" {
-                snbtToDslExpression("{rates:[0.5d,1.5d]}") shouldBe
-                        "nbt { \"rates\" eq list(0.5, 1.5) }"
+                snbtToDslBody("{rates:[0.5d,1.5d]}") shouldBe
+                        "\"rates\" eq list(0.5, 1.5)"
             }
 
             "parses a list of compounds" {
-                snbtToDslExpression("{Lore:[{text:\"L1\"},{text:\"L2\"}]}") shouldBe
-                        "nbt { \"Lore\" eq list({ \"text\" eq \"L1\" }, { \"text\" eq \"L2\" }) }"
+                snbtToDslBody("{Lore:[{text:\"L1\"},{text:\"L2\"}]}") shouldBe
+                        "\"Lore\" eq list({ \"text\" eq \"L1\" }, { \"text\" eq \"L2\" })"
             }
 
             "parses a list of arrays" {
-                snbtToDslExpression("{rows:[[I;1,2],[I;3,4]]}") shouldBe
-                        "nbt { \"rows\" eq list(intArrayOf(1, 2), intArrayOf(3, 4)) }"
+                snbtToDslBody("{rows:[[I;1,2],[I;3,4]]}") shouldBe
+                        "\"rows\" eq list(intArrayOf(1, 2), intArrayOf(3, 4))"
             }
 
             "parses a list of lists" {
-                snbtToDslExpression("{grid:[[1,2],[3,4]]}") shouldBe
-                        "nbt { \"grid\" eq list(list(1, 2), list(3, 4)) }"
+                snbtToDslBody("{grid:[[1,2],[3,4]]}") shouldBe
+                        "\"grid\" eq list(list(1, 2), list(3, 4))"
             }
 
             "parses a list nested in a compound" {
-                snbtToDslExpression("{tag:{lore:[\"a\",\"b\"]}}") shouldBe
-                        "nbt { \"tag\" eq { \"lore\" eq list(\"a\", \"b\") } }"
+                snbtToDslBody("{tag:{lore:[\"a\",\"b\"]}}") shouldBe
+                        "\"tag\" eq { \"lore\" eq list(\"a\", \"b\") }"
             }
 
             "returns null for an empty list" {
-                snbtToDslExpression("{items:[]}").shouldBeNull()
+                snbtToDslBody("{items:[]}").shouldBeNull()
             }
 
             "parses quoted keys" {
-                snbtToDslExpression("{\"foo.bar\":1b}") shouldBe
-                        "nbt { \"foo.bar\" eq 1.toByte() }"
+                snbtToDslBody("{\"foo.bar\":1b}") shouldBe
+                        "\"foo.bar\" eq 1.toByte()"
             }
 
             "parses escaped strings" {
-                snbtToDslExpression("{msg:\"say \\\"hello\\\"\"}") shouldBe
-                        "nbt { \"msg\" eq \"say \\\"hello\\\"\" }"
+                snbtToDslBody("{msg:\"say \\\"hello\\\"\"}") shouldBe
+                        "\"msg\" eq \"say \\\"hello\\\"\""
             }
 
             "returns null for trailing garbage" {
-                snbtToDslExpression("{ok:1b}garbage").shouldBeNull()
+                snbtToDslBody("{ok:1b}garbage").shouldBeNull()
             }
 
             "returns null for malformed input" {
-                snbtToDslExpression("not-snbt").shouldBeNull()
+                snbtToDslBody("not-snbt").shouldBeNull()
             }
 
-            "parses an empty compound" {
-                snbtToDslExpression("{}") shouldBe "nbt { }"
+            "renders an empty compound as an empty body" {
+                snbtToDslBody("{}") shouldBe ""
             }
 
             "parses deeply nested compounds" {
-                snbtToDslExpression("{a:{b:{c:1}}}") shouldBe
-                        "nbt { \"a\" eq { \"b\" eq { \"c\" eq 1 } } }"
+                snbtToDslBody("{a:{b:{c:1}}}") shouldBe
+                        "\"a\" eq { \"b\" eq { \"c\" eq 1 } }"
             }
 
             "sorts keys of a nested compound too" {
-                snbtToDslExpression("{outer:{b:1,a:2}}") shouldBe
-                        "nbt { \"outer\" eq { \"a\" eq 2; \"b\" eq 1 } }"
+                snbtToDslBody("{outer:{b:1,a:2}}") shouldBe
+                        "\"outer\" eq { \"a\" eq 2; \"b\" eq 1 }"
             }
         },
     )

--- a/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
+++ b/modules/serializer/src/test/kotlin/io/github/lmliam/kotventure/serializer/ComponentSerializerExtensionsTest.kt
@@ -3,6 +3,7 @@ package io.github.lmliam.kotventure.serializer
 import io.github.lmliam.kotventure.core.color.hex
 import io.github.lmliam.kotventure.core.component.component
 import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.nbt.nbt
 import io.github.lmliam.kotventure.core.objectcomponent.display
 import io.github.lmliam.kotventure.core.objectcomponent.sprite
 import io.github.lmliam.kotventure.core.text.text
@@ -224,10 +225,9 @@ class ComponentSerializerExtensionsTest :
                     component {
                         text("Hover") {
                             hover {
-                                item(
-                                    key = key("minecraft", "diamond_sword"),
-                                    dataComponents = dataComponents,
-                                )
+                                item(key("minecraft", "diamond_sword")) {
+                                    component(key("minecraft", "custom_data"), nbt("{kotventure:1b}"))
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## What changed

- replace the item hover `dataComponents` map parameter with a typed trailing-lambda DSL
- support compound NBT values, pre-built values, and removal markers in the data-component scope
- update MiniMessage conversion to emit the block form
- update hover, conversion, serializer, and SNBT coverage for the new source shape

## Why

The previous map-based API leaked collection assembly and low-level value construction into the DSL. A focused sub-scope keeps item data components typed and consistent with the existing NBT DSL.

## Impact

Callers can now write item hover data components directly in an optional block. Generated MiniMessage conversion source uses the same public DSL shape.

## Validation

- `./gradlew build`

Closes #189