### PR TITLE
feat(core): add selector team filters

### DIFF
--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/CommonEntitySelectorScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/CommonEntitySelectorScope.kt
@@ -173,6 +173,34 @@ public sealed interface CommonEntitySelectorScope {
      */
     public fun gamemode(mode: Excluded<GameMode>)
 
+    /**
+     * Filters by team membership: `team("red")`. A selector has at most one positive team.
+     *
+     * @throws IllegalArgumentException if the team name is empty (use `team(none)`) or contains
+     *   characters outside vanilla's unquoted-token syntax
+     * @throws IllegalStateException if a positive team is already set or exclusions are present
+     * @sample io.github.lmliam.kotventure.core.selector.selectorTeamSample
+     */
+    public fun team(team: String)
+
+    /**
+     * Filters by team presence: `team(any)` matches entities on any team (vanilla `team=!`),
+     * `team(none)` matches teamless entities (vanilla `team=`).
+     *
+     * @sample io.github.lmliam.kotventure.core.selector.selectorTeamSample
+     */
+    public fun team(presence: SelectorPresence)
+
+    /**
+     * Excludes a team: `team(!"red")`. Exclusions accumulate and may combine with `team(any)`.
+     *
+     * @throws IllegalArgumentException if the team name is empty (use `team(any)`) or contains
+     *   characters outside vanilla's unquoted-token syntax
+     * @throws IllegalStateException if a positive team is already set
+     * @sample io.github.lmliam.kotventure.core.selector.selectorTeamSample
+     */
+    public fun team(team: Excluded<String>)
+
     /** Marks a string argument value as excluded: `tag(!"muted")`. */
     public operator fun String.not(): Excluded<String> = Excluded(this)
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
@@ -25,6 +25,8 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
         private set
     var gamemode: SelectorFilter<GameMode>? = null
         private set
+    var team: SelectorFilter<String>? = null
+        private set
 
     val tags: List<String>
         field = mutableListOf()
@@ -123,6 +125,22 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
         gamemode = gamemode.excluding("gamemode", mode.value)
     }
 
+    override fun team(team: String) {
+        this.team = this.team.including("team", validTeamName(team, emptyHint = "team(none)"))
+    }
+
+    override fun team(presence: SelectorPresence) {
+        team =
+            when (presence) {
+                SelectorPresence.ANY -> team.excluding("team", "")
+                SelectorPresence.NONE -> team.including("team", "")
+            }
+    }
+
+    override fun team(team: Excluded<String>) {
+        this.team = this.team.excluding("team", validTeamName(team.value, emptyHint = "team(any)"))
+    }
+
     override fun limit(n: Int) {
         require(n > 0) { "Selector limit must be positive, got: $n" }
         checkUnset("limit", limit)
@@ -172,6 +190,17 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
         current: Any?,
     ) {
         check(current == null) { "Selector argument '$argument' is already set; vanilla syntax allows it only once." }
+    }
+
+    private fun validTeamName(
+        team: String,
+        emptyHint: String,
+    ): String {
+        require(team.isNotEmpty()) { "Team name must not be empty; use $emptyHint to filter by team presence." }
+        require(team.all { it.isAllowedInUnquotedSelectorToken() }) {
+            "Team name '$team' contains characters outside vanilla's unquoted-token syntax."
+        }
+        return team
     }
 }
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorRenderer.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorRenderer.kt
@@ -17,6 +17,7 @@ internal object EntitySelectorRenderer {
                 builder.yaw?.let { add("y_rotation=${it.rendered}") }
                 builder.level?.let { add("level=${it.rendered}") }
                 builder.gamemode?.renderValues { it.value }?.forEach { add("gamemode=$it") }
+                builder.team?.renderValues { it }?.forEach { add("team=$it") }
                 builder.limit?.let { add("limit=$it") }
                 builder.sort?.let { add("sort=${it.value}") }
                 builder.tags.forEach { add("tag=$it") }
@@ -33,16 +34,7 @@ internal object EntitySelectorRenderer {
 
     private fun renderName(value: String): String = if (needsQuoting(value)) "\"${escapeQuotes(value)}\"" else value
 
-    private fun needsQuoting(value: String): Boolean = value.any { !it.isAllowedInUnquotedString() }
-
-    private fun Char.isAllowedInUnquotedString(): Boolean =
-        this in '0'..'9' ||
-                this in 'A'..'Z' ||
-                this in 'a'..'z' ||
-                this == '_' ||
-                this == '-' ||
-                this == '.' ||
-                this == '+'
+    private fun needsQuoting(value: String): Boolean = value.any { !it.isAllowedInUnquotedSelectorToken() }
 
     private fun escapeQuotes(value: String): String =
         value

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorPresence.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorPresence.kt
@@ -1,7 +1,8 @@
 package io.github.lmliam.kotventure.core.selector
 
 /**
- * Presence condition for scoreboard tag selector arguments.
+ * Presence condition for selector arguments that test whether a value exists at all, such as
+ * `tag` and `team`.
  *
  * Access via the scoped [CommonEntitySelectorScope.any] and [CommonEntitySelectorScope.none] constants.
  *

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorToken.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorToken.kt
@@ -6,9 +6,9 @@ package io.github.lmliam.kotventure.core.selector
  */
 internal fun Char.isAllowedInUnquotedSelectorToken(): Boolean =
     this in '0'..'9' ||
-        this in 'A'..'Z' ||
-        this in 'a'..'z' ||
-        this == '_' ||
-        this == '-' ||
-        this == '.' ||
-        this == '+'
+            this in 'A'..'Z' ||
+            this in 'a'..'z' ||
+            this == '_' ||
+            this == '-' ||
+            this == '.' ||
+            this == '+'

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorToken.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorToken.kt
@@ -1,0 +1,14 @@
+package io.github.lmliam.kotventure.core.selector
+
+/**
+ * Whether this character is legal in a vanilla unquoted selector-argument token
+ * (Brigadier's unquoted-string charset).
+ */
+internal fun Char.isAllowedInUnquotedSelectorToken(): Boolean =
+    this in '0'..'9' ||
+        this in 'A'..'Z' ||
+        this in 'a'..'z' ||
+        this == '_' ||
+        this == '-' ||
+        this == '.' ||
+        this == '+'

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSamples.kt
@@ -61,6 +61,15 @@ internal fun selectorRotationSample() {
     }
 }
 
+internal fun selectorTeamSample() {
+    allPlayers { team("red") }
+    entities { team(none) }
+    entities {
+        team(any)
+        team(!"spectators")
+    }
+}
+
 internal fun entitiesSample() {
     entities {
         type("armor_stand")

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
@@ -312,6 +312,75 @@ class EntitySelectorTest :
                 selector.asString() shouldBe "@a[tag=!,tag=vip,tag=!muted,tag=]"
             }
 
+            "team filter with named team" {
+                allPlayers { team("red") }.asString() shouldBe "@a[team=red]"
+            }
+
+            "team exclusions accumulate" {
+                entities {
+                    team(!"red")
+                    team(!"blue")
+                }.asString() shouldBe "@e[team=!red,team=!blue]"
+            }
+
+            "team presence renders vanilla forms" {
+                entities { team(any) }.asString() shouldBe "@e[team=!]"
+                entities { team(none) }.asString() shouldBe "@e[team=]"
+            }
+
+            "team presence combines with named exclusions" {
+                entities {
+                    team(any)
+                    team(!"red")
+                }.asString() shouldBe "@e[team=!,team=!red]"
+            }
+
+            "team is available on the self scope" {
+                self { team("red") }.asString() shouldBe "@s[team=red]"
+            }
+
+            "duplicate positive team filters are rejected" {
+                shouldThrow<IllegalStateException> {
+                    allPlayers {
+                        team("red")
+                        team("blue")
+                    }
+                }
+                shouldThrow<IllegalStateException> {
+                    entities {
+                        team(none)
+                        team("red")
+                    }
+                }
+            }
+
+            "mixed team polarity is rejected in both orders" {
+                shouldThrow<IllegalStateException> {
+                    entities {
+                        team("red")
+                        team(!"blue")
+                    }
+                }
+                shouldThrow<IllegalStateException> {
+                    entities {
+                        team(any)
+                        team(none)
+                    }
+                }
+            }
+
+            "invalid team names are rejected" {
+                shouldThrow<IllegalArgumentException> {
+                    allPlayers { team("") }
+                }
+                shouldThrow<IllegalArgumentException> {
+                    allPlayers { team(!"") }
+                }
+                shouldThrow<IllegalArgumentException> {
+                    allPlayers { team("red team") }
+                }
+            }
+
             "origin and volume render full and partial coordinates" {
                 entities {
                     origin(1.5.x, 64.y, (-2).z)


### PR DESCRIPTION
## Summary

- add the full vanilla `team` surface to `CommonEntitySelectorScope` (every head): `team("red")`, accumulating exclusions `team(!"red")`, and presence forms `team(any)` / `team(none)`
- presence maps onto vanilla's own grammar — `team=` is a *positive empty* value (teamless) and `team=!` a *negated empty* (on any team) — so the existing `SelectorFilter` polarity rules apply unchanged, including the vanilla-legal combination `team(any); team(!"red")` → `team=!,team=!red`
- named teams are validated against vanilla's unquoted-token charset (empty names point to the matching presence form); the charset predicate is extracted to `SelectorToken.kt`, shared with the renderer's name-quoting logic

## Deviations from the issue text (by maintainer decision)

- **Negation uses the `!` operator** (`team(!"red")`), not the issue's `not {}` block — that design was replaced in #207.
- **A second positive team throws `IllegalStateException`** instead of the issue's "last-write-wins", per the strictness rule adopted in #207. Mixed polarity is likewise rejected, matching vanilla's parser (a positive `team=` cannot be combined with negations).
- **Invalid team names are rejected, not quoted** — unlike `name`, vanilla's `team` argument has no quoted form, so quoting would silently produce an unparseable selector.

## Related issues

Closes #197

## Type of change

- [x] feat — new capability
- [ ] fix — bug fix
- [ ] refactor — internal, no behaviour change
- [ ] docs
- [x] test
- [ ] chore / build / ci

## Testing

- `./gradlew :core:test`
- `./gradlew build` (lint, coverage, samples)
- New cases: named/excluded/presence rendering, presence + exclusion combination, `@s` availability, duplicate-positive and mixed-polarity rejection, empty and non-token name rejection

## Checklist

- [x] Title and commit subjects follow `verb(area): something`
- [x] Linked the related issue
- [x] Tests added/updated (dogfood the `test` matchers where applicable)
- [x] `./gradlew ktlintCheck spotlessCheck` clean; `explicitApi()` satisfied with KDoc on public API
- [x] Updated `docs/` and `CHANGELOG.md` if user-facing (CHANGELOG is release-please-owned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WASDpBnBTUbnvDpaNrDFvA
