### PR TITLE
feat(core): add signed message send and deletion helpers

### DIFF
--- a/.agents/skills/idiomatic-kotlin-dsl/SKILL.md
+++ b/.agents/skills/idiomatic-kotlin-dsl/SKILL.md
@@ -122,6 +122,9 @@ public fun component(init: TextScope.() -> Unit): Component =
 ## Smell check before committing
 
 - Could a reviewer understand this file's one job from its name? If not, split it.
+- **Exactly one top-level class/interface/object per file** (AGENTS.md §5 hard rule). Scope + builder = two files
+  (`FooScope.kt`, `FooBuilder.kt`); base + subtype = two files. Run this check on every new file before committing —
+  the maintainer rejects violations on sight. Feature-grouped top-level functions/vals sharing a file are fine.
 - Does any public declaration lack a visibility modifier, return type, or KDoc? Fix it (`explicitApi()` will fail
   otherwise).
 - Is there a builder field that escapes mutable? Make the output immutable.

--- a/.claude/skills/idiomatic-kotlin-dsl/SKILL.md
+++ b/.claude/skills/idiomatic-kotlin-dsl/SKILL.md
@@ -122,6 +122,9 @@ public fun component(init: TextScope.() -> Unit): Component =
 ## Smell check before committing
 
 - Could a reviewer understand this file's one job from its name? If not, split it.
+- **Exactly one top-level class/interface/object per file** (AGENTS.md §5 hard rule). Scope + builder = two files
+  (`FooScope.kt`, `FooBuilder.kt`); base + subtype = two files. Run this check on every new file before committing —
+  the maintainer rejects violations on sight. Feature-grouped top-level functions/vals sharing a file are fine.
 - Does any public declaration lack a visibility modifier, return type, or KDoc? Fix it (`explicitApi()` will fail
   otherwise).
 - Is there a builder field that escapes mutable? Make the output immutable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,10 @@ See `docs/DESIGN.md` §4 for the full map. Non-negotiables:
 ### Single Responsibility (SRP)
 
 - One file / class / object = **one reason to change**. If a file does two things, split it.
+- **Hard rule — one top-level class/interface/object per file**, named after it. Never co-locate two, however
+  related: a scope and its builder are two files (`FooScope.kt` + `FooBuilder.kt`), a base and its subtype are two
+  files. Only a feature's top-level *functions/properties* may share a file (e.g. `NamedColors.kt`). This is checked
+  in every review; violations are an automatic rework.
 - Prefer **many small, focused files** over a few large ones. A file you can't hold in your head is too big.
 - A function does one thing at one level of abstraction. Extract when it grows, nests deeply, or needs a comment to
   explain a block.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Audience.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Audience.kt
@@ -1,0 +1,17 @@
+package io.github.lmliam.kotventure.core.audience
+
+import net.kyori.adventure.audience.Audience
+
+/**
+ * Returns the [Audience] that silently ignores everything sent to it.
+ *
+ * @sample io.github.lmliam.kotventure.core.audience.emptyAudienceSample
+ */
+public fun emptyAudience(): Audience = Audience.empty()
+
+/**
+ * Creates a forwarding [Audience] that relays every operation to each of [members].
+ *
+ * @sample io.github.lmliam.kotventure.core.audience.audienceOfSample
+ */
+public fun audienceOf(vararg members: Audience): Audience = Audience.audience(*members)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/BoundChatBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/BoundChatBuilder.kt
@@ -1,0 +1,35 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.dsl.once
+import net.kyori.adventure.chat.ChatType
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+
+internal open class BoundChatBuilder : BoundChatScope {
+    private var type: ChatType? by once()
+    private var name: Component? by once()
+    private var target: Component? by once()
+
+    override fun type(type: ChatType) {
+        this.type = type
+    }
+
+    override fun name(init: ComponentScope.() -> Unit) = name(component(init))
+
+    override fun <T : ComponentLike> name(component: T) {
+        name = component.asComponent()
+    }
+
+    override fun target(init: ComponentScope.() -> Unit) = target(component(init))
+
+    override fun <T : ComponentLike> target(component: T) {
+        target = component.asComponent()
+    }
+
+    internal fun buildBound(): ChatType.Bound {
+        val name = checkNotNull(name) { "'name' is not set." }
+        return (type ?: ChatType.CHAT).bind(name, target)
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/BoundChatScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/BoundChatScope.kt
@@ -1,0 +1,72 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.chat.ChatType
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Scope for configuring the bound chat type of a player-styled chat message: the sender [name], an
+ * optional [target], and the [type] of chat the client renders it as.
+ */
+@KotventureDslMarker
+public interface BoundChatScope {
+    /** Ordinary player chat — the [type] used when none is set. */
+    public val chat: ChatType get() = ChatType.CHAT
+
+    /** A message sent with the `/say` command. */
+    public val sayCommand: ChatType get() = ChatType.SAY_COMMAND
+
+    /** A message received through the `/msg` command. */
+    public val msgCommandIncoming: ChatType get() = ChatType.MSG_COMMAND_INCOMING
+
+    /** A message sent with the `/msg` command. */
+    public val msgCommandOutgoing: ChatType get() = ChatType.MSG_COMMAND_OUTGOING
+
+    /** A message received through the `/teammsg` command. */
+    public val teamMsgCommandIncoming: ChatType get() = ChatType.TEAM_MSG_COMMAND_INCOMING
+
+    /** A message sent with the `/teammsg` command. */
+    public val teamMsgCommandOutgoing: ChatType get() = ChatType.TEAM_MSG_COMMAND_OUTGOING
+
+    /** A message sent with the `/me` command. */
+    public val emoteCommand: ChatType get() = ChatType.EMOTE_COMMAND
+
+    /**
+     * Sets the type of chat the message renders as, such as [msgCommandIncoming].
+     *
+     * When not set, the message renders as ordinary player chat ([chat]).
+     *
+     * @throws IllegalStateException when the type is already set in this block.
+     */
+    public fun type(type: ChatType)
+
+    /**
+     * Builds the sender name shown alongside the message from a component DSL block.
+     *
+     * @throws IllegalStateException when the name is already set in this block.
+     */
+    public fun name(init: ComponentScope.() -> Unit)
+
+    /**
+     * Sets the sender name shown alongside the message, such as a player's display name.
+     *
+     * @throws IllegalStateException when the name is already set in this block.
+     */
+    public fun <T : ComponentLike> name(component: T)
+
+    /**
+     * Builds the message target shown by directed chat types (such as the `/msg` commands) from a
+     * component DSL block.
+     *
+     * @throws IllegalStateException when the target is already set in this block.
+     */
+    public fun target(init: ComponentScope.() -> Unit)
+
+    /**
+     * Sets the message target shown by directed chat types (such as the `/msg` commands).
+     *
+     * @throws IllegalStateException when the target is already set in this block.
+     */
+    public fun <T : ComponentLike> target(component: T)
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Chat.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Chat.kt
@@ -7,6 +7,10 @@ import net.kyori.adventure.chat.SignedMessage
  * Builds a component and its bound chat type from a [ChatScope] block and sends it to this
  * [Audience] as a non-system, player-styled chat message.
  *
+ * Unlike [message], which sends an unattributed system line, the client renders this through the
+ * player-chat pipeline: attributed to the scope's `name` in the chosen chat-type format and subject
+ * to the viewer's chat visibility settings.
+ *
  * Works for any audience — a player, the console, or a forwarding audience over many members.
  *
  * @throws IllegalStateException when the block leaves `name` or `content` unset, or sets any slot

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Chat.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Chat.kt
@@ -1,0 +1,35 @@
+package io.github.lmliam.kotventure.core.audience
+
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.chat.SignedMessage
+
+/**
+ * Builds a component and its bound chat type from a [ChatScope] block and sends it to this
+ * [Audience] as a non-system, player-styled chat message.
+ *
+ * Works for any audience — a player, the console, or a forwarding audience over many members.
+ *
+ * @throws IllegalStateException when the block leaves `name` or `content` unset, or sets any slot
+ *   twice.
+ * @sample io.github.lmliam.kotventure.core.audience.chatSample
+ */
+public fun Audience.chat(init: ChatScope.() -> Unit) {
+    val builder = ChatBuilder().apply(init)
+    sendMessage(builder.buildContent(), builder.buildBound())
+}
+
+/**
+ * Builds a bound chat type from a [BoundChatScope] block and sends the already-signed [signed]
+ * message to this [Audience] with it.
+ *
+ * A genuine player-signed [SignedMessage] cannot be constructed by hand — obtain one from a
+ * platform source such as Paper's chat event (`signedMessage()`) or its Brigadier signed-message
+ * command argument; server-authored system messages come from [systemMessage].
+ *
+ * @throws IllegalStateException when the block leaves `name` unset, or sets any slot twice.
+ * @sample io.github.lmliam.kotventure.core.audience.signedChatSample
+ */
+public fun Audience.chat(
+    signed: SignedMessage,
+    init: BoundChatScope.() -> Unit,
+): Unit = sendMessage(signed, BoundChatBuilder().apply(init).buildBound())

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/ChatBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/ChatBuilder.kt
@@ -1,0 +1,49 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.dsl.once
+import net.kyori.adventure.chat.ChatType
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+
+internal open class BoundChatBuilder : BoundChatScope {
+    private var type: ChatType? by once()
+    private var name: Component? by once()
+    private var target: Component? by once()
+
+    override fun type(type: ChatType) {
+        this.type = type
+    }
+
+    override fun name(init: ComponentScope.() -> Unit) = name(component(init))
+
+    override fun <T : ComponentLike> name(component: T) {
+        name = component.asComponent()
+    }
+
+    override fun target(init: ComponentScope.() -> Unit) = target(component(init))
+
+    override fun <T : ComponentLike> target(component: T) {
+        target = component.asComponent()
+    }
+
+    internal fun buildBound(): ChatType.Bound {
+        val name = checkNotNull(name) { "'name' is not set." }
+        return (type ?: ChatType.CHAT).bind(name, target)
+    }
+}
+
+internal class ChatBuilder :
+    BoundChatBuilder(),
+    ChatScope {
+    private var content: Component? by once()
+
+    override fun content(init: ComponentScope.() -> Unit) = content(component(init))
+
+    override fun <T : ComponentLike> content(component: T) {
+        content = component.asComponent()
+    }
+
+    internal fun buildContent(): Component = checkNotNull(content) { "'content' is not set." }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/ChatBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/ChatBuilder.kt
@@ -3,36 +3,8 @@ package io.github.lmliam.kotventure.core.audience
 import io.github.lmliam.kotventure.core.component.ComponentScope
 import io.github.lmliam.kotventure.core.component.component
 import io.github.lmliam.kotventure.core.dsl.once
-import net.kyori.adventure.chat.ChatType
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentLike
-
-internal open class BoundChatBuilder : BoundChatScope {
-    private var type: ChatType? by once()
-    private var name: Component? by once()
-    private var target: Component? by once()
-
-    override fun type(type: ChatType) {
-        this.type = type
-    }
-
-    override fun name(init: ComponentScope.() -> Unit) = name(component(init))
-
-    override fun <T : ComponentLike> name(component: T) {
-        name = component.asComponent()
-    }
-
-    override fun target(init: ComponentScope.() -> Unit) = target(component(init))
-
-    override fun <T : ComponentLike> target(component: T) {
-        target = component.asComponent()
-    }
-
-    internal fun buildBound(): ChatType.Bound {
-        val name = checkNotNull(name) { "'name' is not set." }
-        return (type ?: ChatType.CHAT).bind(name, target)
-    }
-}
 
 internal class ChatBuilder :
     BoundChatBuilder(),

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/ChatScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/ChatScope.kt
@@ -2,53 +2,7 @@ package io.github.lmliam.kotventure.core.audience
 
 import io.github.lmliam.kotventure.core.component.ComponentScope
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
-import net.kyori.adventure.chat.ChatType
 import net.kyori.adventure.text.ComponentLike
-
-/**
- * Scope for configuring the bound chat type of a player-styled chat message: the sender [name], an
- * optional [target], and the [type] of chat the client renders it as.
- */
-@KotventureDslMarker
-public interface BoundChatScope {
-    /**
-     * Sets the type of chat the message renders as, such as [ChatType.MSG_COMMAND_INCOMING].
-     *
-     * When not set, the message renders as ordinary player chat ([ChatType.CHAT]).
-     *
-     * @throws IllegalStateException when the type is already set in this block.
-     */
-    public fun type(type: ChatType)
-
-    /**
-     * Builds the sender name shown alongside the message from a component DSL block.
-     *
-     * @throws IllegalStateException when the name is already set in this block.
-     */
-    public fun name(init: ComponentScope.() -> Unit)
-
-    /**
-     * Sets the sender name shown alongside the message, such as a player's display name.
-     *
-     * @throws IllegalStateException when the name is already set in this block.
-     */
-    public fun <T : ComponentLike> name(component: T)
-
-    /**
-     * Builds the message target shown by directed chat types (such as the `/msg` commands) from a
-     * component DSL block.
-     *
-     * @throws IllegalStateException when the target is already set in this block.
-     */
-    public fun target(init: ComponentScope.() -> Unit)
-
-    /**
-     * Sets the message target shown by directed chat types (such as the `/msg` commands).
-     *
-     * @throws IllegalStateException when the target is already set in this block.
-     */
-    public fun <T : ComponentLike> target(component: T)
-}
 
 /**
  * Scope for sending a component as a player-styled chat message: the [BoundChatScope] slots plus

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/ChatScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/ChatScope.kt
@@ -1,0 +1,72 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.chat.ChatType
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Scope for configuring the bound chat type of a player-styled chat message: the sender [name], an
+ * optional [target], and the [type] of chat the client renders it as.
+ */
+@KotventureDslMarker
+public interface BoundChatScope {
+    /**
+     * Sets the type of chat the message renders as, such as [ChatType.MSG_COMMAND_INCOMING].
+     *
+     * When not set, the message renders as ordinary player chat ([ChatType.CHAT]).
+     *
+     * @throws IllegalStateException when the type is already set in this block.
+     */
+    public fun type(type: ChatType)
+
+    /**
+     * Builds the sender name shown alongside the message from a component DSL block.
+     *
+     * @throws IllegalStateException when the name is already set in this block.
+     */
+    public fun name(init: ComponentScope.() -> Unit)
+
+    /**
+     * Sets the sender name shown alongside the message, such as a player's display name.
+     *
+     * @throws IllegalStateException when the name is already set in this block.
+     */
+    public fun <T : ComponentLike> name(component: T)
+
+    /**
+     * Builds the message target shown by directed chat types (such as the `/msg` commands) from a
+     * component DSL block.
+     *
+     * @throws IllegalStateException when the target is already set in this block.
+     */
+    public fun target(init: ComponentScope.() -> Unit)
+
+    /**
+     * Sets the message target shown by directed chat types (such as the `/msg` commands).
+     *
+     * @throws IllegalStateException when the target is already set in this block.
+     */
+    public fun <T : ComponentLike> target(component: T)
+}
+
+/**
+ * Scope for sending a component as a player-styled chat message: the [BoundChatScope] slots plus
+ * the message [content] itself.
+ */
+@KotventureDslMarker
+public interface ChatScope : BoundChatScope {
+    /**
+     * Builds the chat message content from a component DSL block.
+     *
+     * @throws IllegalStateException when the content is already set in this block.
+     */
+    public fun content(init: ComponentScope.() -> Unit)
+
+    /**
+     * Sets the chat message content.
+     *
+     * @throws IllegalStateException when the content is already set in this block.
+     */
+    public fun <T : ComponentLike> content(component: T)
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Delete.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Delete.kt
@@ -1,0 +1,26 @@
+package io.github.lmliam.kotventure.core.audience
+
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.chat.SignedMessage
+
+/**
+ * Requests deletion of the previously sent [signed] message from this [Audience]'s chat.
+ *
+ * Adventure silently ignores messages without a signature; this helper fails fast instead, so a
+ * deletion that can never happen is surfaced at the call site.
+ *
+ * @throws IllegalStateException when [signed] carries no signature ([SignedMessage.canDelete] is
+ *   `false`), as is the case for system messages.
+ * @sample io.github.lmliam.kotventure.core.audience.deleteSample
+ */
+public fun Audience.delete(signed: SignedMessage) {
+    check(signed.canDelete()) { "'signed' has no signature, so it can never be deleted." }
+    deleteMessage(signed)
+}
+
+/**
+ * Requests deletion of the previously sent message with [signature] from this [Audience]'s chat.
+ *
+ * @sample io.github.lmliam.kotventure.core.audience.deleteBySignatureSample
+ */
+public fun Audience.delete(signature: SignedMessage.Signature): Unit = deleteMessage(signature)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Message.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Message.kt
@@ -8,6 +8,9 @@ import net.kyori.adventure.audience.Audience
  * Builds a component from a Kotventure component DSL block and sends it to this [Audience] as a
  * system chat message.
  *
+ * A system message renders as a plain, unattributed line from the server; to send player-styled
+ * chat attributed to a sender name, use [chat].
+ *
  * Works for any audience — a player, the console, or a forwarding audience over many members.
  */
 public fun Audience.message(init: ComponentScope.() -> Unit): Unit = sendMessage(component(init))

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Signature.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Signature.kt
@@ -1,0 +1,11 @@
+package io.github.lmliam.kotventure.core.audience
+
+import net.kyori.adventure.chat.SignedMessage
+
+/**
+ * Wraps raw signature [bytes] as a [SignedMessage.Signature], for [delete]-by-signature calls when
+ * only the stored bytes of a signed message survive.
+ *
+ * @sample io.github.lmliam.kotventure.core.audience.deleteBySignatureSample
+ */
+public fun signature(bytes: ByteArray): SignedMessage.Signature = SignedMessage.signature(bytes)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/SystemMessage.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/SystemMessage.kt
@@ -1,0 +1,19 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import net.kyori.adventure.chat.SignedMessage
+
+/**
+ * Creates a server-authored system [SignedMessage] from the plain [message] string, with unsigned
+ * component content built from [init] when given.
+ *
+ * System messages carry no player signature, so they cannot be deleted through [delete]; genuine
+ * player-signed messages can only be obtained from a platform source such as Paper's chat event.
+ *
+ * @sample io.github.lmliam.kotventure.core.audience.systemMessageSample
+ */
+public fun systemMessage(
+    message: String,
+    init: (ComponentScope.() -> Unit)? = null,
+): SignedMessage = SignedMessage.system(message, init?.let { component(it) })

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/AudienceSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/AudienceSamples.kt
@@ -1,0 +1,15 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.text.text
+
+internal fun emptyAudienceSample() {
+    val nobody = emptyAudience()
+
+    nobody.message { text("never rendered") }
+}
+
+internal fun audienceOfSample() {
+    val team = audienceOf(emptyAudience(), emptyAudience())
+
+    team.message { text("delivered to every member") }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/ChatSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/ChatSamples.kt
@@ -3,23 +3,21 @@ package io.github.lmliam.kotventure.core.audience
 import io.github.lmliam.kotventure.core.color.aqua
 import io.github.lmliam.kotventure.core.color.gold
 import io.github.lmliam.kotventure.core.text.text
-import net.kyori.adventure.audience.Audience
-import net.kyori.adventure.chat.ChatType
 import net.kyori.adventure.chat.SignedMessage
 
 internal fun chatSample() {
-    val audience = Audience.empty()
+    val audience = emptyAudience()
 
     audience.chat {
         name { text("Steve") { color(aqua) } }
         target { text("Alex") }
-        type(ChatType.MSG_COMMAND_OUTGOING)
+        type(msgCommandOutgoing)
         content { text("hi there") }
     }
 }
 
 internal fun signedChatSample() {
-    val audience = Audience.empty()
+    val audience = emptyAudience()
     val signed = signedMessageFromPlatform()
 
     audience.chat(signed) {
@@ -28,7 +26,7 @@ internal fun signedChatSample() {
 }
 
 internal fun deleteSample() {
-    val audience = Audience.empty()
+    val audience = emptyAudience()
     val signed = signedMessageFromPlatform()
 
     if (signed.canDelete()) {
@@ -37,10 +35,9 @@ internal fun deleteSample() {
 }
 
 internal fun deleteBySignatureSample() {
-    val audience = Audience.empty()
-    val signature = SignedMessage.signature(byteArrayOf(1, 2, 3))
+    val audience = emptyAudience()
 
-    audience.delete(signature)
+    audience.delete(signature(byteArrayOf(1, 2, 3)))
 }
 
 internal fun systemMessageSample() {
@@ -50,7 +47,7 @@ internal fun systemMessageSample() {
             text("soon")
         }
 
-    Audience.empty().chat(announcement) {
+    emptyAudience().chat(announcement) {
         name { text("Server") }
     }
 }

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/ChatSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/ChatSamples.kt
@@ -1,0 +1,59 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.color.aqua
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.text.text
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.chat.ChatType
+import net.kyori.adventure.chat.SignedMessage
+
+internal fun chatSample() {
+    val audience = Audience.empty()
+
+    audience.chat {
+        name { text("Steve") { color(aqua) } }
+        target { text("Alex") }
+        type(ChatType.MSG_COMMAND_OUTGOING)
+        content { text("hi there") }
+    }
+}
+
+internal fun signedChatSample() {
+    val audience = Audience.empty()
+    val signed = signedMessageFromPlatform()
+
+    audience.chat(signed) {
+        name { text("Steve") }
+    }
+}
+
+internal fun deleteSample() {
+    val audience = Audience.empty()
+    val signed = signedMessageFromPlatform()
+
+    if (signed.canDelete()) {
+        audience.delete(signed)
+    }
+}
+
+internal fun deleteBySignatureSample() {
+    val audience = Audience.empty()
+    val signature = SignedMessage.signature(byteArrayOf(1, 2, 3))
+
+    audience.delete(signature)
+}
+
+internal fun systemMessageSample() {
+    val announcement =
+        systemMessage("Server restarting soon") {
+            text("Server restarting ") { color(gold) }
+            text("soon")
+        }
+
+    Audience.empty().chat(announcement) {
+        name { text("Server") }
+    }
+}
+
+/** Stand-in for a platform source such as Paper's chat event or signed-message command argument. */
+private fun signedMessageFromPlatform(): SignedMessage = systemMessage("hi there")

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/AudienceTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/AudienceTest.kt
@@ -1,0 +1,37 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.text.text
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.Component
+
+private class RecordingMemberAudience : Audience {
+    val messages = mutableListOf<Component>()
+
+    override fun sendMessage(message: Component) {
+        messages += message
+    }
+}
+
+class AudienceTest :
+    StringSpec(
+        {
+            "emptyAudience returns the audience that ignores everything" {
+                emptyAudience() shouldBeSameInstanceAs Audience.empty()
+            }
+
+            "audienceOf forwards to every member" {
+                val first = RecordingMemberAudience()
+                val second = RecordingMemberAudience()
+
+                audienceOf(first, second).message { text("Broadcast") }
+
+                first.messages shouldHaveSize 1
+                second.messages shouldHaveSize 1
+                first.messages.single() shouldBe second.messages.single()
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/ChatDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/ChatDslTest.kt
@@ -1,0 +1,180 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.color.aqua
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.chat.ChatType
+import net.kyori.adventure.chat.SignedMessage
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.Component
+
+private class RecordingChatAudience : Audience {
+    val componentSends = mutableListOf<Pair<Component, ChatType.Bound>>()
+    val signedSends = mutableListOf<Pair<SignedMessage, ChatType.Bound>>()
+
+    override fun sendMessage(
+        message: Component,
+        boundChatType: ChatType.Bound,
+    ) {
+        componentSends += message to boundChatType
+    }
+
+    override fun sendMessage(
+        signedMessage: SignedMessage,
+        boundChatType: ChatType.Bound,
+    ) {
+        signedSends += signedMessage to boundChatType
+    }
+}
+
+class ChatDslTest :
+    StringSpec(
+        {
+            "sends the content as ordinary player chat by default" {
+                val audience = RecordingChatAudience()
+
+                audience.chat {
+                    name { text("Steve") { color(aqua) } }
+                    content { text("hi there") }
+                }
+
+                audience.componentSends shouldHaveSize 1
+                val (content, bound) = audience.componentSends.single()
+                content shouldContainText "hi there"
+                bound.type().key() shouldBe Key.key("chat")
+                bound.name().childAt(0) shouldContainText "Steve"
+                bound.name().childAt(0) shouldHaveColor aqua
+                bound.target().shouldBeNull()
+            }
+
+            "binds an explicit chat type and target" {
+                val audience = RecordingChatAudience()
+
+                audience.chat {
+                    type(ChatType.MSG_COMMAND_OUTGOING)
+                    name { text("Steve") }
+                    target { text("Alex") }
+                    content { text("psst") }
+                }
+
+                val (_, bound) = audience.componentSends.single()
+                bound.type().key() shouldBe Key.key("msg_command_outgoing")
+                bound.target().shouldNotBeNull() shouldContainText "Alex"
+            }
+
+            "accepts existing components for name, target, and content" {
+                val audience = RecordingChatAudience()
+                val name = Component.text("Steve")
+                val target = Component.text("Alex")
+                val content = Component.text("hi there")
+
+                audience.chat {
+                    name(name)
+                    target(target)
+                    content(content)
+                }
+
+                val (sent, bound) = audience.componentSends.single()
+                sent shouldBe content
+                bound.name() shouldBe name
+                bound.target() shouldBe target
+            }
+
+            "sends a signed message with the built bound chat type" {
+                val audience = RecordingChatAudience()
+                val signed = systemMessage("hi there")
+
+                audience.chat(signed) {
+                    name { text("Steve") }
+                }
+
+                audience.signedSends shouldHaveSize 1
+                val (sent, bound) = audience.signedSends.single()
+                sent shouldBeSameInstanceAs signed
+                bound.type().key() shouldBe Key.key("chat")
+                bound.name() shouldContainText "Steve"
+            }
+
+            "sends the same chat to every member of a forwarding audience" {
+                val first = RecordingChatAudience()
+                val second = RecordingChatAudience()
+
+                Audience.audience(first, second).chat {
+                    name { text("Steve") }
+                    content { text("broadcast") }
+                }
+
+                first.componentSends shouldHaveSize 1
+                second.componentSends shouldHaveSize 1
+                first.componentSends.single() shouldBe second.componentSends.single()
+            }
+
+            "rejects a block without a name" {
+                shouldThrow<IllegalStateException> {
+                    RecordingChatAudience().chat {
+                        content { text("hi") }
+                    }
+                }
+            }
+
+            "rejects a block without content" {
+                shouldThrow<IllegalStateException> {
+                    RecordingChatAudience().chat {
+                        name { text("Steve") }
+                    }
+                }
+            }
+
+            "rejects a signed block without a name" {
+                shouldThrow<IllegalStateException> {
+                    RecordingChatAudience().chat(systemMessage("hi")) {}
+                }
+            }
+
+            "rejects a duplicate name" {
+                shouldThrow<IllegalStateException> {
+                    RecordingChatAudience().chat {
+                        name { text("Steve") }
+                        name { text("Alex") }
+                    }
+                }
+            }
+
+            "rejects a duplicate target" {
+                shouldThrow<IllegalStateException> {
+                    RecordingChatAudience().chat {
+                        target { text("Alex") }
+                        target { text("Steve") }
+                    }
+                }
+            }
+
+            "rejects a duplicate type" {
+                shouldThrow<IllegalStateException> {
+                    RecordingChatAudience().chat {
+                        type(ChatType.CHAT)
+                        type(ChatType.SAY_COMMAND)
+                    }
+                }
+            }
+
+            "rejects duplicate content" {
+                shouldThrow<IllegalStateException> {
+                    RecordingChatAudience().chat {
+                        content { text("hi") }
+                        content { text("there") }
+                    }
+                }
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/ChatDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/ChatDslTest.kt
@@ -61,7 +61,7 @@ class ChatDslTest :
                 val audience = RecordingChatAudience()
 
                 audience.chat {
-                    type(ChatType.MSG_COMMAND_OUTGOING)
+                    type(msgCommandOutgoing)
                     name { text("Steve") }
                     target { text("Alex") }
                     content { text("psst") }
@@ -109,7 +109,7 @@ class ChatDslTest :
                 val first = RecordingChatAudience()
                 val second = RecordingChatAudience()
 
-                Audience.audience(first, second).chat {
+                audienceOf(first, second).chat {
                     name { text("Steve") }
                     content { text("broadcast") }
                 }
@@ -162,8 +162,8 @@ class ChatDslTest :
             "rejects a duplicate type" {
                 shouldThrow<IllegalStateException> {
                     RecordingChatAudience().chat {
-                        type(ChatType.CHAT)
-                        type(ChatType.SAY_COMMAND)
+                        type(chat)
+                        type(sayCommand)
                     }
                 }
             }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/DeleteDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/DeleteDslTest.kt
@@ -47,7 +47,7 @@ class DeleteDslTest :
         {
             "deletes a signed message" {
                 val audience = RecordingDeleteAudience()
-                val signed = PlayerSignedMessage(SignedMessage.signature(byteArrayOf(1, 2, 3)))
+                val signed = PlayerSignedMessage(signature(byteArrayOf(1, 2, 3)))
 
                 audience.delete(signed)
 
@@ -68,7 +68,7 @@ class DeleteDslTest :
 
             "deletes by signature" {
                 val audience = RecordingDeleteAudience()
-                val signature = SignedMessage.signature(byteArrayOf(4, 5, 6))
+                val signature = signature(byteArrayOf(4, 5, 6))
 
                 audience.delete(signature)
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/DeleteDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/DeleteDslTest.kt
@@ -1,0 +1,79 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.chat.SignedMessage
+import net.kyori.adventure.identity.Identity
+import net.kyori.adventure.text.Component
+import java.time.Instant
+import java.util.UUID
+
+private class RecordingDeleteAudience : Audience {
+    val deletedMessages = mutableListOf<SignedMessage>()
+    val deletedSignatures = mutableListOf<SignedMessage.Signature>()
+
+    override fun deleteMessage(signedMessage: SignedMessage) {
+        deletedMessages += signedMessage
+    }
+
+    override fun deleteMessage(signature: SignedMessage.Signature) {
+        deletedSignatures += signature
+    }
+}
+
+/** A player-signed message stand-in; genuine ones only exist on a platform. */
+private class PlayerSignedMessage(
+    private val signature: SignedMessage.Signature,
+) : SignedMessage {
+    override fun timestamp(): Instant = Instant.EPOCH
+
+    override fun salt(): Long = 0
+
+    override fun signature(): SignedMessage.Signature = signature
+
+    override fun unsignedContent(): Component? = null
+
+    override fun message(): String = "player chat"
+
+    override fun identity(): Identity = Identity.identity(UUID(0, 0))
+}
+
+class DeleteDslTest :
+    StringSpec(
+        {
+            "deletes a signed message" {
+                val audience = RecordingDeleteAudience()
+                val signed = PlayerSignedMessage(SignedMessage.signature(byteArrayOf(1, 2, 3)))
+
+                audience.delete(signed)
+
+                audience.deletedMessages shouldHaveSize 1
+                audience.deletedMessages.single() shouldBeSameInstanceAs signed
+            }
+
+            "rejects deleting a message without a signature" {
+                val audience = RecordingDeleteAudience()
+
+                shouldThrow<IllegalStateException> {
+                    audience.delete(systemMessage("cannot be deleted"))
+                }
+
+                audience.deletedMessages.shouldBeEmpty()
+                audience.deletedSignatures.shouldBeEmpty()
+            }
+
+            "deletes by signature" {
+                val audience = RecordingDeleteAudience()
+                val signature = SignedMessage.signature(byteArrayOf(4, 5, 6))
+
+                audience.delete(signature)
+
+                audience.deletedSignatures shouldHaveSize 1
+                audience.deletedSignatures.single() shouldBeSameInstanceAs signature
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/SignatureTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/SignatureTest.kt
@@ -1,0 +1,15 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class SignatureTest :
+    StringSpec(
+        {
+            "wraps the raw bytes" {
+                val bytes = byteArrayOf(1, 2, 3)
+
+                signature(bytes).bytes() shouldBe bytes
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/SystemMessageDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/SystemMessageDslTest.kt
@@ -1,0 +1,42 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class SystemMessageDslTest :
+    StringSpec(
+        {
+            "builds a bare system message without unsigned content" {
+                val message = systemMessage("Server restarting soon")
+
+                message.isSystem shouldBe true
+                message.message() shouldBe "Server restarting soon"
+                message.unsignedContent().shouldBeNull()
+                message.canDelete() shouldBe false
+            }
+
+            "builds unsigned content from the block" {
+                val message =
+                    systemMessage("Server restarting soon") {
+                        text("Server restarting ") { color(gold) }
+                        text("soon")
+                    }
+
+                message.isSystem shouldBe true
+                message.message() shouldBe "Server restarting soon"
+                val content = message.unsignedContent().shouldNotBeNull()
+                content shouldHaveChildCount 2
+                content.childAt(0) shouldContainText "Server restarting "
+                content.childAt(0) shouldHaveColor gold
+                content.childAt(1) shouldContainText "soon"
+            }
+        },
+    )


### PR DESCRIPTION
## Summary

Adds audience DSL coverage for Adventure 5.x's modern chat surface: a unified `chat { }` DSL for
player-styled (bound chat type) sends of both plain components and already-signed messages,
fail-fast `delete(...)` helpers for signed messages and signatures, and a `systemMessage(...)`
string+block factory for the only constructible `SignedMessage` kind.

## Related Issues

Closes #84

## DSL Impact

```kotlin
// unsigned component as player-styled chat (type defaults to ChatType.CHAT)
audience.chat {
    name { text("Steve") { color(aqua) } }
    target { text("Alex") }              // optional
    type(ChatType.MSG_COMMAND_OUTGOING)  // optional
    content { text("hi there") }
}

// already-signed message — the scope has no content, so the compiler enforces the difference
audience.chat(signed) {
    name { text("Steve") }
}

// deletion
audience.delete(signed)      // ISE when the message has no signature (Adventure silently no-ops)
audience.delete(signature)

// system SignedMessage factory
val msg = systemMessage("plain fallback") { text("Fancy") { color(gold) } }
```

Design notes:

- No `ChatType.CHAT.bind(...)` at call sites — the bound chat type is built by the DSL, named after
  the concept (player chat) rather than the machinery (bind/bound).
- All singleton slots are strict: duplicates and missing required slots (`name`, `content`) throw
  `IllegalStateException` naming the slot, via the existing `once()` delegate.
- `delete(signed)` upgrades Adventure's silent no-op on unsigned messages to a fail-fast ISE
  (`SignedMessage.canDelete()` guard).
- The issue's "Kotlin-friendly system/non-system wrappers" scope bullet is deliberately narrowed to
  the `systemMessage` factory: `isSystem()` already surfaces as a synthetic Kotlin property, so
  accessor wrappers would add no idiomatic value.
- Paper acquisition of genuine player-signed messages is documented in KDoc prose only (chat event
  `signedMessage()`, Brigadier signed-message argument) — no Paper types anywhere in `core`.

## Rationale

Adventure 5.x removed the legacy `Identity`/`Identified` message overloads; plugins that render
player chat, `/msg`-style whispers, or moderate (delete) chat must go through
`sendMessage(SignedMessage | Component, ChatType.Bound)` and `deleteMessage(...)`. This gives those
operations the same idiomatic, strict DSL surface as the rest of the audience feature (#33).

## Testing

- `ChatDslTest` — bound sends through a recording audience: default `CHAT` type, explicit
  type/target, existing-component overloads, signed sends, forwarding audiences, and ISE on every
  missing/duplicate slot.
- `DeleteDslTest` — delete-by-message (recorded instance), ISE on unsigned messages, and
  delete-by-signature.
- `SystemMessageDslTest` — bare and block-built system messages, asserted with the project's own
  component matchers.
- Local recording fakes per the pre-#66 convention; `./gradlew build` green (ktlint, spotless,
  koverVerify).

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages — n/a; KDoc + `@sample`-linked `ChatSamples.kt` cover the new surface
- [x] Verified examples build and run — samples compile in the `samples` source set; behaviour exercised by the Kotest suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLUKXPAvRHZZJDyh42yUFZ
