### PR TITLE
chore(build): drop redundant explicit-backing-fields flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,6 @@ subprojects {
             // visibility modifier and an explicit type. App/sample modules may opt out with
             // `explicitApi = org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode.Disabled`.
             explicitApi()
-            compilerOptions {
-                freeCompilerArgs.add('-Xexplicit-backing-fields')
-            }
         }
 
         test {


### PR DESCRIPTION
## Summary

Removes `-Xexplicit-backing-fields` from the shared library `kotlin {}` block: the feature is stable in Kotlin 2.4 and the compiler warns the flag is redundant on every build. The `compilerOptions` block only existed to carry it, so it goes too.

Verified `:core:compileKotlin :core:compileTestKotlin` still compile the explicit backing fields in `EntitySelectorBuilder` without the flag.

## Type of change

- [ ] feat — new capability
- [ ] fix — bug fix
- [ ] refactor — internal, no behaviour change
- [ ] docs
- [ ] test
- [x] chore / build / ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WASDpBnBTUbnvDpaNrDFvA
