### PR TITLE
feat(core): add selector NBT filters

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -112,6 +112,8 @@ val msg = component {
             origin(64.y)
             volume(16.dx, 8.dy, 16.dz)
             !tag("hidden")
+            nbt { "Health" eq 20.0f }
+            !nbt { "Invisible" eq true }
         },
     )
     blockNbt(blockPos(1, 64, 1), "Items[0].id")

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/CommonEntitySelectorScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/CommonEntitySelectorScope.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.kotventure.core.selector
 
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.core.nbt.NbtCompoundScope
 
 /**
  * Arguments shared by every typed entity-selector head.
@@ -144,6 +145,15 @@ public sealed interface CommonEntitySelectorScope {
 
     /** Filters by whether any scoreboard tag is present. */
     public fun tag(presence: SelectorPresence)
+
+    /**
+     * Filters by a structured NBT compound. Prefix the call with `!` to exclude matching NBT.
+     *
+     * Raw SNBT is intentionally unsupported; use [entitySelector] for raw selector interop.
+     *
+     * @sample io.github.lmliam.kotventure.core.selector.selectorNbtSample
+     */
+    public fun nbt(init: NbtCompoundScope.() -> Unit): SelectorFilterExpression
 
     /**
      * Filters by entity name. Prefix the call with `!` to exclude the name.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
@@ -1,5 +1,8 @@
 package io.github.lmliam.kotventure.core.selector
 
+import io.github.lmliam.kotventure.core.nbt.NbtCompound
+import io.github.lmliam.kotventure.core.nbt.NbtCompoundBuilder
+import io.github.lmliam.kotventure.core.nbt.NbtCompoundScope
 import net.kyori.adventure.key.Key
 
 /**
@@ -25,6 +28,7 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     val gamemodeFilters = SelectorFilterGroup<GameMode>("gamemode", SelectorFilterPolicy.EXCLUSIVE)
     val teamFilters = SelectorFilterGroup<String>("team", SelectorFilterPolicy.EXCLUSIVE)
     val tagFilters = SelectorFilterGroup<String>("tag", SelectorFilterPolicy.REPEATABLE)
+    val nbtFilters = SelectorFilterGroup<NbtCompound>("nbt", SelectorFilterPolicy.REPEATABLE)
 
     val coordinates: Map<SelectorAxis, Double>
         field = mutableMapOf()
@@ -104,6 +108,9 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
         tagFilters.addFixed(this, "", presence.polarity)
     }
 
+    override fun nbt(init: NbtCompoundScope.() -> Unit): SelectorFilterExpression =
+        nbtFilters.add(this, NbtCompoundBuilder().apply(init).build())
+
     override fun name(name: String): SelectorFilterExpression = nameFilters.add(this, name)
 
     override fun level(range: LevelRange) {
@@ -155,6 +162,7 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
         gamemodeFilters.validate()
         teamFilters.validate()
         tagFilters.validate()
+        nbtFilters.validate()
     }
 
     private fun bindCoordinates(bindings: List<Pair<SelectorAxis, Double>>) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorRenderer.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorRenderer.kt
@@ -1,5 +1,7 @@
 package io.github.lmliam.kotventure.core.selector
 
+import io.github.lmliam.kotventure.core.nbt.renderCompound
+
 internal object EntitySelectorRenderer {
     fun render(
         head: String,
@@ -21,6 +23,7 @@ internal object EntitySelectorRenderer {
                 builder.limit?.let { add("limit=$it") }
                 builder.sort?.let { add("sort=${it.value}") }
                 addAll(builder.tagFilters.rendered { it })
+                addAll(builder.nbtFilters.rendered(::renderCompound))
             }
         val suffix = if (arguments.isEmpty()) "" else arguments.joinToString(",", prefix = "[", postfix = "]")
         return EntitySelector("$head$suffix")

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSamples.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.kotventure.core.selector
 
 import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.nbt.list
 
 internal fun selectorSample() {
     val nearby = selector(entities { distance(atMost(10.0)) }) { separator { content(", ") } }
@@ -101,6 +102,16 @@ internal fun selectorPresenceSample() {
     allPlayers {
         tag(any)
         tag(none)
+    }
+}
+
+internal fun selectorNbtSample() {
+    entities {
+        nbt {
+            "Health" eq 20.0f
+            "Tags" eq list("boss", "hostile")
+        }
+        !nbt { "Invisible" eq true }
     }
 }
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
@@ -2,7 +2,6 @@ package io.github.lmliam.kotventure.core.selector
 
 import io.github.lmliam.kotventure.core.key.key
 import io.github.lmliam.kotventure.core.nbt.list
-import io.github.lmliam.kotventure.test.compilation.assertCompiles
 import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
@@ -356,23 +355,21 @@ class EntitySelectorTest :
                     "@e[nbt={Health:20.0f,Tags:[\"boss\",\"hostile\"]},nbt=!{Invisible:1b},nbt={}]"
             }
 
-            "NBT filters are available on every selector head without a raw overload" {
-                assertCompiles(
-                    "AllSelectorNbtFiltersTest.kt",
-                    """
-                    import io.github.lmliam.kotventure.core.selector.*
+            "NBT filters are available on every selector head" {
+                fun CommonEntitySelectorScope.bothPolarities() {
+                    nbt {}
+                    !nbt {}
+                }
 
-                    fun allNbtFilters() {
-                        nearestPlayer { nbt {}; !nbt {} }
-                        allPlayers { nbt {}; !nbt {} }
-                        randomPlayer { nbt {}; !nbt {} }
-                        self { nbt {}; !nbt {} }
-                        entities { nbt {}; !nbt {} }
-                        nearestEntity { nbt {}; !nbt {} }
-                    }
-                    """.trimIndent(),
-                )
+                nearestPlayer { bothPolarities() }.asString() shouldBe "@p[nbt={},nbt=!{}]"
+                allPlayers { bothPolarities() }.asString() shouldBe "@a[nbt={},nbt=!{}]"
+                randomPlayer { bothPolarities() }.asString() shouldBe "@r[nbt={},nbt=!{}]"
+                self { bothPolarities() }.asString() shouldBe "@s[nbt={},nbt=!{}]"
+                entities { bothPolarities() }.asString() shouldBe "@e[nbt={},nbt=!{}]"
+                nearestEntity { bothPolarities() }.asString() shouldBe "@n[nbt={},nbt=!{}]"
+            }
 
+            "raw SNBT strings do not compile as selector NBT filters" {
                 assertDoesNotCompile(
                     "RawSelectorNbtFilterTest.kt",
                     """
@@ -384,6 +381,7 @@ class EntitySelectorTest :
                         }
                     }
                     """.trimIndent(),
+                    "Argument type mismatch",
                 )
             }
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
@@ -1,6 +1,8 @@
 package io.github.lmliam.kotventure.core.selector
 
 import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.nbt.list
+import io.github.lmliam.kotventure.test.compilation.assertCompiles
 import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
@@ -337,6 +339,71 @@ class EntitySelectorTest :
 
             "team is available on the self scope" {
                 self { team("red") }.asString() shouldBe "@s[team=red]"
+            }
+
+            "NBT filters preserve positive and negated call order" {
+                val selector =
+                    entities {
+                        nbt {
+                            "Health" eq 20.0f
+                            "Tags" eq list("boss", "hostile")
+                        }
+                        !nbt { "Invisible" eq true }
+                        nbt {}
+                    }
+
+                selector.asString() shouldBe
+                    "@e[nbt={Health:20.0f,Tags:[\"boss\",\"hostile\"]},nbt=!{Invisible:1b},nbt={}]"
+            }
+
+            "NBT filters are available on every selector head without a raw overload" {
+                assertCompiles(
+                    "AllSelectorNbtFiltersTest.kt",
+                    """
+                    import io.github.lmliam.kotventure.core.selector.*
+
+                    fun allNbtFilters() {
+                        nearestPlayer { nbt {}; !nbt {} }
+                        allPlayers { nbt {}; !nbt {} }
+                        randomPlayer { nbt {}; !nbt {} }
+                        self { nbt {}; !nbt {} }
+                        entities { nbt {}; !nbt {} }
+                        nearestEntity { nbt {}; !nbt {} }
+                    }
+                    """.trimIndent(),
+                )
+
+                assertDoesNotCompile(
+                    "RawSelectorNbtFilterTest.kt",
+                    """
+                    import io.github.lmliam.kotventure.core.selector.*
+
+                    fun rawNbtFilter() {
+                        entities {
+                            nbt("{Health:20f}")
+                        }
+                    }
+                    """.trimIndent(),
+                )
+            }
+
+            "NBT filters reuse nested compound array list and escaping rules" {
+                val selector =
+                    self {
+                        nbt {
+                            "display name" eq "say \"hello\""
+                            "nested" eq {
+                                "bytes" eq byteArrayOf(1, 2)
+                                "ints" eq intArrayOf(3, 4)
+                                "longs" eq longArrayOf(5L, 6L)
+                                "rows" eq list(list(7, 8), list(9, 10))
+                            }
+                        }
+                    }
+
+                selector.asString() shouldBe
+                    "@s[nbt={\"display name\":\"say \\\"hello\\\"\",nested:" +
+                    "{bytes:[B;1b,2b],ints:[I;3,4],longs:[L;5L,6L],rows:[[7,8],[9,10]]}}]"
             }
 
             "duplicate positive team filters are rejected" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.kotventure.core.selector
 
 import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.nbt.list
 import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldBeSelectorComponent
 import io.github.lmliam.kotventure.test.text.shouldContainText
@@ -49,6 +50,20 @@ class SelectorDslTest :
                     ).shouldBeSelectorComponent()
 
                 component shouldHaveSelectorPattern "@e[type=#minecraft:raiders,tag=!hidden]"
+            }
+
+            "builds a selector component with typed NBT filters" {
+                val component =
+                    selector(
+                        entities {
+                            nbt {
+                                "Tags" eq list("boss")
+                            }
+                            !nbt { "Silent" eq true }
+                        },
+                    ).shouldBeSelectorComponent()
+
+                component shouldHaveSelectorPattern "@e[nbt={Tags:[\"boss\"]},nbt=!{Silent:1b}]"
             }
 
             "builds a selector component with a typed origin and volume" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/test/compilation/Assertions.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/test/compilation/Assertions.kt
@@ -10,17 +10,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
-internal fun assertCompiles(
-    fileName: String,
-    source: String,
-) {
-    val result = compile(fileName, source)
-
-    withClue(result.messages) {
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-    }
-}
-
 internal fun assertDoesNotCompile(
     fileName: String,
     source: String,

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/test/compilation/Assertions.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/test/compilation/Assertions.kt
@@ -10,6 +10,17 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
+internal fun assertCompiles(
+    fileName: String,
+    source: String,
+) {
+    val result = compile(fileName, source)
+
+    withClue(result.messages) {
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+    }
+}
+
 internal fun assertDoesNotCompile(
     fileName: String,
     source: String,


### PR DESCRIPTION
## Summary

- add repeatable structured `nbt { ... }` filters to every typed selector head
- support negated structured filters with the uniform `!nbt { ... }` syntax from #222
- retain `NbtCompound` values until selector rendering and reuse the canonical SNBT renderer
- reject a raw-string overload while covering nested compounds, arrays, lists, escaping, empty compounds, and selector-component integration

## Design

This PR deliberately adds no selector-specific NBT wrapper or negation scope. NBT participates in the generic repeatable selector-filter model introduced by #222, keeping polarity handling separate from compound construction and serialization.

## Staff review pass (Claude, on top of the original implementation)

- **Rebased onto the merged #222** (its pre-merge base commit is dropped); the renderer wiring now uses the deduplicated `rendered(::renderCompound)` extension from the review pass there.
- **Per-head coverage calls the DSL directly** and asserts the rendered selector (`@p[nbt={},nbt=!{}]` … for all six heads) instead of invoking the embedded compiler — inline test code already proves the calls compile, and the rendering assertion is stronger. The unused `assertCompiles` helper is removed from the test toolkit.
- **The raw-overload compile-fail test pins its diagnostic** ("Argument type mismatch") so it cannot pass on an unrelated compilation error, matching the convention set in #222.

## Validation

- `./gradlew ktlintFormat`
- `./gradlew build` (full: tests, lint, coverage, samples)

Closes #198
Parent: #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WASDpBnBTUbnvDpaNrDFvA
