### PR TITLE
feat(audience): add the action bar dsl

### DIFF
--- a/.agents/skills/writing-component-tests/SKILL.md
+++ b/.agents/skills/writing-component-tests/SKILL.md
@@ -34,6 +34,16 @@ class StyleDslTest : StringSpec({
   deliverable in its own right — see issue #31) rather than asserting inline.
 - Matchers must give **readable failure messages** (actual vs expected).
 
+## Dogfood the DSL surface too
+
+- Arrange/act code uses **Kotventure's own entry points** wherever an equivalent exists: `audienceOf(first, second)`
+  not `Audience.audience(first, second)`, `emptyAudience()` not `Audience.empty()`, `component { }` not
+  `Component.text()...`. Before reaching for a raw `net.kyori` factory, check the owning feature package for the DSL
+  equivalent.
+- The exception is the **expected value in an assertion**: keep it raw Adventure (e.g. `shouldBe Component.empty()`)
+  so the DSL is verified against Adventure ground truth rather than against itself — asserting `component {}` equals
+  `component {}` proves nothing.
+
 ## Snapshot / golden tests
 
 - For larger messages where regressions matter, use `shouldMatchSnapshot()` (issue #32). Snapshots serialize to a stable

--- a/.claude/skills/writing-component-tests/SKILL.md
+++ b/.claude/skills/writing-component-tests/SKILL.md
@@ -34,6 +34,16 @@ class StyleDslTest : StringSpec({
   deliverable in its own right — see issue #31) rather than asserting inline.
 - Matchers must give **readable failure messages** (actual vs expected).
 
+## Dogfood the DSL surface too
+
+- Arrange/act code uses **Kotventure's own entry points** wherever an equivalent exists: `audienceOf(first, second)`
+  not `Audience.audience(first, second)`, `emptyAudience()` not `Audience.empty()`, `component { }` not
+  `Component.text()...`. Before reaching for a raw `net.kyori` factory, check the owning feature package for the DSL
+  equivalent.
+- The exception is the **expected value in an assertion**: keep it raw Adventure (e.g. `shouldBe Component.empty()`)
+  so the DSL is verified against Adventure ground truth rather than against itself — asserting `component {}` equals
+  `component {}` proves nothing.
+
 ## Snapshot / golden tests
 
 - For larger messages where regressions matter, use `shouldMatchSnapshot()` (issue #32). Snapshots serialize to a stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,10 @@ Qualitative metrics (reviewed, not measured — the review bar):
 
 - **Kotest** for everything. Every behavioural change ships with tests; write the test first when practical.
 - **Dogfood the project's own matchers** (the `test` module). See the skill `writing-component-tests`.
+- **Dogfood the DSL surface in arrange/act code** — tests, samples, and docs use Kotventure's own entry points wherever
+  an equivalent exists (`audienceOf(...)` over `Audience.audience(...)`, `emptyAudience()` over `Audience.empty()`).
+  Assertion *expected values* are the exception: they stay raw `net.kyori` (e.g. `Component.empty()`) so builders are
+  verified against Adventure ground truth, not against the DSL itself (§5 "Wrapping Adventure").
 - Use **snapshot tests** for message regressions where appropriate.
 
 ## 7. Commits, PRs, branches (enforced in CI)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -161,6 +161,7 @@ themes.theme("brand")?.style("header")       // dynamic interop lookup
 
 // ── Sending (Audience extensions) ──────────────────────────────
 player.message { text("hi") }
+player.actionBar { text("+10 XP") }
 player.title {
     title { text("Welcome") }
     subtitle { mini("<gray>to the server") }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/ActionBar.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/ActionBar.kt
@@ -1,0 +1,19 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import net.kyori.adventure.audience.Audience
+
+/**
+ * Builds a component from a Kotventure component DSL block and shows it in this [Audience]'s
+ * action bar.
+ *
+ * The action bar is the transient line above a player's hotbar; to send a persistent chat line
+ * instead, use [message].
+ *
+ * Works for any audience — a player, the console, or a forwarding audience over many members;
+ * audiences without an action bar ignore it.
+ *
+ * @sample io.github.lmliam.kotventure.core.audience.actionBarSample
+ */
+public fun Audience.actionBar(init: ComponentScope.() -> Unit): Unit = sendActionBar(component(init))

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Message.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Message.kt
@@ -12,5 +12,7 @@ import net.kyori.adventure.audience.Audience
  * chat attributed to a sender name, use [chat].
  *
  * Works for any audience — a player, the console, or a forwarding audience over many members.
+ *
+ * @sample io.github.lmliam.kotventure.core.audience.messageSample
  */
 public fun Audience.message(init: ComponentScope.() -> Unit): Unit = sendMessage(component(init))

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/ActionBarSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/ActionBarSamples.kt
@@ -1,0 +1,12 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.text.text
+
+internal fun actionBarSample() {
+    val audience = emptyAudience()
+
+    audience.actionBar {
+        text("+10 XP") { color(gold) }
+    }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/MessageSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/MessageSamples.kt
@@ -1,0 +1,12 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.text.text
+
+internal fun messageSample() {
+    val audience = emptyAudience()
+
+    audience.message {
+        text("Welcome to the server") { color(gold) }
+    }
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/ActionBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/ActionBarDslTest.kt
@@ -1,0 +1,67 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.color.red
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextDecoration
+
+private class ActionBarRecordingAudience : Audience {
+    val actionBars = mutableListOf<Component>()
+
+    override fun sendActionBar(message: Component) {
+        actionBars += message
+    }
+}
+
+class ActionBarDslTest :
+    StringSpec(
+        {
+            "builds and shows the component" {
+                val audience = ActionBarRecordingAudience()
+
+                audience.actionBar {
+                    text("+10 XP") {
+                        color(red)
+                        bold()
+                    }
+                }
+
+                audience.actionBars shouldHaveSize 1
+                val actionBar = audience.actionBars.single()
+                actionBar shouldHaveChildCount 1
+                actionBar.childAt(0) shouldContainText "+10 XP"
+                actionBar.childAt(0) shouldHaveColor red
+                actionBar.childAt(0) shouldHaveDecoration TextDecoration.BOLD
+            }
+
+            "shows the same component to every member of a forwarding audience" {
+                val first = ActionBarRecordingAudience()
+                val second = ActionBarRecordingAudience()
+
+                Audience.audience(first, second).actionBar {
+                    text("Broadcast")
+                }
+
+                first.actionBars shouldHaveSize 1
+                second.actionBars shouldHaveSize 1
+                first.actionBars.single() shouldBe second.actionBars.single()
+            }
+
+            "shows an empty component from an empty block" {
+                val audience = ActionBarRecordingAudience()
+
+                audience.actionBar {}
+
+                audience.actionBars.single() shouldBe Component.empty()
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/ActionBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/ActionBarDslTest.kt
@@ -47,7 +47,7 @@ class ActionBarDslTest :
                 val first = ActionBarRecordingAudience()
                 val second = ActionBarRecordingAudience()
 
-                Audience.audience(first, second).actionBar {
+                audienceOf(first, second).actionBar {
                     text("Broadcast")
                 }
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/MessageDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/MessageDslTest.kt
@@ -47,7 +47,7 @@ class MessageDslTest :
                 val first = RecordingAudience()
                 val second = RecordingAudience()
 
-                Audience.audience(first, second).message {
+                audienceOf(first, second).message {
                     text("Broadcast")
                 }
 


### PR DESCRIPTION
## Summary

Adds `Audience.actionBar { ... }` — build a component with the Kotventure DSL and show it in the audience's action bar in one expression, wrapping Adventure's `Audience.sendActionBar(Component)`. Also backfills the missing `@sample` on `Audience.message`, the lone gap in the audience package.

## Related Issues

Closes #34

## DSL Impact

New extension in `io.github.lmliam.kotventure.core.audience`:

```kotlin
audience.actionBar {
    text("+10 XP") { color(gold) }
}
```

Same shape as `Audience.message` (#33): a single `ComponentScope` block, no string or pre-built-component overloads (Adventure's `sendActionBar` already covers those), empty block sends `Component.empty()`. `docs/DESIGN.md`'s audience-send sketch gains the `actionBar` line.

## Rationale

Next slice of the Phase 2 noun-based audience send family (`message`/`actionBar`/`title`/…): one idiomatic expression for the most common HUD feedback line, consistent with the rest of the family so plugin authors learn the pattern once.

## Testing

- `ActionBarDslTest` (Kotest `StringSpec`, mirrors `MessageDslTest`): builds and shows the styled component (asserted with the `test`-module matchers), fans out identically over a forwarding audience, and sends `Component.empty()` from an empty block.
- New Dokka samples (`actionBarSample`, `messageSample`) compile as part of the build.

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages (`docs/DESIGN.md` sending sketch)
- [x] Verified examples build and run (`./gradlew build` green: tests, ktlint/spotless, kover, samples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLUKXPAvRHZZJDyh42yUFZ
