### PR TITLE
feat(minimessage): emit typed selectors from the converter

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -218,6 +218,8 @@ Three layers, shipped incrementally:
    ** (Gradle plugin over resource bundles).
 
 A **MiniMessage ⇄ DSL converter** round‑trips between markup strings and DSL/Kotlin, aiding migration and learning.
+Selector patterns convert through the strict `core` parser and emit the typed selector factories and arguments,
+canonicalized; invalid patterns fail with the parser's offset-bearing exception.
 
 ## 7. Testing strategy
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtListFactory.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtListFactory.kt
@@ -49,22 +49,22 @@ internal fun buildNbtCompound(block: NbtCompoundScope.() -> Unit): NbtValue.Comp
 
 private fun Any?.toNbtValue(): NbtValue =
     when (this) {
-    is String -> NbtValue.StringValue(this)
-    is Boolean -> NbtValue.ByteValue(if (this) 1.toByte() else 0.toByte())
-    is Byte -> NbtValue.ByteValue(this)
-    is Short -> NbtValue.ShortValue(this)
-    is Int -> NbtValue.IntValue(this)
-    is Long -> NbtValue.LongValue(this)
-    is Float -> NbtValue.FloatValue(this)
-    is Double -> NbtValue.DoubleValue(this)
-    is ByteArray -> NbtValue.ByteArrayValue(copyOf())
-    is IntArray -> NbtValue.IntArrayValue(copyOf())
-    is LongArray -> NbtValue.LongArrayValue(copyOf())
-    is NbtList -> NbtValue.ListValue(elements)
-    null -> throw IllegalArgumentException("NBT list elements cannot be null.")
-    else -> throw IllegalArgumentException(
-        "NBT list elements must be a scalar (String, Boolean, Byte, Short, Int, Long, Float, Double), " +
-        "an array (ByteArray, IntArray, LongArray), a nested list, or a compound block. " +
-        "Got: ${this::class.qualifiedName ?: this::class}.",
-    )
-}
+        is String -> NbtValue.StringValue(this)
+        is Boolean -> NbtValue.ByteValue(if (this) 1.toByte() else 0.toByte())
+        is Byte -> NbtValue.ByteValue(this)
+        is Short -> NbtValue.ShortValue(this)
+        is Int -> NbtValue.IntValue(this)
+        is Long -> NbtValue.LongValue(this)
+        is Float -> NbtValue.FloatValue(this)
+        is Double -> NbtValue.DoubleValue(this)
+        is ByteArray -> NbtValue.ByteArrayValue(copyOf())
+        is IntArray -> NbtValue.IntArrayValue(copyOf())
+        is LongArray -> NbtValue.LongArrayValue(copyOf())
+        is NbtList -> NbtValue.ListValue(elements)
+        null -> throw IllegalArgumentException("NBT list elements cannot be null.")
+        else -> throw IllegalArgumentException(
+            "NBT list elements must be a scalar (String, Boolean, Byte, Short, Int, Long, Float, Double), " +
+                    "an array (ByteArray, IntArray, LongArray), a nested list, or a compound block. " +
+                    "Got: ${this::class.qualifiedName ?: this::class}.",
+        )
+    }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtListFactory.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtListFactory.kt
@@ -3,20 +3,27 @@ package io.github.lmliam.kotventure.core.nbt
 /**
  * Builds a homogeneous NBT list (`TAG_List`) of [values].
  *
- * The element type is fixed by [T], so the list cannot be mixed; `list("a", 1)` infers `T` to a common
- * supertype and is rejected at compile time. Supported element types: the scalars (`String`, `Boolean`,
- * `Byte`, `Short`, `Int`, `Long`, `Float`, `Double`), the arrays (`ByteArray`, `IntArray`, `LongArray`),
- * and nested lists ([NbtList]) — so `list(list(1, 2), list(3, 4))` and `list(intArrayOf(1), intArrayOf(2))`
- * are lists of lists and lists of arrays. `Boolean` renders as a byte (`true` → `1b`). For lists of
- * compounds, use the [list] overload that takes compound blocks.
+ * The element type is fixed by [T], so a well-typed call (`list(1, 2, 3)`, `list("a", "b")`)
+ * produces a list of one kind. Mixing element types (`list("a", 1)`) compiles — [T] simply
+ * widens to a common supertype — but is rejected at runtime with a descriptive error.
+ *
+ * Supported element types: the scalars (`String`, `Boolean`, `Byte`, `Short`, `Int`, `Long`,
+ * `Float`, `Double`), the arrays (`ByteArray`, `IntArray`, `LongArray`), and nested lists
+ * ([NbtList]) — so `list(list(1, 2), list(3, 4))` and `list(intArrayOf(1), intArrayOf(2))`
+ * are lists of lists and lists of arrays. `Boolean` renders as a byte (`true` -> `1b`).
+ * For lists of compounds, use the [list] overload that takes compound blocks.
  *
  * Defined as an extension on [NbtCompoundScope] so it stays scoped to an `nbt { ... }` block.
  *
- * @throws IllegalArgumentException if [T] is not a supported NBT element type.
+ * @throws IllegalArgumentException if any element is null or not a supported NBT element type.
  * @sample io.github.lmliam.kotventure.core.nbt.nbtListSample
  */
 @Suppress("UnusedReceiverParameter")
-public inline fun <reified T> NbtCompoundScope.list(vararg values: T): NbtList = nbtList(values.asList())
+public fun <T> NbtCompoundScope.list(vararg values: T): NbtList = NbtList(values.map { it.toNbtValue() })
+
+/** Iterable overload for ergonomics. */
+@Suppress("UnusedReceiverParameter")
+public fun <T> NbtCompoundScope.list(values: Iterable<T>): NbtList = NbtList(values.map { it.toNbtValue() })
 
 /**
  * Builds an empty NBT list (`TAG_List` with no elements): `"Items" eq list()`.
@@ -27,34 +34,37 @@ public inline fun <reified T> NbtCompoundScope.list(vararg values: T): NbtList =
 public fun NbtCompoundScope.list(): NbtList = NbtList(emptyList())
 
 /**
- * Builds a homogeneous NBT list (`TAG_List`) of the compounds built by [compounds].
+ * Builds a homogeneous NBT list (`TAG_List`) of the compounds built by [blocks].
  *
  * @sample io.github.lmliam.kotventure.core.nbt.nbtListSample
  */
 @Suppress("UnusedReceiverParameter")
-public fun NbtCompoundScope.list(vararg compounds: NbtCompoundScope.() -> Unit): NbtList =
-    NbtList(compounds.map { NbtValue.CompoundValue(NbtCompoundBuilder().apply(it).build()) })
+@JvmName("listOfCompounds")
+public fun NbtCompoundScope.list(vararg blocks: NbtCompoundScope.() -> Unit): NbtList =
+    NbtList(blocks.map(::buildNbtCompound))
 
-@PublishedApi
-internal fun nbtList(values: List<Any?>): NbtList = NbtList(values.map(::nbtElement))
+/** Build a compound and wrap as a compound value. Put this next to your nbt DSL if you prefer. */
+internal fun buildNbtCompound(block: NbtCompoundScope.() -> Unit): NbtValue.CompoundValue =
+    NbtValue.CompoundValue(NbtCompoundBuilder().apply(block).build())
 
-private fun nbtElement(value: Any?): NbtValue =
-    when (value) {
-        is String -> NbtValue.StringValue(value)
-        is Boolean -> NbtValue.ByteValue(if (value) 1 else 0)
-        is Byte -> NbtValue.ByteValue(value)
-        is Short -> NbtValue.ShortValue(value)
-        is Int -> NbtValue.IntValue(value)
-        is Long -> NbtValue.LongValue(value)
-        is Float -> NbtValue.FloatValue(value)
-        is Double -> NbtValue.DoubleValue(value)
-        is ByteArray -> NbtValue.ByteArrayValue(value.copyOf())
-        is IntArray -> NbtValue.IntArrayValue(value.copyOf())
-        is LongArray -> NbtValue.LongArrayValue(value.copyOf())
-        is NbtList -> NbtValue.ListValue(value.elements)
-        else -> throw IllegalArgumentException(
-            "NBT list elements must be a scalar (String, Boolean, Byte, Short, Int, Long, Float, Double), " +
-                    "an array (ByteArray, IntArray, LongArray), a nested list, or a compound block. " +
-                    "Got: ${if (value == null) "null" else value::class.qualifiedName ?: value::class}.",
-        )
-    }
+private fun Any?.toNbtValue(): NbtValue =
+    when (this) {
+    is String -> NbtValue.StringValue(this)
+    is Boolean -> NbtValue.ByteValue(if (this) 1.toByte() else 0.toByte())
+    is Byte -> NbtValue.ByteValue(this)
+    is Short -> NbtValue.ShortValue(this)
+    is Int -> NbtValue.IntValue(this)
+    is Long -> NbtValue.LongValue(this)
+    is Float -> NbtValue.FloatValue(this)
+    is Double -> NbtValue.DoubleValue(this)
+    is ByteArray -> NbtValue.ByteArrayValue(copyOf())
+    is IntArray -> NbtValue.IntArrayValue(copyOf())
+    is LongArray -> NbtValue.LongArrayValue(copyOf())
+    is NbtList -> NbtValue.ListValue(elements)
+    null -> throw IllegalArgumentException("NBT list elements cannot be null.")
+    else -> throw IllegalArgumentException(
+        "NBT list elements must be a scalar (String, Boolean, Byte, Short, Int, Long, Float, Double), " +
+        "an array (ByteArray, IntArray, LongArray), a nested list, or a compound block. " +
+        "Got: ${this::class.qualifiedName ?: this::class}.",
+    )
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtListFactory.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/NbtListFactory.kt
@@ -19,6 +19,14 @@ package io.github.lmliam.kotventure.core.nbt
 public inline fun <reified T> NbtCompoundScope.list(vararg values: T): NbtList = nbtList(values.asList())
 
 /**
+ * Builds an empty NBT list (`TAG_List` with no elements): `"Items" eq list()`.
+ *
+ * @sample io.github.lmliam.kotventure.core.nbt.nbtListSample
+ */
+@Suppress("UnusedReceiverParameter")
+public fun NbtCompoundScope.list(): NbtList = NbtList(emptyList())
+
+/**
  * Builds a homogeneous NBT list (`TAG_List`) of the compounds built by [compounds].
  *
  * @sample io.github.lmliam.kotventure.core.nbt.nbtListSample

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/nbt/NbtSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/nbt/NbtSamples.kt
@@ -3,6 +3,7 @@ package io.github.lmliam.kotventure.core.nbt
 import io.github.lmliam.kotventure.core.key.key
 import io.github.lmliam.kotventure.core.selector.self
 
+@Suppress("unused") // samples exist for documentation generation
 internal fun nbtPathSample() {
     nbtPath("Items")[0]["tag"]["display"]["Name"]
     nbtPath("Inventory")[all]["id"]
@@ -46,7 +47,9 @@ internal fun nbtCompoundScopeSample() {
     matching {
         "id" eq "minecraft:diamond"
         "Count" eq 1.toByte()
-        "tag" eq { "Unbreakable" eq 1.toByte() }
+        "tag" eq {
+            "Unbreakable" eq 1.toByte()
+        }
     }
 }
 
@@ -64,10 +67,14 @@ internal fun nbtListSample() {
         "pages" eq list("Once", "upon", "a", "time")
         "Items" eq list()
         "Lore" eq
-                list(
-                    { "text" eq "Line 1" },
-                    { "text" eq "Line 2" },
-                )
+            list(
+            {
+                "text" eq "Line 1"
+            },
+            {
+                "text" eq "Line 2"
+            },
+        )
         "rows" eq list(intArrayOf(1, 2), intArrayOf(3, 4))
         "grid" eq list(list(1, 2), list(3, 4))
     }

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/nbt/NbtSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/nbt/NbtSamples.kt
@@ -67,14 +67,14 @@ internal fun nbtListSample() {
         "pages" eq list("Once", "upon", "a", "time")
         "Items" eq list()
         "Lore" eq
-            list(
-            {
-                "text" eq "Line 1"
-            },
-            {
-                "text" eq "Line 2"
-            },
-        )
+                list(
+                    {
+                        "text" eq "Line 1"
+                    },
+                    {
+                        "text" eq "Line 2"
+                    },
+                )
         "rows" eq list(intArrayOf(1, 2), intArrayOf(3, 4))
         "grid" eq list(list(1, 2), list(3, 4))
     }

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/nbt/NbtSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/nbt/NbtSamples.kt
@@ -62,6 +62,7 @@ internal fun nbtSample() {
 internal fun nbtListSample() {
     nbt {
         "pages" eq list("Once", "upon", "a", "time")
+        "Items" eq list()
         "Lore" eq
                 list(
                     { "text" eq "Line 1" },

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/NbtListTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/NbtListTest.kt
@@ -6,104 +6,106 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 
 class NbtListTest :
-    StringSpec({
-    // Helper to reduce repetition
-    fun render(block: NbtCompoundScope.() -> Unit): String = nbt(block).string()
+    StringSpec(
+        {
+            // Helper to reduce repetition
+            fun render(block: NbtCompoundScope.() -> Unit): String = nbt(block).string()
 
-    "builds an empty list" {
-        val actual = render { "Items" eq list() }
-        val expected = """{Items:[]}"""
-        actual shouldBe expected
-    }
+            "builds an empty list" {
+                val actual = render { "Items" eq list() }
+                val expected = """{Items:[]}"""
+                actual shouldBe expected
+            }
 
-    "builds a list of strings" {
-        val actual = render { "pages" eq list("a", "b") }
-        val expected = """{pages:["a","b"]}"""
-        actual shouldBe expected
-    }
+            "builds a list of strings" {
+                val actual = render { "pages" eq list("a", "b") }
+                val expected = """{pages:["a","b"]}"""
+                actual shouldBe expected
+            }
 
-    "builds a list of ints (distinct from an int array)" {
-        val actual = render { "nums" eq list(1, 2, 3) }
-        val expected = """{nums:[1,2,3]}"""
-        actual shouldBe expected
-    }
+            "builds a list of ints (distinct from an int array)" {
+                val actual = render { "nums" eq list(1, 2, 3) }
+                val expected = """{nums:[1,2,3]}"""
+                actual shouldBe expected
+            }
 
-    "builds a list of bytes (distinct from a byte array)" {
-        val actual = render { "flags" eq list(1.toByte(), 2.toByte()) }
-        val expected = """{flags:[1b,2b]}"""
-        actual shouldBe expected
-    }
+            "builds a list of bytes (distinct from a byte array)" {
+                val actual = render { "flags" eq list(1.toByte(), 2.toByte()) }
+                val expected = """{flags:[1b,2b]}"""
+                actual shouldBe expected
+            }
 
-    "builds a list of shorts" {
-        val actual = render { "slots" eq list(3.toShort(), 4.toShort()) }
-        val expected = """{slots:[3s,4s]}"""
-        actual shouldBe expected
-    }
+            "builds a list of shorts" {
+                val actual = render { "slots" eq list(3.toShort(), 4.toShort()) }
+                val expected = """{slots:[3s,4s]}"""
+                actual shouldBe expected
+            }
 
-    "builds a list of longs" {
-        val actual = render { "times" eq list(10L, 20L) }
-        val expected = """{times:[10L,20L]}"""
-        actual shouldBe expected
-    }
+            "builds a list of longs" {
+                val actual = render { "times" eq list(10L, 20L) }
+                val expected = """{times:[10L,20L]}"""
+                actual shouldBe expected
+            }
 
-    "builds a list of floats" {
-        val actual = render { "speeds" eq list(1.5f, 2.5f) }
-        val expected = """{speeds:[1.5f,2.5f]}"""
-        actual shouldBe expected
-    }
+            "builds a list of floats" {
+                val actual = render { "speeds" eq list(1.5f, 2.5f) }
+                val expected = """{speeds:[1.5f,2.5f]}"""
+                actual shouldBe expected
+            }
 
-    "builds a list of doubles" {
-        val actual = render { "rates" eq list(0.5, 1.5) }
-        val expected = """{rates:[0.5d,1.5d]}"""
-        actual shouldBe expected
-    }
+            "builds a list of doubles" {
+                val actual = render { "rates" eq list(0.5, 1.5) }
+                val expected = """{rates:[0.5d,1.5d]}"""
+                actual shouldBe expected
+            }
 
-    "renders booleans as bytes" {
-        val actual = render { "checks" eq list(true, false) }
-        val expected = """{checks:[1b,0b]}"""
-        actual shouldBe expected
-    }
+            "renders booleans as bytes" {
+                val actual = render { "checks" eq list(true, false) }
+                val expected = """{checks:[1b,0b]}"""
+                actual shouldBe expected
+            }
 
-    "builds a list of compounds" {
-        val actual =
-            render {
-            "Lore" eq
-                list(
-                { "text" eq "Line 1" },
-                { "text" eq "Line 2" },
-            )
-        }
-        val expected = """{Lore:[{text:"Line 1"},{text:"Line 2"}]}"""
-        actual shouldBe expected
-    }
+            "builds a list of compounds" {
+                val actual =
+                    render {
+                        "Lore" eq
+                                list(
+                                    { "text" eq "Line 1" },
+                                    { "text" eq "Line 2" },
+                                )
+                    }
+                val expected = """{Lore:[{text:"Line 1"},{text:"Line 2"}]}"""
+                actual shouldBe expected
+            }
 
-    "builds a list of arrays" {
-        val actual = render { "rows" eq list(intArrayOf(1, 2), intArrayOf(3, 4)) }
-        val expected = """{rows:[[I;1,2],[I;3,4]]}"""
-        actual shouldBe expected
-    }
+            "builds a list of arrays" {
+                val actual = render { "rows" eq list(intArrayOf(1, 2), intArrayOf(3, 4)) }
+                val expected = """{rows:[[I;1,2],[I;3,4]]}"""
+                actual shouldBe expected
+            }
 
-    "builds a list of lists" {
-        val actual = render { "grid" eq list(list(1, 2), list(3, 4)) }
-        val expected = """{grid:[[1,2],[3,4]]}"""
-        actual shouldBe expected
-    }
+            "builds a list of lists" {
+                val actual = render { "grid" eq list(list(1, 2), list(3, 4)) }
+                val expected = """{grid:[[1,2],[3,4]]}"""
+                actual shouldBe expected
+            }
 
-    "nests a list inside a compound element" {
-        val actual =
-            render {
-            "outer" eq list({ "inner" eq list("x", "y") })
-        }
-        val expected = """{outer:[{inner:["x","y"]}]}"""
-        actual shouldBe expected
-    }
+            "nests a list inside a compound element" {
+                val actual =
+                    render {
+                        "outer" eq list({ "inner" eq list("x", "y") })
+                    }
+                val expected = """{outer:[{inner:["x","y"]}]}"""
+                actual shouldBe expected
+            }
 
-    "rejects an unsupported element type at runtime" {
-        val e =
-            shouldThrow<IllegalArgumentException> {
-            render { "chars" eq list('a', 'b') }
-        }
-        // Assert the message mentions the NBT element contract (protects future regressions)
-        e.message.shouldContain("NBT list elements must be")
-    }
-})
+            "rejects an unsupported element type at runtime" {
+                val e =
+                    shouldThrow<IllegalArgumentException> {
+                        render { "chars" eq list('a', 'b') }
+                    }
+                // Assert the message mentions the NBT element contract (protects future regressions)
+                e.message.shouldContain("NBT list elements must be")
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/NbtListTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/NbtListTest.kt
@@ -3,79 +3,107 @@ package io.github.lmliam.kotventure.core.nbt
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
 class NbtListTest :
-    StringSpec(
-        {
-            "builds an empty list" {
-                nbt { "Items" eq list() }.string() shouldBe "{Items:[]}"
-            }
+    StringSpec({
+    // Helper to reduce repetition
+    fun render(block: NbtCompoundScope.() -> Unit): String = nbt(block).string()
 
-            "builds a list of strings" {
-                nbt { "pages" eq list("a", "b") }.string() shouldBe "{pages:[\"a\",\"b\"]}"
-            }
+    "builds an empty list" {
+        val actual = render { "Items" eq list() }
+        val expected = """{Items:[]}"""
+        actual shouldBe expected
+    }
 
-            "builds a list of ints (distinct from an int array)" {
-                nbt { "nums" eq list(1, 2, 3) }.string() shouldBe "{nums:[1,2,3]}"
-            }
+    "builds a list of strings" {
+        val actual = render { "pages" eq list("a", "b") }
+        val expected = """{pages:["a","b"]}"""
+        actual shouldBe expected
+    }
 
-            "builds a list of bytes (distinct from a byte array)" {
-                nbt { "flags" eq list(1.toByte(), 2.toByte()) }.string() shouldBe "{flags:[1b,2b]}"
-            }
+    "builds a list of ints (distinct from an int array)" {
+        val actual = render { "nums" eq list(1, 2, 3) }
+        val expected = """{nums:[1,2,3]}"""
+        actual shouldBe expected
+    }
 
-            "builds a list of shorts" {
-                nbt { "slots" eq list(3.toShort(), 4.toShort()) }.string() shouldBe "{slots:[3s,4s]}"
-            }
+    "builds a list of bytes (distinct from a byte array)" {
+        val actual = render { "flags" eq list(1.toByte(), 2.toByte()) }
+        val expected = """{flags:[1b,2b]}"""
+        actual shouldBe expected
+    }
 
-            "builds a list of longs" {
-                nbt { "times" eq list(10L, 20L) }.string() shouldBe "{times:[10L,20L]}"
-            }
+    "builds a list of shorts" {
+        val actual = render { "slots" eq list(3.toShort(), 4.toShort()) }
+        val expected = """{slots:[3s,4s]}"""
+        actual shouldBe expected
+    }
 
-            "builds a list of floats" {
-                nbt { "speeds" eq list(1.5f, 2.5f) }.string() shouldBe "{speeds:[1.5f,2.5f]}"
-            }
+    "builds a list of longs" {
+        val actual = render { "times" eq list(10L, 20L) }
+        val expected = """{times:[10L,20L]}"""
+        actual shouldBe expected
+    }
 
-            "builds a list of doubles" {
-                nbt { "rates" eq list(0.5, 1.5) }.string() shouldBe "{rates:[0.5d,1.5d]}"
-            }
+    "builds a list of floats" {
+        val actual = render { "speeds" eq list(1.5f, 2.5f) }
+        val expected = """{speeds:[1.5f,2.5f]}"""
+        actual shouldBe expected
+    }
 
-            "renders booleans as bytes" {
-                nbt { "checks" eq list(true, false) }.string() shouldBe "{checks:[1b,0b]}"
-            }
+    "builds a list of doubles" {
+        val actual = render { "rates" eq list(0.5, 1.5) }
+        val expected = """{rates:[0.5d,1.5d]}"""
+        actual shouldBe expected
+    }
 
-            "builds a list of compounds" {
-                nbt {
-                    "Lore" eq
-                            list(
-                                { "text" eq "Line 1" },
-                                { "text" eq "Line 2" },
-                            )
-                }.string() shouldBe "{Lore:[{text:\"Line 1\"},{text:\"Line 2\"}]}"
-            }
+    "renders booleans as bytes" {
+        val actual = render { "checks" eq list(true, false) }
+        val expected = """{checks:[1b,0b]}"""
+        actual shouldBe expected
+    }
 
-            "builds a list of arrays" {
-                nbt { "rows" eq list(intArrayOf(1, 2), intArrayOf(3, 4)) }.string() shouldBe
-                        "{rows:[[I;1,2],[I;3,4]]}"
-            }
+    "builds a list of compounds" {
+        val actual =
+            render {
+            "Lore" eq
+                list(
+                { "text" eq "Line 1" },
+                { "text" eq "Line 2" },
+            )
+        }
+        val expected = """{Lore:[{text:"Line 1"},{text:"Line 2"}]}"""
+        actual shouldBe expected
+    }
 
-            "builds a list of lists" {
-                nbt { "grid" eq list(list(1, 2), list(3, 4)) }.string() shouldBe
-                        "{grid:[[1,2],[3,4]]}"
-            }
+    "builds a list of arrays" {
+        val actual = render { "rows" eq list(intArrayOf(1, 2), intArrayOf(3, 4)) }
+        val expected = """{rows:[[I;1,2],[I;3,4]]}"""
+        actual shouldBe expected
+    }
 
-            "nests a list inside a compound element" {
-                nbt {
-                    "outer" eq list({ "inner" eq list("x", "y") })
-                }.string() shouldBe "{outer:[{inner:[\"x\",\"y\"]}]}"
-            }
+    "builds a list of lists" {
+        val actual = render { "grid" eq list(list(1, 2), list(3, 4)) }
+        val expected = """{grid:[[1,2],[3,4]]}"""
+        actual shouldBe expected
+    }
 
-            // An inferred mixed list (list("a", 1)) is rejected at compile time: the reified T is
-            // inferred to an intersection of the element types, which is a warning we treat as an error.
-            // Unsupported element types are caught at runtime.
-            "rejects an unsupported element type at runtime" {
-                shouldThrow<IllegalArgumentException> {
-                    nbt { "chars" eq list('a', 'b') }
-                }
-            }
-        },
-    )
+    "nests a list inside a compound element" {
+        val actual =
+            render {
+            "outer" eq list({ "inner" eq list("x", "y") })
+        }
+        val expected = """{outer:[{inner:["x","y"]}]}"""
+        actual shouldBe expected
+    }
+
+    "rejects an unsupported element type at runtime" {
+        val e =
+            shouldThrow<IllegalArgumentException> {
+            render { "chars" eq list('a', 'b') }
+        }
+        // Assert the message mentions the NBT element contract (protects future regressions)
+        e.message.shouldContain("NBT list elements must be")
+    }
+})

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/NbtListTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/nbt/NbtListTest.kt
@@ -7,6 +7,10 @@ import io.kotest.matchers.shouldBe
 class NbtListTest :
     StringSpec(
         {
+            "builds an empty list" {
+                nbt { "Items" eq list() }.string() shouldBe "{Items:[]}"
+            }
+
             "builds a list of strings" {
                 nbt { "pages" eq list("a", "b") }.string() shouldBe "{pages:[\"a\",\"b\"]}"
             }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageDsl.kt
@@ -23,6 +23,9 @@ public fun mini(input: String): Component = parseMiniMessage(input)
  * reproduces those children rather than a `gradient` call — a lossy-but-faithful expansion: the rendering is exact, but
  * the `<gradient>` markup itself is not reconstructed.
  *
+ * Selector patterns parse through the strict `core` parser and emit the typed selector factories and arguments
+ * (canonicalized, like every selector conversion); invalid patterns fail with the parser's offset-bearing exception.
+ *
  * @throws IllegalArgumentException when [input] resolves to a shape with no DSL surface, such as a player head with no
  * single skin source, profile properties, or unsupported click or data-component payloads.
  */

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslBlocks.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslBlocks.kt
@@ -30,7 +30,7 @@ internal fun KotlinSourceBuilder.appendStructured(
  * Emits a structured-component call with multi-line arguments.
  *
  * The `opener` appears on its own line, each argument is emitted indented and comma-separated
- * (via [openArguments]), and then either a single closing `)` or a `) { ... }` body that carries
+ * , and then either a single closing `)` or a `) { ... }` body that carries
  * [body], the component's style, and its children.
  *
  * This overload accepts a List of argument-emitting lambdas to remain compatible with existing callers.

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslBlocks.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslBlocks.kt
@@ -21,6 +21,31 @@ internal fun KotlinSourceBuilder.appendStructured(
     }
 }
 
+/**
+ * Emits a structured-component call whose arguments are multi-line expressions: `$opener` on its own
+ * line, each argument indented and comma-separated, then either `)` or a `) { ... }` body carrying
+ * [body], the component's style, and its children.
+ */
+internal fun KotlinSourceBuilder.appendStructuredArguments(
+    opener: String,
+    arguments: List<KotlinSourceBuilder.() -> Unit>,
+    component: Component,
+    hasExtraBody: Boolean = false,
+    body: KotlinSourceBuilder.() -> Unit = {},
+) {
+    openArguments(opener, arguments.map { { it() } })
+    if (!hasExtraBody && !hasDslOutput(component.style()) && component.children().isEmpty()) {
+        line(")")
+        return
+    }
+
+    block(")") {
+        body()
+        appendStyle(component.style())
+        component.children().forEach { appendComponent(it) }
+    }
+}
+
 internal fun KotlinSourceBuilder.appendComponentArgument(
     label: String,
     component: Component,

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslBlocks.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslBlocks.kt
@@ -55,17 +55,6 @@ internal fun KotlinSourceBuilder.appendStructuredArguments(
 }
 
 /**
- * Ergonomic overload that accepts vararg argument lambdas.
- */
-internal fun KotlinSourceBuilder.appendStructuredArguments(
-    opener: String,
-    vararg arguments: KotlinSourceBuilder.() -> Unit,
-    component: Component,
-    hasExtraBody: Boolean = false,
-    body: KotlinSourceBuilder.() -> Unit = {},
-) = appendStructuredArguments(opener, arguments.toList(), component, hasExtraBody, body)
-
-/**
  * Emit a labelled component argument block, e.g. `label { ... }`.
  */
 internal fun KotlinSourceBuilder.appendComponentArgument(

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslBlocks.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslBlocks.kt
@@ -2,29 +2,38 @@ package io.github.lmliam.kotventure.minimessage.conversion
 
 import net.kyori.adventure.text.Component
 
+/**
+ * Helpers for emitting structured DSL blocks for components.
+ *
+ * These functions intentionally work as small, composable building blocks:
+ * - prefer small helpers for the body emission to avoid duplicated logic
+ * - expose a vararg overload for arguments for ergonomic callers
+ */
 internal fun KotlinSourceBuilder.appendStructured(
     header: String,
     component: Component,
     hasExtraBody: Boolean = false,
-    body: KotlinSourceBuilder.() -> Unit,
+    body: KotlinSourceBuilder.() -> Unit = {},
 ) {
-    val hasStyle = hasDslOutput(component.style())
-    if (!hasExtraBody && !hasStyle && component.children().isEmpty()) {
+    val needsBlock = hasExtraBody || hasDslOutput(component.style()) || component.children().isNotEmpty()
+    if (!needsBlock) {
         line(header)
         return
     }
 
     block(header) {
-        body()
-        appendStyle(component.style())
-        component.children().forEach { appendComponent(it) }
+        emitComponentBody(component, body)
     }
 }
 
 /**
- * Emits a structured-component call whose arguments are multi-line expressions: `$opener` on its own
- * line, each argument indented and comma-separated, then either `)` or a `) { ... }` body carrying
+ * Emits a structured-component call with multi-line arguments.
+ *
+ * The `opener` appears on its own line, each argument is emitted indented and comma-separated
+ * (via [openArguments]), and then either a single closing `)` or a `) { ... }` body that carries
  * [body], the component's style, and its children.
+ *
+ * This overload accepts a List of argument-emitting lambdas to remain compatible with existing callers.
  */
 internal fun KotlinSourceBuilder.appendStructuredArguments(
     opener: String,
@@ -34,21 +43,47 @@ internal fun KotlinSourceBuilder.appendStructuredArguments(
     body: KotlinSourceBuilder.() -> Unit = {},
 ) {
     openArguments(opener, arguments.map { { it() } })
-    if (!hasExtraBody && !hasDslOutput(component.style()) && component.children().isEmpty()) {
+    val needsBlock = hasExtraBody || hasDslOutput(component.style()) || component.children().isNotEmpty()
+    if (!needsBlock) {
         line(")")
         return
     }
 
     block(")") {
-        body()
-        appendStyle(component.style())
-        component.children().forEach { appendComponent(it) }
+        emitComponentBody(component, body)
     }
 }
 
+/**
+ * Ergonomic overload that accepts vararg argument lambdas.
+ */
+internal fun KotlinSourceBuilder.appendStructuredArguments(
+    opener: String,
+    vararg arguments: KotlinSourceBuilder.() -> Unit,
+    component: Component,
+    hasExtraBody: Boolean = false,
+    body: KotlinSourceBuilder.() -> Unit = {},
+) = appendStructuredArguments(opener, arguments.toList(), component, hasExtraBody, body)
+
+/**
+ * Emit a labelled component argument block, e.g. `label { ... }`.
+ */
 internal fun KotlinSourceBuilder.appendComponentArgument(
     label: String,
     component: Component,
+) = block(label) { appendRoot(component) }
+
+/**
+ * Shared small helper that emits the common trailing content for structured blocks:
+ * - optional extra body content (via [body])
+ * - style emission
+ * - child components
+ */
+private fun KotlinSourceBuilder.emitComponentBody(
+    component: Component,
+    body: KotlinSourceBuilder.() -> Unit,
 ) {
-    block(label) { appendRoot(component) }
+    body()
+    appendStyle(component.style())
+    component.children().forEach { appendComponent(it) }
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslLiterals.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslLiterals.kt
@@ -1,7 +1,5 @@
 package io.github.lmliam.kotventure.minimessage.conversion
 
-import io.github.lmliam.kotventure.core.selector.EntitySelectorParseException
-import io.github.lmliam.kotventure.core.selector.parseSelector
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.ShadowColor
@@ -67,13 +65,6 @@ internal fun shadowColorLiteral(color: ShadowColor): String {
 
 /** Renders [key] as a `key("namespace", "value")` call. */
 internal fun keyLiteral(key: Key): String = "key(${quoted(key.namespace())}, ${quoted(key.value())})"
-
-/**
- * Validates raw selector [source] and renders it as the canonical `parseSelector("...")` call.
- *
- * @throws EntitySelectorParseException if [source] is not valid selector syntax
- */
-internal fun parseSelectorLiteral(source: String): String = "parseSelector(${quoted(parseSelector(source).toString())})"
 
 /**
  * Renders [contents] as the object-contents expression that reconstructs it, using the single-argument `sprite` form

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslNbtComponents.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslNbtComponents.kt
@@ -1,5 +1,6 @@
 package io.github.lmliam.kotventure.minimessage.conversion
 
+import io.github.lmliam.kotventure.core.selector.parseSelector
 import net.kyori.adventure.text.BlockNBTComponent
 import net.kyori.adventure.text.EntityNBTComponent
 import net.kyori.adventure.text.NBTComponent
@@ -13,12 +14,23 @@ internal fun KotlinSourceBuilder.appendBlockNbt(component: BlockNBTComponent) =
         component = component,
     )
 
-internal fun KotlinSourceBuilder.appendEntityNbt(component: EntityNBTComponent) =
-    appendNbt(
-        functionName = "entityNbt",
-        sourceExpression = parseSelectorLiteral(component.selector()),
+internal fun KotlinSourceBuilder.appendEntityNbt(component: EntityNBTComponent) {
+    val selector = parseSelector(component.selector())
+
+    appendStructuredArguments(
+        opener = "entityNbt(",
+        arguments =
+            listOf(
+                { appendEntitySelector(selector) },
+                { line("nbtPath(${quoted(component.nbtPath())})") },
+            ),
         component = component,
-    )
+        hasExtraBody = component.interpret() || component.separator() != null,
+    ) {
+        if (component.interpret()) line("interpret(true)")
+        component.separator()?.let { appendComponentArgument("separator", it) }
+    }
+}
 
 internal fun KotlinSourceBuilder.appendStorageNbt(component: StorageNBTComponent) =
     appendNbt(

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslStructuredComponents.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslStructuredComponents.kt
@@ -1,5 +1,6 @@
 package io.github.lmliam.kotventure.minimessage.conversion
 
+import io.github.lmliam.kotventure.core.selector.parseSelector
 import net.kyori.adventure.text.KeybindComponent
 import net.kyori.adventure.text.ScoreComponent
 import net.kyori.adventure.text.SelectorComponent
@@ -33,10 +34,12 @@ internal fun KotlinSourceBuilder.appendScore(component: ScoreComponent) {
 }
 
 internal fun KotlinSourceBuilder.appendSelector(component: SelectorComponent) {
+    val selector = parseSelector(component.pattern())
     val separator = component.separator()
 
-    appendStructured(
-        header = "selector(${parseSelectorLiteral(component.pattern())})",
+    appendStructuredArguments(
+        opener = "selector(",
+        arguments = listOf({ appendEntitySelector(selector) }),
         component = component,
         hasExtraBody = separator != null,
     ) {

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SelectorToDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SelectorToDsl.kt
@@ -30,13 +30,13 @@ internal fun KotlinSourceBuilder.appendEntitySelector(selector: EntitySelector) 
 private val EntitySelectorHead.factoryName: String
     get() =
         when (this) {
-        EntitySelectorHead.NEAREST_PLAYER -> "nearestPlayer"
-        EntitySelectorHead.ALL_PLAYERS -> "allPlayers"
-        EntitySelectorHead.RANDOM_PLAYER -> "randomPlayer"
-        EntitySelectorHead.SELF -> "self"
-        EntitySelectorHead.ENTITIES -> "entities"
-        EntitySelectorHead.NEAREST_ENTITY -> "nearestEntity"
-    }
+            EntitySelectorHead.NEAREST_PLAYER -> "nearestPlayer"
+            EntitySelectorHead.ALL_PLAYERS -> "allPlayers"
+            EntitySelectorHead.RANDOM_PLAYER -> "randomPlayer"
+            EntitySelectorHead.SELF -> "self"
+            EntitySelectorHead.ENTITIES -> "entities"
+            EntitySelectorHead.NEAREST_ENTITY -> "nearestEntity"
+        }
 
 /**
  * Emit selector arguments preserving model order. Coordinates are emitted as grouped calls the
@@ -91,9 +91,9 @@ private fun KotlinSourceBuilder.emitCoordinateGroupIfFirstSeen(
 
     val coordinates =
         arguments
-        .filterIsInstance<EntitySelectorArgument.Coordinate>()
-        .filter { it.coordinate.groupFunction == groupFunction }
-        .joinToString(", ") { "${it.value.toCoordinateLiteral()}.${it.coordinate.argumentName}" }
+            .filterIsInstance<EntitySelectorArgument.Coordinate>()
+            .filter { it.coordinate.groupFunction == groupFunction }
+            .joinToString(", ") { "${it.value.toCoordinateLiteral()}.${it.coordinate.argumentName}" }
 
     line("$groupFunction($coordinates)")
 }
@@ -101,24 +101,24 @@ private fun KotlinSourceBuilder.emitCoordinateGroupIfFirstSeen(
 private val SelectorCoordinate.groupFunction: String
     get() =
         when (this) {
-        SelectorCoordinate.X, SelectorCoordinate.Y, SelectorCoordinate.Z -> "origin"
-        SelectorCoordinate.DX, SelectorCoordinate.DY, SelectorCoordinate.DZ -> "volume"
-    }
+            SelectorCoordinate.X, SelectorCoordinate.Y, SelectorCoordinate.Z -> "origin"
+            SelectorCoordinate.DX, SelectorCoordinate.DY, SelectorCoordinate.DZ -> "volume"
+        }
 
 private val SelectorRangeArgument.dslFunction: String
     get() =
         when (this) {
-        SelectorRangeArgument.DISTANCE -> "distance"
-        SelectorRangeArgument.X_ROTATION -> "pitch"
-        SelectorRangeArgument.Y_ROTATION -> "yaw"
-    }
+            SelectorRangeArgument.DISTANCE -> "distance"
+            SelectorRangeArgument.X_ROTATION -> "pitch"
+            SelectorRangeArgument.Y_ROTATION -> "yaw"
+        }
 
 private val SelectorEntityType.dslFunction: String
     get() =
         when (this) {
-        is SelectorEntityType.Direct -> "type"
-        is SelectorEntityType.Tag -> "typeTag"
-    }
+            is SelectorEntityType.Direct -> "type"
+            is SelectorEntityType.Tag -> "typeTag"
+        }
 
 private val EntitySelectorArgument.Negatable.negation: String
     get() = if (isNegated) "!" else ""
@@ -140,7 +140,7 @@ private fun KotlinSourceBuilder.appendStringCondition(
 private fun KotlinSourceBuilder.appendNbtFilter(argument: EntitySelectorArgument.Nbt) {
     val body =
         snbtToDslBody(argument.snbt.value)
-        ?: conversionError("miniToDsl cannot represent selector SNBT ${argument.snbt.value}")
+            ?: conversionError("miniToDsl cannot represent selector SNBT ${argument.snbt.value}")
     val call = if (body.isEmpty()) "nbt { }" else "nbt { $body }"
     line("${argument.negation}$call")
 }
@@ -194,11 +194,11 @@ private fun <T> rangeDslArgument(
     render: (T) -> String,
 ): String =
     when {
-    minimum != null && minimum == maximum -> "exactly(${render(minimum)})"
-    minimum != null && maximum != null -> "${render(minimum)}..${render(maximum)}"
-    minimum != null -> "atLeast(${render(minimum)})"
-    else -> "atMost(${render(checkNotNull(maximum))})"
-}
+        minimum != null && minimum == maximum -> "exactly(${render(minimum)})"
+        minimum != null && maximum != null -> "${render(minimum)}..${render(maximum)}"
+        minimum != null -> "atLeast(${render(minimum)})"
+        else -> "atMost(${render(checkNotNull(maximum))})"
+    }
 
 private fun Double.toCoordinateLiteral(): String {
     val literal = toString()

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SelectorToDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SelectorToDsl.kt
@@ -12,9 +12,11 @@ import io.github.lmliam.kotventure.core.selector.SelectorRangeArgument
 import io.github.lmliam.kotventure.core.selector.SelectorStringCondition
 
 /**
- * Emits [selector] as the typed selector-DSL expression that reconstructs it: the head's factory
- * (`entities`, `self`, ...) with one scope call per argument in model order. Coordinates group into
- * single `origin(...)`/`volume(...)` calls; negated filters emit the scope's `!` prefix.
+ * Emit [selector] as the typed selector-DSL expression that reconstructs it.
+ *
+ * The factory name (e.g. `entities`, `self`, ...) is emitted, and each argument becomes one scope
+ * call in model order. Coordinates for a group are collapsed into a single `origin(...)` or
+ * `volume(...)` call, emitted the first time that group appears.
  */
 internal fun KotlinSourceBuilder.appendEntitySelector(selector: EntitySelector) {
     val factory = selector.head.factoryName
@@ -28,21 +30,25 @@ internal fun KotlinSourceBuilder.appendEntitySelector(selector: EntitySelector) 
 private val EntitySelectorHead.factoryName: String
     get() =
         when (this) {
-            EntitySelectorHead.NEAREST_PLAYER -> "nearestPlayer"
-            EntitySelectorHead.ALL_PLAYERS -> "allPlayers"
-            EntitySelectorHead.RANDOM_PLAYER -> "randomPlayer"
-            EntitySelectorHead.SELF -> "self"
-            EntitySelectorHead.ENTITIES -> "entities"
-            EntitySelectorHead.NEAREST_ENTITY -> "nearestEntity"
-        }
+        EntitySelectorHead.NEAREST_PLAYER -> "nearestPlayer"
+        EntitySelectorHead.ALL_PLAYERS -> "allPlayers"
+        EntitySelectorHead.RANDOM_PLAYER -> "randomPlayer"
+        EntitySelectorHead.SELF -> "self"
+        EntitySelectorHead.ENTITIES -> "entities"
+        EntitySelectorHead.NEAREST_ENTITY -> "nearestEntity"
+    }
 
+/**
+ * Emit selector arguments preserving model order. Coordinates are emitted as grouped calls the
+ * first time their coordinate-group appears.
+ */
 private fun KotlinSourceBuilder.appendArguments(arguments: List<EntitySelectorArgument>) {
     val emittedCoordinateGroups = mutableSetOf<String>()
 
     arguments.forEach { argument ->
         when (argument) {
             is EntitySelectorArgument.Coordinate ->
-                appendCoordinateGroupOnce(argument.coordinate.groupFunction, arguments, emittedCoordinateGroups)
+                emitCoordinateGroupIfFirstSeen(argument.coordinate.groupFunction, arguments, emittedCoordinateGroups)
 
             is EntitySelectorArgument.Range ->
                 line("${argument.argument.dslFunction}(${argument.range.toDslArgument()})")
@@ -54,7 +60,8 @@ private fun KotlinSourceBuilder.appendArguments(arguments: List<EntitySelectorAr
             is EntitySelectorArgument.GameMode ->
                 line("${argument.negation}gamemode(${argument.value.name.lowercase()})")
 
-            is EntitySelectorArgument.Name -> line("${argument.negation}name(${quoted(argument.value)})")
+            is EntitySelectorArgument.Name ->
+                line("${argument.negation}name(${quoted(argument.value)})")
 
             is EntitySelectorArgument.Type ->
                 line("${argument.negation}${argument.target.dslFunction}(${keyLiteral(argument.target.key)})")
@@ -73,48 +80,50 @@ private fun KotlinSourceBuilder.appendArguments(arguments: List<EntitySelectorAr
 }
 
 /**
- * Emits one `origin(...)`/`volume(...)` call gathering every coordinate of that group, the first
- * time the group is seen; later coordinates of the same group were already emitted.
+ * Emit one grouped coordinate call (e.g. `origin(x, y, z)`) the first time the group is seen.
  */
-private fun KotlinSourceBuilder.appendCoordinateGroupOnce(
+private fun KotlinSourceBuilder.emitCoordinateGroupIfFirstSeen(
     groupFunction: String,
     arguments: List<EntitySelectorArgument>,
     emittedGroups: MutableSet<String>,
 ) {
     if (!emittedGroups.add(groupFunction)) return
+
     val coordinates =
         arguments
-            .filterIsInstance<EntitySelectorArgument.Coordinate>()
-            .filter { it.coordinate.groupFunction == groupFunction }
-            .joinToString(", ") { "${it.value.toCoordinateLiteral()}.${it.coordinate.argumentName}" }
+        .filterIsInstance<EntitySelectorArgument.Coordinate>()
+        .filter { it.coordinate.groupFunction == groupFunction }
+        .joinToString(", ") { "${it.value.toCoordinateLiteral()}.${it.coordinate.argumentName}" }
+
     line("$groupFunction($coordinates)")
 }
 
 private val SelectorCoordinate.groupFunction: String
     get() =
         when (this) {
-            SelectorCoordinate.X, SelectorCoordinate.Y, SelectorCoordinate.Z -> "origin"
-            SelectorCoordinate.DX, SelectorCoordinate.DY, SelectorCoordinate.DZ -> "volume"
-        }
+        SelectorCoordinate.X, SelectorCoordinate.Y, SelectorCoordinate.Z -> "origin"
+        SelectorCoordinate.DX, SelectorCoordinate.DY, SelectorCoordinate.DZ -> "volume"
+    }
 
 private val SelectorRangeArgument.dslFunction: String
     get() =
         when (this) {
-            SelectorRangeArgument.DISTANCE -> "distance"
-            SelectorRangeArgument.X_ROTATION -> "pitch"
-            SelectorRangeArgument.Y_ROTATION -> "yaw"
-        }
+        SelectorRangeArgument.DISTANCE -> "distance"
+        SelectorRangeArgument.X_ROTATION -> "pitch"
+        SelectorRangeArgument.Y_ROTATION -> "yaw"
+    }
 
 private val SelectorEntityType.dslFunction: String
     get() =
         when (this) {
-            is SelectorEntityType.Direct -> "type"
-            is SelectorEntityType.Tag -> "typeTag"
-        }
+        is SelectorEntityType.Direct -> "type"
+        is SelectorEntityType.Tag -> "typeTag"
+    }
 
 private val EntitySelectorArgument.Negatable.negation: String
     get() = if (isNegated) "!" else ""
 
+/** Emit name/team/tag conditions (negation and presence variants). */
 private fun KotlinSourceBuilder.appendStringCondition(
     function: String,
     condition: SelectorStringCondition,
@@ -123,25 +132,25 @@ private fun KotlinSourceBuilder.appendStringCondition(
         is SelectorStringCondition.Named ->
             line("${if (condition.isNegated) "!" else ""}$function(${quoted(condition.value)})")
 
-        is SelectorStringCondition.Presence -> line("$function(${condition.value.name.lowercase()})")
+        is SelectorStringCondition.Presence ->
+            line("$function(${condition.value.name.lowercase()})")
     }
 }
 
 private fun KotlinSourceBuilder.appendNbtFilter(argument: EntitySelectorArgument.Nbt) {
     val body =
         snbtToDslBody(argument.snbt.value)
-            ?: conversionError("miniToDsl cannot represent selector SNBT ${argument.snbt.value}.")
+        ?: conversionError("miniToDsl cannot represent selector SNBT ${argument.snbt.value}")
     val call = if (body.isEmpty()) "nbt { }" else "nbt { $body }"
     line("${argument.negation}$call")
 }
 
-private fun KotlinSourceBuilder.appendScores(argument: EntitySelectorArgument.Scores) {
+private fun KotlinSourceBuilder.appendScores(argument: EntitySelectorArgument.Scores) =
     appendEntryBlock("scores", argument.scores) { score ->
         line("${quoted(score.objective)} eq ${score.range.toDslArgument()}")
     }
-}
 
-private fun KotlinSourceBuilder.appendAdvancements(argument: EntitySelectorArgument.Advancements) {
+private fun KotlinSourceBuilder.appendAdvancements(argument: EntitySelectorArgument.Advancements) =
     appendEntryBlock("advancements", argument.advancements) { requirement ->
         val advancement = keyLiteral(requirement.advancement)
         when (val progress = requirement.progress) {
@@ -149,7 +158,6 @@ private fun KotlinSourceBuilder.appendAdvancements(argument: EntitySelectorArgum
             is SelectorAdvancementProgress.Criteria -> appendCriteria(advancement, progress)
         }
     }
-}
 
 private fun KotlinSourceBuilder.appendCriteria(
     advancement: String,
@@ -176,7 +184,7 @@ private fun <T> KotlinSourceBuilder.appendEntryBlock(
     }
 }
 
-private fun SelectorRange.toDslArgument(): String = rangeDslArgument(minimum, maximum, Double::toKotlinLiteral)
+private fun SelectorRange.toDslArgument(): String = rangeDslArgument(minimum, maximum, Double::toString)
 
 private fun SelectorIntRange.toDslArgument(): String = rangeDslArgument(minimum, maximum, Int::toString)
 
@@ -186,17 +194,13 @@ private fun <T> rangeDslArgument(
     render: (T) -> String,
 ): String =
     when {
-        minimum != null && minimum == maximum -> "exactly(${render(minimum)})"
-        minimum != null && maximum != null -> "${render(minimum)}..${render(maximum)}"
-        minimum != null -> "atLeast(${render(minimum)})"
-        else -> "atMost(${render(checkNotNull(maximum))})"
-    }
+    minimum != null && minimum == maximum -> "exactly(${render(minimum)})"
+    minimum != null && maximum != null -> "${render(minimum)}..${render(maximum)}"
+    minimum != null -> "atLeast(${render(minimum)})"
+    else -> "atMost(${render(checkNotNull(maximum))})"
+}
 
-/** Kotlin `Double` literals always spell a `.` or exponent, so `toString` is already source form. */
-private fun Double.toKotlinLiteral(): String = toString()
-
-/** Parenthesises negative and exponent-form values so a trailing `.x`/`.dx` member access parses. */
 private fun Double.toCoordinateLiteral(): String {
-    val literal = toKotlinLiteral()
+    val literal = toString()
     return if (this < 0 || 'E' in literal) "($literal)" else literal
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SelectorToDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SelectorToDsl.kt
@@ -1,0 +1,202 @@
+package io.github.lmliam.kotventure.minimessage.conversion
+
+import io.github.lmliam.kotventure.core.selector.EntitySelector
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument
+import io.github.lmliam.kotventure.core.selector.EntitySelectorHead
+import io.github.lmliam.kotventure.core.selector.SelectorAdvancementProgress
+import io.github.lmliam.kotventure.core.selector.SelectorCoordinate
+import io.github.lmliam.kotventure.core.selector.SelectorEntityType
+import io.github.lmliam.kotventure.core.selector.SelectorIntRange
+import io.github.lmliam.kotventure.core.selector.SelectorRange
+import io.github.lmliam.kotventure.core.selector.SelectorRangeArgument
+import io.github.lmliam.kotventure.core.selector.SelectorStringCondition
+
+/**
+ * Emits [selector] as the typed selector-DSL expression that reconstructs it: the head's factory
+ * (`entities`, `self`, ...) with one scope call per argument in model order. Coordinates group into
+ * single `origin(...)`/`volume(...)` calls; negated filters emit the scope's `!` prefix.
+ */
+internal fun KotlinSourceBuilder.appendEntitySelector(selector: EntitySelector) {
+    val factory = selector.head.factoryName
+    if (selector.arguments.isEmpty()) {
+        line("$factory()")
+    } else {
+        block(factory) { appendArguments(selector.arguments) }
+    }
+}
+
+private val EntitySelectorHead.factoryName: String
+    get() =
+        when (this) {
+            EntitySelectorHead.NEAREST_PLAYER -> "nearestPlayer"
+            EntitySelectorHead.ALL_PLAYERS -> "allPlayers"
+            EntitySelectorHead.RANDOM_PLAYER -> "randomPlayer"
+            EntitySelectorHead.SELF -> "self"
+            EntitySelectorHead.ENTITIES -> "entities"
+            EntitySelectorHead.NEAREST_ENTITY -> "nearestEntity"
+        }
+
+private fun KotlinSourceBuilder.appendArguments(arguments: List<EntitySelectorArgument>) {
+    val emittedCoordinateGroups = mutableSetOf<String>()
+
+    arguments.forEach { argument ->
+        when (argument) {
+            is EntitySelectorArgument.Coordinate ->
+                appendCoordinateGroupOnce(argument.coordinate.groupFunction, arguments, emittedCoordinateGroups)
+
+            is EntitySelectorArgument.Range ->
+                line("${argument.argument.dslFunction}(${argument.range.toDslArgument()})")
+
+            is EntitySelectorArgument.Level -> line("level(${argument.range.toDslArgument()})")
+            is EntitySelectorArgument.Limit -> line("limit(${argument.value})")
+            is EntitySelectorArgument.Sort -> line("sort(${argument.value.name.lowercase()})")
+
+            is EntitySelectorArgument.GameMode ->
+                line("${argument.negation}gamemode(${argument.value.name.lowercase()})")
+
+            is EntitySelectorArgument.Name -> line("${argument.negation}name(${quoted(argument.value)})")
+
+            is EntitySelectorArgument.Type ->
+                line("${argument.negation}${argument.target.dslFunction}(${keyLiteral(argument.target.key)})")
+
+            is EntitySelectorArgument.Tag -> appendStringCondition("tag", argument.condition)
+            is EntitySelectorArgument.Team -> appendStringCondition("team", argument.condition)
+
+            is EntitySelectorArgument.Nbt -> appendNbtFilter(argument)
+            is EntitySelectorArgument.Predicate ->
+                line("${argument.negation}predicate(${keyLiteral(argument.key)})")
+
+            is EntitySelectorArgument.Scores -> appendScores(argument)
+            is EntitySelectorArgument.Advancements -> appendAdvancements(argument)
+        }
+    }
+}
+
+/**
+ * Emits one `origin(...)`/`volume(...)` call gathering every coordinate of that group, the first
+ * time the group is seen; later coordinates of the same group were already emitted.
+ */
+private fun KotlinSourceBuilder.appendCoordinateGroupOnce(
+    groupFunction: String,
+    arguments: List<EntitySelectorArgument>,
+    emittedGroups: MutableSet<String>,
+) {
+    if (!emittedGroups.add(groupFunction)) return
+    val coordinates =
+        arguments
+            .filterIsInstance<EntitySelectorArgument.Coordinate>()
+            .filter { it.coordinate.groupFunction == groupFunction }
+            .joinToString(", ") { "${it.value.toCoordinateLiteral()}.${it.coordinate.argumentName}" }
+    line("$groupFunction($coordinates)")
+}
+
+private val SelectorCoordinate.groupFunction: String
+    get() =
+        when (this) {
+            SelectorCoordinate.X, SelectorCoordinate.Y, SelectorCoordinate.Z -> "origin"
+            SelectorCoordinate.DX, SelectorCoordinate.DY, SelectorCoordinate.DZ -> "volume"
+        }
+
+private val SelectorRangeArgument.dslFunction: String
+    get() =
+        when (this) {
+            SelectorRangeArgument.DISTANCE -> "distance"
+            SelectorRangeArgument.X_ROTATION -> "pitch"
+            SelectorRangeArgument.Y_ROTATION -> "yaw"
+        }
+
+private val SelectorEntityType.dslFunction: String
+    get() =
+        when (this) {
+            is SelectorEntityType.Direct -> "type"
+            is SelectorEntityType.Tag -> "typeTag"
+        }
+
+private val EntitySelectorArgument.Negatable.negation: String
+    get() = if (isNegated) "!" else ""
+
+private fun KotlinSourceBuilder.appendStringCondition(
+    function: String,
+    condition: SelectorStringCondition,
+) {
+    when (condition) {
+        is SelectorStringCondition.Named ->
+            line("${if (condition.isNegated) "!" else ""}$function(${quoted(condition.value)})")
+
+        is SelectorStringCondition.Presence -> line("$function(${condition.value.name.lowercase()})")
+    }
+}
+
+private fun KotlinSourceBuilder.appendNbtFilter(argument: EntitySelectorArgument.Nbt) {
+    val body =
+        snbtToDslBody(argument.snbt.value)
+            ?: conversionError("miniToDsl cannot represent selector SNBT ${argument.snbt.value}.")
+    val call = if (body.isEmpty()) "nbt { }" else "nbt { $body }"
+    line("${argument.negation}$call")
+}
+
+private fun KotlinSourceBuilder.appendScores(argument: EntitySelectorArgument.Scores) {
+    appendEntryBlock("scores", argument.scores) { score ->
+        line("${quoted(score.objective)} eq ${score.range.toDslArgument()}")
+    }
+}
+
+private fun KotlinSourceBuilder.appendAdvancements(argument: EntitySelectorArgument.Advancements) {
+    appendEntryBlock("advancements", argument.advancements) { requirement ->
+        val advancement = keyLiteral(requirement.advancement)
+        when (val progress = requirement.progress) {
+            is SelectorAdvancementProgress.Completion -> line("$advancement eq ${progress.completed}")
+            is SelectorAdvancementProgress.Criteria -> appendCriteria(advancement, progress)
+        }
+    }
+}
+
+private fun KotlinSourceBuilder.appendCriteria(
+    advancement: String,
+    progress: SelectorAdvancementProgress.Criteria,
+) {
+    if (progress.criteria.isEmpty()) {
+        line("$advancement eq { }")
+    } else {
+        block("$advancement eq") {
+            progress.criteria.forEach { line("${quoted(it.name)} eq ${it.completed}") }
+        }
+    }
+}
+
+private fun <T> KotlinSourceBuilder.appendEntryBlock(
+    function: String,
+    entries: List<T>,
+    appendEntry: KotlinSourceBuilder.(T) -> Unit,
+) {
+    if (entries.isEmpty()) {
+        line("$function { }")
+    } else {
+        block(function) { entries.forEach { appendEntry(it) } }
+    }
+}
+
+private fun SelectorRange.toDslArgument(): String = rangeDslArgument(minimum, maximum, Double::toKotlinLiteral)
+
+private fun SelectorIntRange.toDslArgument(): String = rangeDslArgument(minimum, maximum, Int::toString)
+
+private fun <T> rangeDslArgument(
+    minimum: T?,
+    maximum: T?,
+    render: (T) -> String,
+): String =
+    when {
+        minimum != null && minimum == maximum -> "exactly(${render(minimum)})"
+        minimum != null && maximum != null -> "${render(minimum)}..${render(maximum)}"
+        minimum != null -> "atLeast(${render(minimum)})"
+        else -> "atMost(${render(checkNotNull(maximum))})"
+    }
+
+/** Kotlin `Double` literals always spell a `.` or exponent, so `toString` is already source form. */
+private fun Double.toKotlinLiteral(): String = toString()
+
+/** Parenthesises negative and exponent-form values so a trailing `.x`/`.dx` member access parses. */
+private fun Double.toCoordinateLiteral(): String {
+    val literal = toKotlinLiteral()
+    return if (this < 0 || 'E' in literal) "($literal)" else literal
+}

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDsl.kt
@@ -33,11 +33,11 @@ private val tagStringIO = TagStringIO.tagStringIO()
 internal fun snbtToDslBody(snbt: String): String? {
     val compound =
         try {
-        tagStringIO.asCompound(snbt)
-    } catch (_: Exception) {
-        // Catches IOException and underlying parser exceptions (e.g., IllegalStateException)
-        return null
-    }
+            tagStringIO.asCompound(snbt)
+        } catch (_: Exception) {
+            // Catches IOException and underlying parser exceptions (e.g., IllegalStateException)
+            return null
+        }
     return renderCompoundBody(compound)
 }
 
@@ -53,25 +53,30 @@ private fun renderCompoundBody(compound: CompoundBinaryTag): String? =
 
 private fun renderTag(tag: BinaryTag): String? =
     when (tag) {
-    is ByteBinaryTag -> renderByteLiteral(tag.value())
-    is ShortBinaryTag -> renderShortLiteral(tag.value())
-    is IntBinaryTag -> renderIntLiteral(tag.value())
-    is LongBinaryTag -> renderLongLiteral(tag.value())
-    is FloatBinaryTag -> "${tag.value()}f"
-    is DoubleBinaryTag -> tag.value().toString()
-    is StringBinaryTag -> "\"${escapeKotlinString(tag.value())}\""
-    is ByteArrayBinaryTag ->
-        tag.value().joinToString(", ", prefix = "byteArrayOf(", postfix = ")")
-    is IntArrayBinaryTag ->
-        tag.value().joinToString(", ", prefix = "intArrayOf(", postfix = ")") { renderIntLiteral(it) }
-    is LongArrayBinaryTag ->
-        tag.value().joinToString(", ", prefix = "longArrayOf(", postfix = ")") { renderLongLiteral(it) }
-    is CompoundBinaryTag ->
-        renderCompoundBody(tag)?.toCompoundLiteral()
-    is ListBinaryTag ->
-        renderListLiteral(tag)
-    else -> null // No typed DSL representation; fall back to raw SNBT.
-}
+        is ByteBinaryTag -> renderByteLiteral(tag.value())
+        is ShortBinaryTag -> renderShortLiteral(tag.value())
+        is IntBinaryTag -> renderIntLiteral(tag.value())
+        is LongBinaryTag -> renderLongLiteral(tag.value())
+        is FloatBinaryTag -> "${tag.value()}f"
+        is DoubleBinaryTag -> tag.value().toString()
+        is StringBinaryTag -> "\"${escapeKotlinString(tag.value())}\""
+        is ByteArrayBinaryTag ->
+            tag.value().joinToString(", ", prefix = "byteArrayOf(", postfix = ")")
+
+        is IntArrayBinaryTag ->
+            tag.value().joinToString(", ", prefix = "intArrayOf(", postfix = ")") { renderIntLiteral(it) }
+
+        is LongArrayBinaryTag ->
+            tag.value().joinToString(", ", prefix = "longArrayOf(", postfix = ")") { renderLongLiteral(it) }
+
+        is CompoundBinaryTag ->
+            renderCompoundBody(tag)?.toCompoundLiteral()
+
+        is ListBinaryTag ->
+            renderListLiteral(tag)
+
+        else -> null // No typed DSL representation; fall back to raw SNBT.
+    }
 
 private fun renderListLiteral(list: ListBinaryTag): String? {
     if (list.size() == 0) return "list()"

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDsl.kt
@@ -16,77 +16,80 @@ import net.kyori.adventure.nbt.StringBinaryTag
 import net.kyori.adventure.nbt.TagStringIO
 import java.io.IOException
 
+private val tagStringIO = TagStringIO.tagStringIO()
+
 /**
- * Converts an SNBT compound string into the body of a Kotventure NBT DSL block: the `"key" eq value`
- * calls that go inside `nbt { ... }` or `component(key) { ... }`. An empty compound renders to `""`.
+ * Converts an SNBT compound string into the body of a Kotventure NBT DSL block.
  *
- * The SNBT is parsed with Adventure's [TagStringIO], then each entry is rendered to its DSL form.
- * Keys are emitted in alphabetical order so the output is deterministic and JDK-independent (NBT
- * compounds are unordered, so reordering is semantically transparent).
+ * The result is the sequence of `"key" eq value` calls that go inside `nbt { ... }` or
+ * `component(key) { ... }`. An empty compound renders to `""`.
  *
- * Returns `null` when the SNBT is malformed, has trailing content, or contains a tag type the typed
- * DSL cannot express, signalling the caller to fall back to `nbt("raw")`.
+ * Keys are emitted in alphabetical order for deterministic, JDK-independent output.
+ * Since NBT compounds are unordered, reordering is semantically transparent.
+ *
+ * @return the DSL body, or `null` if the SNBT is malformed, has trailing content,
+ * or contains a tag type the typed DSL cannot express (triggering a raw fallback).
  */
 internal fun snbtToDslBody(snbt: String): String? {
     val compound =
         try {
-            TagStringIO.tagStringIO().asCompound(snbt)
-        } catch (e: IOException) {
-            return null
-        }
+        tagStringIO.asCompound(snbt)
+    } catch (_: Exception) {
+        // Catches IOException and underlying parser exceptions (e.g., IllegalStateException)
+        return null
+    }
     return renderCompoundBody(compound)
 }
 
-private fun renderCompoundBody(compound: CompoundBinaryTag): String? {
-    val entries =
-        compound.keySet().sorted().map { key ->
-            val value = renderValue(compound.get(key) ?: return null) ?: return null
+private fun renderCompoundBody(compound: CompoundBinaryTag): String? =
+    compound
+        .keySet()
+        .sorted()
+        .map { key ->
+            val tag = compound.get(key) ?: return null
+            val value = renderTag(tag) ?: return null
             "\"${escapeKotlinString(key)}\" eq $value"
-        }
-    return entries.joinToString("; ")
-}
+        }.joinToString("; ")
 
-private fun renderValue(tag: BinaryTag): String? =
+private fun renderTag(tag: BinaryTag): String? =
     when (tag) {
-        is ByteBinaryTag -> renderByteLiteral(tag.value())
-        is ShortBinaryTag -> renderShortLiteral(tag.value())
-        is IntBinaryTag -> renderIntLiteral(tag.value())
-        is LongBinaryTag -> renderLongLiteral(tag.value())
-        is FloatBinaryTag -> "${tag.value()}f"
-        is DoubleBinaryTag -> "${tag.value()}"
-        is StringBinaryTag -> "\"${escapeKotlinString(tag.value())}\""
-        is ByteArrayBinaryTag -> "byteArrayOf(${tag.value().joinToString(", ")})"
-        is IntArrayBinaryTag -> "intArrayOf(${tag.value().joinToString(", ") { renderIntLiteral(it) }})"
-        is LongArrayBinaryTag -> "longArrayOf(${tag.value().joinToString(", ") { renderLongLiteral(it) }})"
-        is CompoundBinaryTag -> renderCompoundBody(tag)?.let { if (it.isEmpty()) "{ }" else "{ $it }" }
-        is ListBinaryTag -> renderListLiteral(tag)
-        else -> null // Any other tag has no typed DSL form yet → raw fallback.
-    }
+    is ByteBinaryTag -> renderByteLiteral(tag.value())
+    is ShortBinaryTag -> renderShortLiteral(tag.value())
+    is IntBinaryTag -> renderIntLiteral(tag.value())
+    is LongBinaryTag -> renderLongLiteral(tag.value())
+    is FloatBinaryTag -> "${tag.value()}f"
+    is DoubleBinaryTag -> tag.value().toString()
+    is StringBinaryTag -> "\"${escapeKotlinString(tag.value())}\""
+    is ByteArrayBinaryTag ->
+        tag.value().joinToString(", ", prefix = "byteArrayOf(", postfix = ")")
+    is IntArrayBinaryTag ->
+        tag.value().joinToString(", ", prefix = "intArrayOf(", postfix = ")") { renderIntLiteral(it) }
+    is LongArrayBinaryTag ->
+        tag.value().joinToString(", ", prefix = "longArrayOf(", postfix = ")") { renderLongLiteral(it) }
+    is CompoundBinaryTag ->
+        renderCompoundBody(tag)?.toCompoundLiteral()
+    is ListBinaryTag ->
+        renderListLiteral(tag)
+    else -> null // No typed DSL representation; fall back to raw SNBT.
+}
 
 private fun renderListLiteral(list: ListBinaryTag): String? {
-    val first = list.firstOrNull() ?: return "list()"
-    if (first is CompoundBinaryTag) return renderCompoundElementList(list)
-    val elements = list.map { renderValue(it) ?: return null }
-    return "list(${elements.joinToString(", ")})"
+    if (list.size() == 0) return "list()"
+
+    val elements = list.map { renderTag(it) ?: return null }
+    return elements.joinToString(", ", prefix = "list(", postfix = ")")
 }
 
-private fun renderCompoundElementList(list: ListBinaryTag): String? {
-    val elements =
-        list.map { element ->
-            val body = renderCompoundBody(element as CompoundBinaryTag) ?: return null
-            if (body.isEmpty()) "{ }" else "{ $body }"
-        }
-    return "list(${elements.joinToString(", ")})"
-}
+private fun String.toCompoundLiteral(): String = if (isEmpty()) "{ }" else "{ $this }"
 
-/** Emits a [Byte] literal, parenthesising negatives so `(-5).toByte()` keeps the `Byte` type. */
+/** Emits a [Byte] literal, parenthesising negatives to preserve the [Byte] type. */
 private fun renderByteLiteral(value: Byte): String = if (value < 0) "($value).toByte()" else "$value.toByte()"
 
-/** Emits a [Short] literal, parenthesising negatives so `(-5).toShort()` keeps the `Short` type. */
+/** Emits a [Short] literal, parenthesising negatives to preserve the [Short] type. */
 private fun renderShortLiteral(value: Short): String = if (value < 0) "($value).toShort()" else "$value.toShort()"
 
-/** Emits an [Int] literal, using `Int.MIN_VALUE` (which has no valid negated-literal form). */
-private fun renderIntLiteral(value: Int): String = if (value == Int.MIN_VALUE) "Int.MIN_VALUE" else "$value"
+/** Emits an [Int] literal, handling the special case of [Int.MIN_VALUE]. */
+private fun renderIntLiteral(value: Int): String = if (value == Int.MIN_VALUE) "Int.MIN_VALUE" else value.toString()
 
-/** Emits a [Long] literal, using `Long.MIN_VALUE` (which has no valid negated-literal form). */
+/** Emits a [Long] literal with an `L` suffix, handling the special case of [Long.MIN_VALUE]. */
 private fun renderLongLiteral(value: Long): String = if (value == Long.MIN_VALUE) "Long.MIN_VALUE" else "${value}L"

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDsl.kt
@@ -24,9 +24,8 @@ import java.io.IOException
  * Keys are emitted in alphabetical order so the output is deterministic and JDK-independent (NBT
  * compounds are unordered, so reordering is semantically transparent).
  *
- * Returns `null` when the SNBT is malformed, has trailing content, or contains a construct the typed
- * DSL cannot express (an empty `TAG_List`, which carries no element type), signalling the caller to
- * fall back to `nbt("raw")`.
+ * Returns `null` when the SNBT is malformed, has trailing content, or contains a tag type the typed
+ * DSL cannot express, signalling the caller to fall back to `nbt("raw")`.
  */
 internal fun snbtToDslBody(snbt: String): String? {
     val compound =
@@ -64,10 +63,8 @@ private fun renderValue(tag: BinaryTag): String? =
         else -> null // Any other tag has no typed DSL form yet → raw fallback.
     }
 
-// An empty list carries no element type, so there's nothing to infer `list`'s type argument from →
-// raw fallback. Scalars, arrays, and nested lists all render through renderValue.
 private fun renderListLiteral(list: ListBinaryTag): String? {
-    val first = list.firstOrNull() ?: return null
+    val first = list.firstOrNull() ?: return "list()"
     if (first is CompoundBinaryTag) return renderCompoundElementList(list)
     val elements = list.map { renderValue(it) ?: return null }
     return "list(${elements.joinToString(", ")})"

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/GeneratedDslCompilation.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/GeneratedDslCompilation.kt
@@ -30,8 +30,7 @@ internal fun compileGeneratedDsl(source: String): Component {
         import io.github.lmliam.kotventure.core.objectcomponent.sprite
         import io.github.lmliam.kotventure.core.objectcomponent.head
         import io.github.lmliam.kotventure.core.score.score
-        import io.github.lmliam.kotventure.core.selector.parseSelector
-        import io.github.lmliam.kotventure.core.selector.selector
+        import io.github.lmliam.kotventure.core.selector.*
         import io.github.lmliam.kotventure.core.text.text
         import io.github.lmliam.kotventure.core.translatable.translatable
         import io.github.lmliam.kotventure.core.uuid.uuid

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslEventRenderingTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslEventRenderingTest.kt
@@ -4,6 +4,7 @@ import io.github.lmliam.kotventure.core.color.aqua
 import io.github.lmliam.kotventure.core.color.gold
 import io.github.lmliam.kotventure.core.component.component
 import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.nbt.list
 import io.github.lmliam.kotventure.core.nbt.nbt
 import io.github.lmliam.kotventure.core.text.text
 import io.github.lmliam.kotventure.core.uuid.uuid
@@ -420,7 +421,7 @@ class MiniMessageToDslEventRenderingTest :
                     )
                 }
 
-                test("falls back to raw nbt for data components the DSL can't model losslessly") {
+                test("emits an empty NBT list as list()") {
                     assertGoldenRoundTrip(
                         expectedSource =
                             """
@@ -428,7 +429,7 @@ class MiniMessageToDslEventRenderingTest :
                             text("Loot data") {
                                 hover {
                                     item(key("minecraft", "diamond_sword")) {
-                                        component(key("minecraft", "custom_data"), nbt("{items:[]}"))
+                                        component(key("minecraft", "custom_data")) { "items" eq list() }
                                     }
                                 }
                             }
@@ -439,7 +440,7 @@ class MiniMessageToDslEventRenderingTest :
                                 text("Loot data") {
                                     hover {
                                         item(key("minecraft", "diamond_sword")) {
-                                            component(key("minecraft", "custom_data"), nbt("{items:[]}"))
+                                            component(key("minecraft", "custom_data")) { "items" eq list() }
                                         }
                                     }
                                 }

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSelectorTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSelectorTest.kt
@@ -1,0 +1,260 @@
+package io.github.lmliam.kotventure.minimessage
+
+import io.github.lmliam.kotventure.minimessage.conversion.MiniMessageToDslWriter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+
+class MiniMessageToDslSelectorTest :
+    FunSpec(
+        {
+            fun writeSelector(pattern: String): String = MiniMessageToDslWriter.write(Component.selector(pattern))
+
+            context("typed selector emission") {
+                test("emits every selector head as its factory") {
+                    mapOf(
+                        "@p" to "nearestPlayer()",
+                        "@a" to "allPlayers()",
+                        "@r" to "randomPlayer()",
+                        "@s" to "self()",
+                        "@e" to "entities()",
+                        "@n" to "nearestEntity()",
+                    ).forEach { (pattern, factory) ->
+                        writeSelector(pattern) shouldBe
+                                """
+                            component {
+                                selector(
+                                    $factory
+                                )
+                            }
+                            """.trimIndent()
+                    }
+                }
+
+                test("emits every typed argument in model order") {
+                    val pattern =
+                        "@e[type=minecraft:zombie,name=\"Boss Mob\",x=12.5,y=64,z=-4,dx=16,dy=8,dz=-16," +
+                                "distance=0..64,x_rotation=..45,y_rotation=170..-170,level=0..30,gamemode=survival," +
+                                "limit=5,sort=nearest,tag=boss,team=raiders,nbt={Health:20.5f}," +
+                                "scores={kills=10..},predicate=minecraft:is_baby,advancements={minecraft:story/root=true}]"
+
+                    writeSelector(pattern) shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    type(key("minecraft", "zombie"))
+                                    name("Boss Mob")
+                                    origin(12.5.x, 64.0.y, (-4.0).z)
+                                    volume(16.0.dx, 8.0.dy, (-16.0).dz)
+                                    distance(0.0..64.0)
+                                    pitch(atMost(45.0))
+                                    yaw(170.0..-170.0)
+                                    level(0..30)
+                                    gamemode(survival)
+                                    limit(5)
+                                    sort(nearest)
+                                    tag("boss")
+                                    team("raiders")
+                                    nbt { "Health" eq 20.5f }
+                                    scores {
+                                        "kills" eq atLeast(10)
+                                    }
+                                    predicate(key("minecraft", "is_baby"))
+                                    advancements {
+                                        key("minecraft", "story/root") eq true
+                                    }
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("emits negated filters with the scope's negation operator") {
+                    val pattern =
+                        "@e[type=!minecraft:zombie,type=!#minecraft:undead,name=!Bot,gamemode=!creative," +
+                                "tag=!hidden,team=!red,nbt=!{Invisible:1b},predicate=!my_pack:hidden]"
+
+                    writeSelector(pattern) shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    !type(key("minecraft", "zombie"))
+                                    !typeTag(key("minecraft", "undead"))
+                                    !name("Bot")
+                                    !gamemode(creative)
+                                    !tag("hidden")
+                                    !team("red")
+                                    !nbt { "Invisible" eq 1.toByte() }
+                                    !predicate(key("my_pack", "hidden"))
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("emits presence filters as scope constants") {
+                    writeSelector("@e[tag=,tag=!,team=!]") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    tag(none)
+                                    tag(any)
+                                    team(any)
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("emits exact and open-ended ranges through the range builders") {
+                    writeSelector("@e[distance=5,x_rotation=-45..,level=3]") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    distance(exactly(5.0))
+                                    pitch(atLeast(-45.0))
+                                    level(exactly(3))
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("emits empty compound maps and empty SNBT containers") {
+                    writeSelector("@e[nbt={},scores={},advancements={minecraft:story/root={}}]") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    nbt { }
+                                    scores { }
+                                    advancements {
+                                        key("minecraft", "story/root") eq { }
+                                    }
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("emits an empty SNBT list as list()") {
+                    writeSelector("@e[nbt={Items:[]}]") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    nbt { "Items" eq list() }
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("emits advancement criteria as nested eq blocks") {
+                    writeSelector("@a[advancements={my_pack:boss={kill_dragon=true,no_deaths=false}}]") shouldBe
+                            """
+                        component {
+                            selector(
+                                allPlayers {
+                                    advancements {
+                                        key("my_pack", "boss") eq {
+                                            "kill_dragon" eq true
+                                            "no_deaths" eq false
+                                        }
+                                    }
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("canonicalizes bare entity types with the minecraft namespace") {
+                    writeSelector("@e[type=zombie]") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    type(key("minecraft", "zombie"))
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+            }
+
+            context("typed selector round trips") {
+                test("compiles and round-trips a selector exercising every argument") {
+                    // Argument order matches the DSL builder's canonical rendering order, so the
+                    // compiled typed emission serializes back to the identical pattern.
+                    val pattern =
+                        "@e[type=minecraft:zombie,name=\"Boss Mob\",x=12.5,dy=8,distance=0..64," +
+                                "x_rotation=..45,level=0..30,scores={kills=10..,deaths=0..5}," +
+                                "advancements={my_pack:boss={kill_dragon=true}},gamemode=!survival,team=," +
+                                "limit=5,sort=nearest,tag=boss,tag=!,nbt={Health:20.5f,Items:[]}," +
+                                "predicate=minecraft:is_baby]"
+
+                    assertGoldenRoundTrip(
+                        input = "<selector:'$pattern'>",
+                        expectedSource =
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    type(key("minecraft", "zombie"))
+                                    name("Boss Mob")
+                                    origin(12.5.x)
+                                    volume(8.0.dy)
+                                    distance(0.0..64.0)
+                                    pitch(atMost(45.0))
+                                    level(0..30)
+                                    scores {
+                                        "kills" eq atLeast(10)
+                                        "deaths" eq 0..5
+                                    }
+                                    advancements {
+                                        key("my_pack", "boss") eq {
+                                            "kill_dragon" eq true
+                                        }
+                                    }
+                                    !gamemode(survival)
+                                    team(none)
+                                    limit(5)
+                                    sort(nearest)
+                                    tag("boss")
+                                    tag(any)
+                                    nbt { "Health" eq 20.5f; "Items" eq list() }
+                                    predicate(key("minecraft", "is_baby"))
+                                }
+                            )
+                        }
+                        """.trimIndent(),
+                        expectedComponent = Component.selector(pattern),
+                    )
+                }
+
+                test("compiles and round-trips a typed entity NBT selector") {
+                    assertGoldenRoundTrip(
+                        input = "<nbt:entity:'@e[type=minecraft:armor_stand,limit=1]':Pos>",
+                        expectedSource =
+                            """
+                        component {
+                            entityNbt(
+                                entities {
+                                    type(key("minecraft", "armor_stand"))
+                                    limit(1)
+                                },
+                                nbtPath("Pos")
+                            )
+                        }
+                        """.trimIndent(),
+                        expectedComponent =
+                            Component.entityNBT("Pos", "@e[type=minecraft:armor_stand,limit=1]"),
+                    )
+                }
+            }
+        },
+    )

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslStructuredComponentTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslStructuredComponentTest.kt
@@ -15,7 +15,8 @@ import io.github.lmliam.kotventure.core.objectcomponent.display
 import io.github.lmliam.kotventure.core.objectcomponent.sprite
 import io.github.lmliam.kotventure.core.score.score
 import io.github.lmliam.kotventure.core.selector.EntitySelectorParseException
-import io.github.lmliam.kotventure.core.selector.parseSelector
+import io.github.lmliam.kotventure.core.selector.entities
+import io.github.lmliam.kotventure.core.selector.nearestPlayer
 import io.github.lmliam.kotventure.core.selector.selector
 import io.github.lmliam.kotventure.core.text.text
 import io.github.lmliam.kotventure.core.translatable.translatable
@@ -108,10 +109,12 @@ class MiniMessageToDslStructuredComponentTest :
                         expectedSource =
                             """
                         component {
-                            selector(parseSelector("@p"))
+                            selector(
+                                nearestPlayer()
+                            )
                         }
                         """.trimIndent(),
-                        expectedComponent = component { selector(parseSelector("@p")) },
+                        expectedComponent = component { selector(nearestPlayer()) },
                     )
                 }
 
@@ -121,7 +124,9 @@ class MiniMessageToDslStructuredComponentTest :
                         expectedSource =
                             """
                         component {
-                            selector(parseSelector("@e")) {
+                            selector(
+                                entities()
+                            ) {
                                 separator {
                                     text(", ")
                                 }
@@ -130,7 +135,7 @@ class MiniMessageToDslStructuredComponentTest :
                         """.trimIndent(),
                         expectedComponent =
                             component {
-                                selector(parseSelector("@e")) {
+                                selector(entities()) {
                                     separator { text(", ") }
                                 }
                             },
@@ -151,16 +156,20 @@ class MiniMessageToDslStructuredComponentTest :
                     MiniMessageToDslWriter.write(component) shouldBe
                             """
                         component {
-                            selector(parseSelector("@e[name=\"Boss Mob\"]"))
+                            selector(
+                                entities {
+                                    name("Boss Mob")
+                                }
+                            )
                         }
                         """.trimIndent()
                 }
 
-                test("emits the same canonical selector literal for selector and entity NBT components") {
+                test("emits the same typed selector for selector and entity NBT components") {
                     MiniMessageToDslWriter.write(Component.selector("@e[type=zombie]")) shouldContain
-                            """parseSelector("@e[type=minecraft:zombie]")"""
+                            """type(key("minecraft", "zombie"))"""
                     MiniMessageToDslWriter.write(Component.entityNBT("Health", "@e[type=zombie]")) shouldContain
-                            """parseSelector("@e[type=minecraft:zombie]")"""
+                            """type(key("minecraft", "zombie"))"""
                 }
 
                 test("round-trips argument-free translatable components against compiled expected DSL") {
@@ -426,7 +435,7 @@ class MiniMessageToDslStructuredComponentTest :
                     val nbt =
                         component {
                             entityNbt(
-                                parseSelector("@e[type=minecraft:armor_stand]"),
+                                entities { type(key("minecraft", "armor_stand")) },
                                 nbtPath("Pos"),
                             )
                         }
@@ -434,7 +443,12 @@ class MiniMessageToDslStructuredComponentTest :
                     MiniMessageToDslWriter.write(nbt) shouldBe
                             """
                     component {
-                        entityNbt(parseSelector("@e[type=minecraft:armor_stand]"), nbtPath("Pos"))
+                        entityNbt(
+                            entities {
+                                type(key("minecraft", "armor_stand"))
+                            },
+                            nbtPath("Pos")
+                        )
                     }
                     """.trimIndent()
                 }
@@ -453,7 +467,12 @@ class MiniMessageToDslStructuredComponentTest :
                     MiniMessageToDslWriter.write(component) shouldBe
                             """
                     component {
-                        entityNbt(parseSelector("@e[name=\"Boss Mob\"]"), nbtPath("Health"))
+                        entityNbt(
+                            entities {
+                                name("Boss Mob")
+                            },
+                            nbtPath("Health")
+                        )
                     }
                     """.trimIndent()
                 }
@@ -495,12 +514,22 @@ class MiniMessageToDslStructuredComponentTest :
                         expectedSource =
                             """
                         component {
-                            selector(parseSelector("@e[type=minecraft:armor_stand,limit=1]"))
+                            selector(
+                                entities {
+                                    type(key("minecraft", "armor_stand"))
+                                    limit(1)
+                                }
+                            )
                         }
                         """.trimIndent(),
                         expectedComponent =
                             component {
-                                selector(parseSelector("@e[type=minecraft:armor_stand,limit=1]"))
+                                selector(
+                                    entities {
+                                        type(key("minecraft", "armor_stand"))
+                                        limit(1)
+                                    },
+                                )
                             },
                     )
                 }

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTextRenderingTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslTextRenderingTest.kt
@@ -340,7 +340,9 @@ class MiniMessageToDslTextRenderingTest :
                     MiniMessageToDslWriter.write(selector) shouldBe
                             """
                         component {
-                            selector(parseSelector("@e")) {
+                            selector(
+                                entities()
+                            ) {
                                 separator {
                                     text(", ") {
                                         shadow(hex("#112233"))

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDslTest.kt
@@ -162,8 +162,8 @@ class SnbtToDslTest :
                         "\"tag\" eq { \"lore\" eq list(\"a\", \"b\") }"
             }
 
-            "returns null for an empty list" {
-                snbtToDslBody("{items:[]}").shouldBeNull()
+            "renders an empty list as list()" {
+                snbtToDslBody("{items:[]}") shouldBe "\"items\" eq list()"
             }
 
             "parses quoted keys" {


### PR DESCRIPTION
## Summary

- parse Adventure selector patterns through core's strict `parseSelector(...)` and emit the typed selector factories with one scoped call per argument
- cover all six heads and every typed argument: grouped `origin`/`volume` coordinates, ranges through the range builders, presence constants, `!`-negated filters, `nbt { }`/`scores { }`/`advancements { }` blocks
- emit entity-NBT components with the same typed selector (`entityNbt(entities { ... }, nbtPath(...))`)
- add `list()` to the core NBT DSL so empty SNBT lists are typed, making emission total — the raw `parseSelector("...")` literal bridge is deleted
- compile generated Kotlin and round-trip it against the original selector pattern

## Related Issues

Closes #204

## Scope

- [x] MiniMessage converter
- [x] Core NBT DSL (`list()` empty-list builder)
- [x] Tests and generated-source compilation
- [x] Documentation (one line in DESIGN.md + miniToDsl KDoc)

## Notes for Reviewers

Rebuilt on the merged #215/#216 model, which dissolves the old design: the 200-line representability check reimplemented core's canonical renderer to decide when typed emission was "lossless", but the strict parser now rejects every form that check guarded against (mixed polarity, duplicate singletons — verified against the vanilla oracle), and conversion already canonicalizes rather than preserving spelling. Typed emission is therefore unconditional; invalid patterns fail with the parser's offset-bearing `EntitySelectorParseException`, exactly as before.

The one genuine expressiveness gap — an empty SNBT list, which carries no element type — is closed in core (`"Items" eq list()`) rather than worked around in the converter.

Validation performed:

- `./gradlew :minimessage:test` (incl. kctfork compilation + MiniMessage-serialization round trips)
- `./gradlew build`

## Checklist

- [x] Linked related issue
- [x] Verified build/test/lint pass after change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLUKXPAvRHZZJDyh42yUFZ
