### PR TITLE
feat(core): add the audience message send dsl

### DIFF
--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Message.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Message.kt
@@ -1,0 +1,13 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import net.kyori.adventure.audience.Audience
+
+/**
+ * Builds a component from a Kotventure component DSL block and sends it to this [Audience] as a
+ * system chat message.
+ *
+ * Works for any audience — a player, the console, or a forwarding audience over many members.
+ */
+public fun Audience.message(init: ComponentScope.() -> Unit): Unit = sendMessage(component(init))

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/MessageDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/MessageDslTest.kt
@@ -1,0 +1,67 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.color.red
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextDecoration
+
+private class RecordingAudience : Audience {
+    val messages = mutableListOf<Component>()
+
+    override fun sendMessage(message: Component) {
+        messages += message
+    }
+}
+
+class MessageDslTest :
+    StringSpec(
+        {
+            "builds and sends the component" {
+                val audience = RecordingAudience()
+
+                audience.message {
+                    text("Hello") {
+                        color(red)
+                        bold()
+                    }
+                }
+
+                audience.messages shouldHaveSize 1
+                val message = audience.messages.single()
+                message shouldHaveChildCount 1
+                message.childAt(0) shouldContainText "Hello"
+                message.childAt(0) shouldHaveColor red
+                message.childAt(0) shouldHaveDecoration TextDecoration.BOLD
+            }
+
+            "sends the same component to every member of a forwarding audience" {
+                val first = RecordingAudience()
+                val second = RecordingAudience()
+
+                Audience.audience(first, second).message {
+                    text("Broadcast")
+                }
+
+                first.messages shouldHaveSize 1
+                second.messages shouldHaveSize 1
+                first.messages.single() shouldBe second.messages.single()
+            }
+
+            "sends an empty component from an empty block" {
+                val audience = RecordingAudience()
+
+                audience.message {}
+
+                audience.messages.single() shouldBe Component.empty()
+            }
+        },
+    )


### PR DESCRIPTION
## Summary

Adds the audience message-send DSL: `audience.message { ... }` builds a component with the existing `component { }` scope and sends it via `Audience.sendMessage(Component)` in one expression, for any `Audience` (players, console, forwarding audiences).

## Related Issues

Closes #33

## DSL Impact

New `core.audience` feature package with a single entry point:

```kotlin
player.message {
    text("Welcome ") { color(gold) }
    text(playerName) { color(aqua) }
}
```

Named `message` (not the issue's original `send`) per maintainer decision — it matches the noun-based Audience family sketched in DESIGN.md §5 (`title { }`, `actionBar { }`, …) and leaves the name free for the future template overload `message(Welcome { ... })`. The issue body was updated to record this.

## Rationale

Foundation for the Phase 2 Audience & UX slice (#34–#41): the one-expression build-and-send idiom every other audience verb will follow. Uses the Adventure 5.x system-message overload `sendMessage(Component)` (the `Identity`/`Identified` overloads no longer exist).

## Testing

`MessageDslTest` (dogfooding the `test` matchers): built component content/colour/decoration reach a recording audience; a forwarding `Audience.audience(...)` delivers the same component to every member; an empty block sends `Component.empty()`.

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages — DESIGN.md §5 already shows `player.message { text("hi") }`; no change needed
- [x] Verified examples build and run — `./gradlew build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLUKXPAvRHZZJDyh42yUFZ
