### PR TITLE
feat(core): add selector rotation arguments

### DIFF
--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/CommonEntitySelectorScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/CommonEntitySelectorScope.kt
@@ -101,6 +101,39 @@ public sealed interface CommonEntitySelectorScope {
     /** Filters by distance using a Kotlin [ClosedFloatingPointRange]. */
     public fun distance(range: ClosedFloatingPointRange<Double>)
 
+    /**
+     * Filters by vertical look angle in degrees — vanilla `x_rotation` — using a [SelectorRange]:
+     * `pitch(atMost(-45.0))`. `-90` looks straight up, `0` level, `90` straight down.
+     *
+     * @sample io.github.lmliam.kotventure.core.selector.selectorRotationSample
+     */
+    public fun pitch(range: SelectorRange)
+
+    /**
+     * Filters by vertical look angle in degrees — vanilla `x_rotation` — using a Kotlin range:
+     * `pitch(-90.0..-45.0)`.
+     *
+     * @sample io.github.lmliam.kotventure.core.selector.selectorRotationSample
+     */
+    public fun pitch(range: ClosedFloatingPointRange<Double>)
+
+    /**
+     * Filters by horizontal look angle in degrees — vanilla `y_rotation` — using a [SelectorRange]:
+     * `yaw(atLeast(90.0))`. `-180` faces due north, `-90` east, `0` south, `90` west.
+     *
+     * @sample io.github.lmliam.kotventure.core.selector.selectorRotationSample
+     */
+    public fun yaw(range: SelectorRange)
+
+    /**
+     * Filters by horizontal look angle in degrees — vanilla `y_rotation` — using a Kotlin range:
+     * `yaw(0.0..90.0)`. A descending range such as `yaw(170.0..-170.0)` wraps around ±180, matching
+     * vanilla semantics.
+     *
+     * @sample io.github.lmliam.kotventure.core.selector.selectorRotationSample
+     */
+    public fun yaw(range: ClosedFloatingPointRange<Double>)
+
     /** Filters by scoreboard tag. */
     public fun tag(tag: String)
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
@@ -11,6 +11,10 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
         private set
     var distance: SelectorRange? = null
         private set
+    var pitch: SelectorRange? = null
+        private set
+    var yaw: SelectorRange? = null
+        private set
     var sort: SelectorSort? = null
         private set
     var level: LevelRange? = null
@@ -57,11 +61,29 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
 
     override fun distance(range: SelectorRange) {
         checkUnset("distance", distance)
-        distance = range
+        distance = range.requireAscending("distance").requireNonNegative("distance")
     }
 
     override fun distance(range: ClosedFloatingPointRange<Double>) {
         distance(closedRange(range.start, range.endInclusive))
+    }
+
+    override fun pitch(range: SelectorRange) {
+        checkUnset("pitch", pitch)
+        pitch = range
+    }
+
+    override fun pitch(range: ClosedFloatingPointRange<Double>) {
+        pitch(closedRange(range.start, range.endInclusive))
+    }
+
+    override fun yaw(range: SelectorRange) {
+        checkUnset("yaw", yaw)
+        yaw = range
+    }
+
+    override fun yaw(range: ClosedFloatingPointRange<Double>) {
+        yaw(closedRange(range.start, range.endInclusive))
     }
 
     override fun tag(tag: String) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorRenderer.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorRenderer.kt
@@ -13,6 +13,8 @@ internal object EntitySelectorRenderer {
                     builder.coordinates[axis]?.let { add("${axis.argument}=${formatSelectorNumber(it)}") }
                 }
                 builder.distance?.let { add("distance=${it.rendered}") }
+                builder.pitch?.let { add("x_rotation=${it.rendered}") }
+                builder.yaw?.let { add("y_rotation=${it.rendered}") }
                 builder.level?.let { add("level=${it.rendered}") }
                 builder.gamemode?.renderValues { it.value }?.forEach { add("gamemode=$it") }
                 builder.limit?.let { add("limit=$it") }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorRange.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorRange.kt
@@ -1,18 +1,30 @@
 package io.github.lmliam.kotventure.core.selector
 
 /**
- * A floating-point range for the `distance` selector argument.
+ * A floating-point range for selector arguments such as `distance`, `pitch`, and `yaw`.
  *
  * Construct open-ended or exact bounds via the helpers [atMost], [atLeast], and [exactly]; for a
- * closed range, pass a native Kotlin range to `distance(a..b)` directly. Integer-valued `level`
- * uses the distinct [LevelRange] instead.
+ * closed range, pass a native Kotlin range to the consuming argument directly, e.g.
+ * `distance(0.5..10.0)`. Validation that differs by argument — such as `distance` rejecting
+ * negative or descending bounds while rotations accept both — is applied by the consuming
+ * argument. Integer-valued `level` uses the distinct [LevelRange] instead.
  */
-@JvmInline
-public value class SelectorRange internal constructor(
-    internal val rendered: String,
+@ConsistentCopyVisibility
+public data class SelectorRange internal constructor(
+    internal val minimum: Double?,
+    internal val maximum: Double?,
 ) {
+    internal val rendered: String
+        get() =
+            when {
+                minimum != null && minimum == maximum -> formatSelectorNumber(minimum)
+                else -> "${minimum.renderedOrEmpty()}..${maximum.renderedOrEmpty()}"
+            }
+
     override fun toString(): String = rendered
 }
+
+private fun Double?.renderedOrEmpty(): String = this?.let(::formatSelectorNumber).orEmpty()
 
 /**
  * A range matching values up to and including [max] (renders as `..max`).
@@ -21,7 +33,7 @@ public value class SelectorRange internal constructor(
  */
 public fun atMost(max: Double): SelectorRange {
     require(max.isFinite()) { "Range value must be finite, got: $max" }
-    return SelectorRange("..${formatSelectorNumber(max)}")
+    return SelectorRange(minimum = null, maximum = max)
 }
 
 /**
@@ -31,7 +43,7 @@ public fun atMost(max: Double): SelectorRange {
  */
 public fun atLeast(min: Double): SelectorRange {
     require(min.isFinite()) { "Range value must be finite, got: $min" }
-    return SelectorRange("${formatSelectorNumber(min)}..")
+    return SelectorRange(minimum = min, maximum = null)
 }
 
 /**
@@ -41,7 +53,7 @@ public fun atLeast(min: Double): SelectorRange {
  */
 public fun exactly(value: Double): SelectorRange {
     require(value.isFinite()) { "Range value must be finite, got: $value" }
-    return SelectorRange(formatSelectorNumber(value))
+    return SelectorRange(minimum = value, maximum = value)
 }
 
 internal fun closedRange(
@@ -50,6 +62,19 @@ internal fun closedRange(
 ): SelectorRange {
     require(min.isFinite()) { "Range min must be finite, got: $min" }
     require(max.isFinite()) { "Range max must be finite, got: $max" }
-    require(min <= max) { "Range min ($min) must not exceed max ($max)" }
-    return SelectorRange("${formatSelectorNumber(min)}..${formatSelectorNumber(max)}")
+    return SelectorRange(minimum = min, maximum = max)
+}
+
+internal fun SelectorRange.requireAscending(argument: String): SelectorRange {
+    require(minimum == null || maximum == null || minimum <= maximum) {
+        "Selector argument '$argument' requires min <= max, got: $rendered"
+    }
+    return this
+}
+
+internal fun SelectorRange.requireNonNegative(argument: String): SelectorRange {
+    require((minimum ?: 0.0) >= 0.0 && (maximum ?: 0.0) >= 0.0) {
+        "Selector argument '$argument' does not accept negative bounds, got: $rendered"
+    }
+    return this
 }

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSamples.kt
@@ -54,6 +54,13 @@ internal fun selectorPositionVolumeSample() {
     }
 }
 
+internal fun selectorRotationSample() {
+    entities {
+        pitch(-90.0..-45.0)
+        yaw(170.0..-170.0)
+    }
+}
+
 internal fun entitiesSample() {
     entities {
         type("armor_stand")

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
@@ -167,6 +167,58 @@ class EntitySelectorTest :
                 }
             }
 
+            "distance with negative bounds is rejected" {
+                shouldThrow<IllegalArgumentException> {
+                    entities { distance(atLeast(-1.0)) }
+                }
+
+                shouldThrow<IllegalArgumentException> {
+                    entities { distance(-5.0..5.0) }
+                }
+            }
+
+            "distance with equal Kotlin range bounds renders as exact value" {
+                entities { distance(5.0..5.0) }.asString() shouldBe "@e[distance=5]"
+            }
+
+            "pitch with typed range" {
+                entities { pitch(atMost(-45.0)) }.asString() shouldBe "@e[x_rotation=..-45]"
+            }
+
+            "yaw with typed range" {
+                allPlayers { yaw(atLeast(90.0)) }.asString() shouldBe "@a[y_rotation=90..]"
+            }
+
+            "pitch with exact value" {
+                entities { pitch(exactly(0.0)) }.asString() shouldBe "@e[x_rotation=0]"
+            }
+
+            "pitch and yaw with Kotlin ranges render in vanilla order" {
+                entities {
+                    yaw(0.0..90.0)
+                    distance(atMost(10.0))
+                    pitch(-90.0..-45.0)
+                }.asString() shouldBe "@e[distance=..10,x_rotation=-90..-45,y_rotation=0..90]"
+            }
+
+            "yaw with descending Kotlin range renders vanilla wrap-around" {
+                entities { yaw(170.0..-170.0) }.asString() shouldBe "@e[y_rotation=170..-170]"
+            }
+
+            "rotation is available on the self scope" {
+                self { pitch(atMost(0.0)) }.asString() shouldBe "@s[x_rotation=..0]"
+            }
+
+            "rotation with non-finite bounds is rejected" {
+                shouldThrow<IllegalArgumentException> {
+                    entities { pitch(Double.NaN..0.0) }
+                }
+
+                shouldThrow<IllegalArgumentException> {
+                    entities { yaw(0.0..Double.POSITIVE_INFINITY) }
+                }
+            }
+
             "level with Kotlin IntRange" {
                 val selector = allPlayers { level(5..30) }
 
@@ -382,6 +434,18 @@ class EntitySelectorTest :
                     allPlayers {
                         level(exactly(3))
                         level(5..10)
+                    }
+                }
+                shouldThrow<IllegalStateException> {
+                    entities {
+                        pitch(atMost(0.0))
+                        pitch(exactly(45.0))
+                    }
+                }
+                shouldThrow<IllegalStateException> {
+                    entities {
+                        yaw(0.0..90.0)
+                        yaw(atLeast(90.0))
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- add `pitch` and `yaw` selector arguments (vanilla `x_rotation` / `y_rotation`) to `CommonEntitySelectorScope`, each accepting a typed `SelectorRange` or a native Kotlin range
- rework `SelectorRange` to carry its numeric bounds and derive its rendering, moving per-argument validation to the consumer: `distance` now rejects negative and descending bounds, while rotations accept both
- a descending Kotlin range such as `yaw(170.0..-170.0)` renders vanilla's wrap-around form verbatim

## Deviations from the issue text (by maintainer decision)

- **Named `pitch`/`yaw`, not `xRotation`/`yRotation`** — vanilla's `x_rotation` is the *vertical* angle, a notorious confusion; the DSL uses game-dev vocabulary and the KDoc states the vanilla mapping. Same precedent as `origin`/`volume`.
- **Duplicate rotation arguments throw `IllegalStateException`** instead of the issue's "last-write-wins", per the strictness rule adopted in #207 (reject malformed input).
- **Equal closed bounds normalise to the exact form**: `distance(5.0..5.0)` renders `distance=5` (semantically identical in vanilla), a consequence of deriving rendering from bounds instead of storing a pre-rendered string.

## Related issues

Closes #196

## Type of change

- [x] feat — new capability
- [ ] fix — bug fix
- [ ] refactor — internal, no behaviour change
- [ ] docs
- [x] test
- [ ] chore / build / ci

## Testing

- `./gradlew :core:test`
- `./gradlew build` (lint, coverage, samples)
- New cases: typed + native ranges on both axes, wrap-around rendering, render order, rotation on `@s`, non-finite rejection, negative-distance rejection, duplicate-singleton strictness

## Checklist

- [x] Title and commit subjects follow `verb(area): something`
- [x] Linked the related issue
- [x] Tests added/updated (dogfood the `test` matchers where applicable)
- [x] `./gradlew ktlintCheck spotlessCheck` clean; `explicitApi()` satisfied with KDoc on public API
- [x] Updated `docs/` and `CHANGELOG.md` if user-facing (CHANGELOG is release-please-owned; DESIGN.md has no selector-argument inventory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WASDpBnBTUbnvDpaNrDFvA
