### PR TITLE
feat(core): add selector predicate filters

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -115,6 +115,7 @@ val msg = component {
             nbt { "Health" eq 20.0f }
             !nbt { "Invisible" eq true }
             scores { "kills" eq atLeast(10) }
+            !predicate(key("my_pack", "hidden"))
         },
     )
     blockNbt(blockPos(1, 64, 1), "Items[0].id")

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/CommonEntitySelectorScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/CommonEntitySelectorScope.kt
@@ -2,6 +2,7 @@ package io.github.lmliam.kotventure.core.selector
 
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
 import io.github.lmliam.kotventure.core.nbt.NbtCompoundScope
+import net.kyori.adventure.key.Key
 
 /**
  * Arguments shared by every typed entity-selector head.
@@ -154,6 +155,20 @@ public sealed interface CommonEntitySelectorScope {
      * @sample io.github.lmliam.kotventure.core.selector.selectorNbtSample
      */
     public fun nbt(init: NbtCompoundScope.() -> Unit): SelectorFilterExpression
+
+    /**
+     * Filters by a datapack predicate (vanilla `predicate`): `predicate(key("my_pack", "flying"))`.
+     * Prefix the call with `!` to require the predicate to fail; repeated calls accumulate in call
+     * order and must all match.
+     *
+     * There is deliberately no string overload: predicate IDs are datapack-defined, so a default
+     * namespace would usually be wrong. Build IDs with
+     * [key][io.github.lmliam.kotventure.core.key.key]; `entitySelector(...)` remains the raw
+     * interop bridge.
+     *
+     * @sample io.github.lmliam.kotventure.core.selector.selectorPredicateSample
+     */
+    public fun predicate(predicate: Key): SelectorFilterExpression
 
     /**
      * Filters by entity name. Prefix the call with `!` to exclude the name.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
@@ -29,6 +29,7 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     val teamFilters = SelectorFilterGroup<String>("team", SelectorFilterPolicy.EXCLUSIVE)
     val tagFilters = SelectorFilterGroup<String>("tag", SelectorFilterPolicy.REPEATABLE)
     val nbtFilters = SelectorFilterGroup<NbtCompound>("nbt", SelectorFilterPolicy.REPEATABLE)
+    val predicateFilters = SelectorFilterGroup<String>("predicate", SelectorFilterPolicy.REPEATABLE)
 
     val coordinates: Map<SelectorAxis, Double>
         field = mutableMapOf()
@@ -114,6 +115,8 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     override fun nbt(init: NbtCompoundScope.() -> Unit): SelectorFilterExpression =
         nbtFilters.add(this, NbtCompoundBuilder().apply(init).build())
 
+    override fun predicate(predicate: Key): SelectorFilterExpression = predicateFilters.add(this, predicate.asString())
+
     override fun name(name: String): SelectorFilterExpression = nameFilters.add(this, name)
 
     override fun level(range: SelectorIntRange) {
@@ -171,6 +174,7 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
         teamFilters.validate()
         tagFilters.validate()
         nbtFilters.validate()
+        predicateFilters.validate()
     }
 
     private fun bindCoordinates(bindings: List<Pair<SelectorAxis, Double>>) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorRenderer.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorRenderer.kt
@@ -27,6 +27,7 @@ internal object EntitySelectorRenderer {
                 builder.sort?.let { add("sort=${it.value}") }
                 addAll(builder.tagFilters.rendered { it })
                 addAll(builder.nbtFilters.rendered(::renderCompound))
+                addAll(builder.predicateFilters.rendered { it })
             }
         val suffix = if (arguments.isEmpty()) "" else arguments.joinToString(",", prefix = "[", postfix = "]")
         return EntitySelector("$head$suffix")

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSamples.kt
@@ -124,6 +124,13 @@ internal fun selectorNbtSample() {
     }
 }
 
+internal fun selectorPredicateSample() {
+    entities {
+        predicate(key("my_pack", "on_fire"))
+        !predicate(key("my_pack", "hidden"))
+    }
+}
+
 internal fun negatedCommonArgumentsSample() {
     allPlayers {
         !name("Bot")

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
@@ -504,6 +504,48 @@ class EntitySelectorTest :
                     "{bytes:[B;1b,2b],ints:[I;3,4],longs:[L;5L,6L],rows:[[7,8],[9,10]]}}]"
             }
 
+            "predicate filters preserve positive and negated keys in call order" {
+                val selector =
+                    entities {
+                        predicate(key("minecraft", "is_baby"))
+                        !predicate(key("my_pack", "hidden"))
+                        predicate(key("my_pack", "active"))
+                    }
+
+                selector.asString() shouldBe
+                    "@e[predicate=minecraft:is_baby,predicate=!my_pack:hidden,predicate=my_pack:active]"
+            }
+
+            "identical predicates accumulate rather than collapse" {
+                val selector =
+                    entities {
+                        predicate(key("my_pack", "active"))
+                        predicate(key("my_pack", "active"))
+                    }
+
+                selector.asString() shouldBe "@e[predicate=my_pack:active,predicate=my_pack:active]"
+            }
+
+            "predicates are available on the self scope" {
+                self { !predicate(key("my_pack", "flying")) }.asString() shouldBe "@s[predicate=!my_pack:flying]"
+            }
+
+            "raw predicate strings do not compile" {
+                assertDoesNotCompile(
+                    "RawPredicateTest.kt",
+                    """
+                    import io.github.lmliam.kotventure.core.selector.*
+
+                    fun rawPredicate() {
+                        entities {
+                            predicate("my_pack:active")
+                        }
+                    }
+                    """.trimIndent(),
+                    "Argument type mismatch",
+                )
+            }
+
             "duplicate positive team filters are rejected" {
                 shouldThrow<IllegalStateException> {
                     allPlayers {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
@@ -80,6 +80,18 @@ class SelectorDslTest :
                 component shouldHaveSelectorPattern "@a[scores={kills=10..,deaths=0..5}]"
             }
 
+            "builds a selector component with typed predicate filters" {
+                val component =
+                    selector(
+                        entities {
+                            predicate(key("my_pack", "on_fire"))
+                            !predicate(key("my_pack", "hidden"))
+                        },
+                    ).shouldBeSelectorComponent()
+
+                component shouldHaveSelectorPattern "@e[predicate=my_pack:on_fire,predicate=!my_pack:hidden]"
+            }
+
             "builds a selector component with a typed origin and volume" {
                 val component =
                     selector(


### PR DESCRIPTION
## Summary

- add `predicate(Key)` to the common selector scope as a repeatable, prefix-negatable typed filter
- render positive and negated predicates as `predicate=namespace:id` / `predicate=!namespace:id`, preserving call order across polarities
- keep Adventure `Key` as the only entry point — no parallel string overload

## Design

- Predicates plug into the generic filter model from #222 as a REPEATABLE `SelectorFilterGroup`, so negation is the uniform `!predicate(key("my_pack", "hidden"))` prefix form (the issue's `not { ... }` sketch predates #222 and is superseded by maintainer decision).
- Predicate IDs are datapack-defined namespaced identifiers, so Adventure `Key` is the right typed-key rung; a string overload defaulting to the `minecraft:` namespace would almost always be wrong. `entitySelector("...")` remains the raw interop bridge, and a compile-fail test pins that `predicate("my_pack:active")` does not compile.
- Identical predicates accumulate rather than collapse, per the repeatable-argument rule from #207.

## Staff review pass (Claude, rebuilt from the original implementation)

The original branch was stacked on the pre-rework selector architecture, so this is a fresh rebuild on master (~80 lines): filter group + scope function + renderer line + sample + tests, reusing the original branch's test scenarios (mixed-polarity call order, duplicate accumulation, per-head availability, no-string-overload compile check with a pinned diagnostic).

## Validation

- `./gradlew ktlintFormat`
- `./gradlew build` (full: tests, lint, coverage, samples)

Closes #200
Parent: #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WASDpBnBTUbnvDpaNrDFvA
