### PR TITLE
feat(core): add selector advancement filters

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -116,6 +116,7 @@ val msg = component {
             !nbt { "Invisible" eq true }
             scores { "kills" eq atLeast(10) }
             !predicate(key("my_pack", "hidden"))
+            advancements { key("minecraft", "story/smelt_iron") eq true }
         },
     )
     blockNbt(blockPos(1, 64, 1), "Items[0].id")

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/AdvancementCondition.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/AdvancementCondition.kt
@@ -1,0 +1,14 @@
+package io.github.lmliam.kotventure.core.selector
+
+/** One advancement's requirement: whole-advancement completion or per-criterion states. */
+internal sealed interface AdvancementCondition {
+    @JvmInline
+    value class Completed(
+        val completed: Boolean,
+    ) : AdvancementCondition
+
+    @JvmInline
+    value class Criteria(
+        val criteria: Map<String, Boolean>,
+    ) : AdvancementCondition
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/AdvancementCriteriaBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/AdvancementCriteriaBuilder.kt
@@ -1,0 +1,23 @@
+package io.github.lmliam.kotventure.core.selector
+
+/** The mutable builder behind one advancement's criterion block, keyed in declaration order. */
+internal class AdvancementCriteriaBuilder : AdvancementCriteriaScope {
+    val criteria: Map<String, Boolean>
+        field = mutableMapOf()
+
+    override infix fun String.eq(completed: Boolean) {
+        val criterion = validCriterionName(this)
+        check(criterion !in criteria) {
+            "Advancement criterion '$criterion' is already set; vanilla syntax evaluates one state per criterion."
+        }
+        criteria[criterion] = completed
+    }
+
+    private fun validCriterionName(criterion: String): String {
+        require(criterion.isNotEmpty()) { "Advancement criterion name must not be empty." }
+        require(criterion.all { it.isAllowedInUnquotedSelectorToken() }) {
+            "Advancement criterion name '$criterion' contains characters outside vanilla's unquoted-token syntax."
+        }
+        return criterion
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/AdvancementCriteriaScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/AdvancementCriteriaScope.kt
@@ -1,0 +1,22 @@
+package io.github.lmliam.kotventure.core.selector
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+
+/**
+ * The criterion-to-completion entries of one advancement condition inside
+ * [SelectorAdvancementsScope].
+ *
+ * @sample io.github.lmliam.kotventure.core.selector.selectorAdvancementsSample
+ */
+@KotventureDslMarker
+public sealed interface AdvancementCriteriaScope {
+    /**
+     * Requires this criterion to be complete (`true`) or incomplete (`false`):
+     * `"kill_dragon" eq true`.
+     *
+     * @throws IllegalArgumentException if the criterion name is empty or contains characters
+     *   outside vanilla's unquoted-token syntax
+     * @throws IllegalStateException if this criterion already has a completion state
+     */
+    public infix fun String.eq(completed: Boolean)
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/CommonEntitySelectorScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/CommonEntitySelectorScope.kt
@@ -205,6 +205,20 @@ public sealed interface CommonEntitySelectorScope {
     public fun scores(init: SelectorScoresScope.() -> Unit)
 
     /**
+     * Filters by advancement progress (vanilla `advancements={...}`):
+     * `advancements { key("minecraft", "story/smelt_iron") eq true }`.
+     *
+     * Advancements render in declaration order. Each advancement binds once inside the block, and
+     * the whole argument binds once across the selector. Vanilla does not support negating
+     * `advancements`, so the block is not prefix-negatable — require an incomplete advancement
+     * with `eq false`.
+     *
+     * @throws IllegalStateException if `advancements` is already set or an advancement is repeated
+     * @sample io.github.lmliam.kotventure.core.selector.selectorAdvancementsSample
+     */
+    public fun advancements(init: SelectorAdvancementsScope.() -> Unit)
+
+    /**
      * Filters by game mode. Prefix the call with `!` to exclude the mode.
      *
      * @sample io.github.lmliam.kotventure.core.selector.negatedCommonArgumentsSample

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
@@ -37,6 +37,9 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     var scores: Map<String, SelectorIntRange>? = null
         private set
 
+    var advancements: Map<String, AdvancementCondition>? = null
+        private set
+
     private var isConfiguring = false
 
     override val any: SelectorPresence get() = SelectorPresence.ANY
@@ -131,6 +134,11 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     override fun scores(init: SelectorScoresScope.() -> Unit) {
         checkUnset("scores", scores)
         scores = SelectorScoresBuilder().apply(init).scores
+    }
+
+    override fun advancements(init: SelectorAdvancementsScope.() -> Unit) {
+        checkUnset("advancements", advancements)
+        advancements = SelectorAdvancementsBuilder().apply(init).advancements
     }
 
     override fun gamemode(mode: GameMode): SelectorFilterExpression = gamemodeFilters.add(this, mode)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorRenderer.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorRenderer.kt
@@ -21,6 +21,9 @@ internal object EntitySelectorRenderer {
                 builder.scores?.let { scores ->
                     add(scores.entries.joinToString(",", "scores={", "}", transform = ::renderScore))
                 }
+                builder.advancements?.let { advancements ->
+                    add(advancements.entries.joinToString(",", "advancements={", "}", transform = ::renderAdvancement))
+                }
                 addAll(builder.gamemodeFilters.rendered { it.value })
                 addAll(builder.teamFilters.rendered { it })
                 builder.limit?.let { add("limit=$it") }
@@ -40,6 +43,16 @@ internal object EntitySelectorRenderer {
         }
 
     private fun renderScore(score: Map.Entry<String, SelectorIntRange>): String = "${score.key}=${score.value.rendered}"
+
+    private fun renderAdvancement(advancement: Map.Entry<String, AdvancementCondition>): String =
+        "${advancement.key}=${renderAdvancementCondition(advancement.value)}"
+
+    private fun renderAdvancementCondition(condition: AdvancementCondition): String =
+        when (condition) {
+            is AdvancementCondition.Completed -> condition.completed.toString()
+            is AdvancementCondition.Criteria ->
+                condition.criteria.entries.joinToString(",", "{", "}") { "${it.key}=${it.value}" }
+        }
 
     private fun renderName(value: String): String = if (needsQuoting(value)) "\"${escapeQuotes(value)}\"" else value
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorAdvancementsBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorAdvancementsBuilder.kt
@@ -1,0 +1,28 @@
+package io.github.lmliam.kotventure.core.selector
+
+import net.kyori.adventure.key.Key
+
+/** The mutable builder behind one `advancements { ... }` block, keyed in declaration order. */
+internal class SelectorAdvancementsBuilder : SelectorAdvancementsScope {
+    val advancements: Map<String, AdvancementCondition>
+        field = mutableMapOf()
+
+    override infix fun Key.eq(completed: Boolean) {
+        put(this, AdvancementCondition.Completed(completed))
+    }
+
+    override infix fun Key.eq(criteria: AdvancementCriteriaScope.() -> Unit) {
+        put(this, AdvancementCondition.Criteria(AdvancementCriteriaBuilder().apply(criteria).criteria))
+    }
+
+    private fun put(
+        advancement: Key,
+        condition: AdvancementCondition,
+    ) {
+        val id = advancement.asString()
+        check(id !in advancements) {
+            "Selector advancement '$id' is already set; vanilla syntax evaluates one condition per advancement."
+        }
+        advancements[id] = condition
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorAdvancementsScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorAdvancementsScope.kt
@@ -1,0 +1,29 @@
+package io.github.lmliam.kotventure.core.selector
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.key.Key
+
+/**
+ * The advancement-to-condition entries of one vanilla `advancements={...}` selector argument.
+ *
+ * @sample io.github.lmliam.kotventure.core.selector.selectorAdvancementsSample
+ */
+@KotventureDslMarker
+public sealed interface SelectorAdvancementsScope {
+    /**
+     * Requires this advancement to be complete (`true`) or incomplete (`false`):
+     * `key("minecraft", "story/smelt_iron") eq true`.
+     *
+     * @throws IllegalStateException if this advancement already has a condition
+     */
+    public infix fun Key.eq(completed: Boolean)
+
+    /**
+     * Requires per-criterion completion states within this advancement:
+     * `key("my_pack", "boss") eq { "kill_dragon" eq true }`. An empty block renders the valid
+     * vanilla form `{}`.
+     *
+     * @throws IllegalStateException if this advancement already has a condition
+     */
+    public infix fun Key.eq(criteria: AdvancementCriteriaScope.() -> Unit)
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSamples.kt
@@ -71,6 +71,18 @@ internal fun selectorScoreSample() {
     }
 }
 
+internal fun selectorAdvancementsSample() {
+    allPlayers {
+        advancements {
+            key("minecraft", "story/smelt_iron") eq true
+            key("my_pack", "boss") eq {
+                "kill_dragon" eq true
+                "no_deaths" eq false
+            }
+        }
+    }
+}
+
 internal fun selectorTeamSample() {
     allPlayers { team("red") }
     entities { team(none) }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
@@ -350,6 +350,97 @@ class EntitySelectorTest :
                 }
             }
 
+            "advancements render completion and criterion conditions in declaration order" {
+                val selector =
+                    allPlayers {
+                        advancements {
+                            key("minecraft", "story/smelt_iron") eq true
+                            key("my_pack", "boss") eq {
+                                "kill_dragon" eq true
+                                "no_deaths" eq false
+                            }
+                            key("my_pack", "secret") eq false
+                        }
+                    }
+
+                selector.asString() shouldBe
+                    "@a[advancements={minecraft:story/smelt_iron=true," +
+                    "my_pack:boss={kill_dragon=true,no_deaths=false},my_pack:secret=false}]"
+            }
+
+            "an empty advancement criterion block renders the valid vanilla form" {
+                allPlayers { advancements { key("my_pack", "boss") eq {} } }.asString() shouldBe
+                    "@a[advancements={my_pack:boss={}}]"
+            }
+
+            "an empty advancements block renders an empty map" {
+                entities { advancements {} }.asString() shouldBe "@e[advancements={}]"
+            }
+
+            "advancements are available on the self scope" {
+                self { advancements { key("minecraft", "story/root") eq true } }.asString() shouldBe
+                    "@s[advancements={minecraft:story/root=true}]"
+            }
+
+            "repeated advancements are rejected" {
+                shouldThrow<IllegalStateException> {
+                    allPlayers {
+                        advancements {
+                            key("my_pack", "boss") eq true
+                            key("my_pack", "boss") eq { "kill_dragon" eq true }
+                        }
+                    }
+                }
+            }
+
+            "a duplicate advancements block is rejected" {
+                shouldThrow<IllegalStateException> {
+                    allPlayers {
+                        advancements { key("my_pack", "boss") eq true }
+                        advancements { key("my_pack", "secret") eq false }
+                    }
+                }
+            }
+
+            "repeated advancement criteria are rejected" {
+                shouldThrow<IllegalStateException> {
+                    allPlayers {
+                        advancements {
+                            key("my_pack", "boss") eq {
+                                "kill_dragon" eq true
+                                "kill_dragon" eq false
+                            }
+                        }
+                    }
+                }
+            }
+
+            "advancement criteria outside vanilla's unquoted-token syntax are rejected" {
+                shouldThrow<IllegalArgumentException> {
+                    allPlayers { advancements { key("my_pack", "boss") eq { "bad name" eq true } } }
+                }
+                shouldThrow<IllegalArgumentException> {
+                    allPlayers { advancements { key("my_pack", "boss") eq { "" eq true } } }
+                }
+            }
+
+            "an advancements block cannot be negated" {
+                assertDoesNotCompile(
+                    "NegatedAdvancementsTest.kt",
+                    """
+                    import io.github.lmliam.kotventure.core.key.key
+                    import io.github.lmliam.kotventure.core.selector.*
+
+                    fun negatedAdvancements() {
+                        entities {
+                            !advancements { key("my_pack", "boss") eq true }
+                        }
+                    }
+                    """.trimIndent(),
+                    "receiver type mismatch",
+                )
+            }
+
             "type with Adventure Key" {
                 val selector = entities { type(key("minecraft", "creeper")) }
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorTest.kt
@@ -279,7 +279,7 @@ class EntitySelectorTest :
                     }
 
                 selector.asString() shouldBe
-                    "@e[scores={kills=5,level_up=1..,deaths=..3,balance=-10..-1,progress=-5..}]"
+                        "@e[scores={kills=5,level_up=1..,deaths=..3,balance=-10..-1,progress=-5..}]"
             }
 
             "an exact closed score range collapses to the exact form" {
@@ -316,7 +316,7 @@ class EntitySelectorTest :
 
             "score objectives may use every allowed unquoted-token punctuation class" {
                 entities { scores { "obj_1.kills-total+x" eq exactly(1) } }.asString() shouldBe
-                    "@e[scores={obj_1.kills-total+x=1}]"
+                        "@e[scores={obj_1.kills-total+x=1}]"
             }
 
             "a scores block cannot be negated" {
@@ -364,13 +364,13 @@ class EntitySelectorTest :
                     }
 
                 selector.asString() shouldBe
-                    "@a[advancements={minecraft:story/smelt_iron=true," +
-                    "my_pack:boss={kill_dragon=true,no_deaths=false},my_pack:secret=false}]"
+                        "@a[advancements={minecraft:story/smelt_iron=true," +
+                        "my_pack:boss={kill_dragon=true,no_deaths=false},my_pack:secret=false}]"
             }
 
             "an empty advancement criterion block renders the valid vanilla form" {
                 allPlayers { advancements { key("my_pack", "boss") eq {} } }.asString() shouldBe
-                    "@a[advancements={my_pack:boss={}}]"
+                        "@a[advancements={my_pack:boss={}}]"
             }
 
             "an empty advancements block renders an empty map" {
@@ -379,7 +379,7 @@ class EntitySelectorTest :
 
             "advancements are available on the self scope" {
                 self { advancements { key("minecraft", "story/root") eq true } }.asString() shouldBe
-                    "@s[advancements={minecraft:story/root=true}]"
+                        "@s[advancements={minecraft:story/root=true}]"
             }
 
             "repeated advancements are rejected" {
@@ -543,7 +543,7 @@ class EntitySelectorTest :
                     }
 
                 selector.asString() shouldBe
-                    "@e[nbt={Health:20.0f,Tags:[\"boss\",\"hostile\"]},nbt=!{Invisible:1b},nbt={}]"
+                        "@e[nbt={Health:20.0f,Tags:[\"boss\",\"hostile\"]},nbt=!{Invisible:1b},nbt={}]"
             }
 
             "NBT filters are available on every selector head" {
@@ -591,8 +591,8 @@ class EntitySelectorTest :
                     }
 
                 selector.asString() shouldBe
-                    "@s[nbt={\"display name\":\"say \\\"hello\\\"\",nested:" +
-                    "{bytes:[B;1b,2b],ints:[I;3,4],longs:[L;5L,6L],rows:[[7,8],[9,10]]}}]"
+                        "@s[nbt={\"display name\":\"say \\\"hello\\\"\",nested:" +
+                        "{bytes:[B;1b,2b],ints:[I;3,4],longs:[L;5L,6L],rows:[[7,8],[9,10]]}}]"
             }
 
             "predicate filters preserve positive and negated keys in call order" {
@@ -604,7 +604,7 @@ class EntitySelectorTest :
                     }
 
                 selector.asString() shouldBe
-                    "@e[predicate=minecraft:is_baby,predicate=!my_pack:hidden,predicate=my_pack:active]"
+                        "@e[predicate=minecraft:is_baby,predicate=!my_pack:hidden,predicate=my_pack:active]"
             }
 
             "identical predicates accumulate rather than collapse" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
@@ -92,6 +92,21 @@ class SelectorDslTest :
                 component shouldHaveSelectorPattern "@e[predicate=my_pack:on_fire,predicate=!my_pack:hidden]"
             }
 
+            "builds a selector component with typed advancement filters" {
+                val component =
+                    selector(
+                        allPlayers {
+                            advancements {
+                                key("minecraft", "story/smelt_iron") eq true
+                                key("my_pack", "boss") eq { "kill_dragon" eq true }
+                            }
+                        },
+                    ).shouldBeSelectorComponent()
+
+                component shouldHaveSelectorPattern
+                    "@a[advancements={minecraft:story/smelt_iron=true,my_pack:boss={kill_dragon=true}}]"
+            }
+
             "builds a selector component with a typed origin and volume" {
                 val component =
                     selector(

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
@@ -104,7 +104,7 @@ class SelectorDslTest :
                     ).shouldBeSelectorComponent()
 
                 component shouldHaveSelectorPattern
-                    "@a[advancements={minecraft:story/smelt_iron=true,my_pack:boss={kill_dragon=true}}]"
+                        "@a[advancements={minecraft:story/smelt_iron=true,my_pack:boss={kill_dragon=true}}]"
             }
 
             "builds a selector component with a typed origin and volume" {


### PR DESCRIPTION
## Summary

- add an `advancements { ... }` block mirroring vanilla's single `advancements={...}` map argument, on every typed selector head
- `Key eq Boolean` for whole-advancement completion; `Key eq { "criterion" eq Boolean }` for criterion-level progress, with the valid empty `{}` form supported
- render advancements and criteria in declaration order with Adventure `Key` as the only advancement-ID entry point

## Design (deviations from the issue sketch, by maintainer decision)

- **`advancements { ... }` block instead of flat `advancement(key, ...)` calls** — like `scores` (#212), vanilla `advancements` is *one* argument whose value is a map literal, so the DSL mirrors it: the whole block binds once, each advancement binds once, each criterion binds once.
- **Repeats throw `IllegalStateException` at the offending call** instead of the issue's insertion-ordered last-write-wins — the issue predates the #207 fail-fast ruling; contradictions are rejected, not normalized away.
- Vanilla does not support negating `advancements`, so the block is not prefix-negatable (a compile-fail test pins the diagnostic); "not completed" is expressed as `eq false`, per the issue.
- Criterion names are validated against vanilla's unquoted-token charset; advancement IDs stay `Key`-only (datapack-defined, so no default-namespace string overload).

## Structure

Two public scopes (`SelectorAdvancementsScope`, `AdvancementCriteriaScope`), two internal builders, and an internal `AdvancementCondition` value model (completion vs criteria) retained until the renderer serializes it — one file each.

## Validation

- `./gradlew ktlintFormat`
- `./gradlew build` (full: tests, lint, coverage, samples)

Closes #201
Parent: #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WASDpBnBTUbnvDpaNrDFvA
