### PR TITLE
feat(audience): add the title dsl with times

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -165,7 +165,11 @@ player.actionBar { text("+10 XP") }
 player.title {
     title { text("Welcome") }
     subtitle { mini("<gray>to the server") }
-    times(fadeIn = 1.ticks, stay = 3.seconds, fadeOut = 1.ticks)
+    times {
+        fadeIn(1.ticks)
+        stay(3.seconds)
+        fadeOut(1.ticks)
+    }
 }
 
 // ── Typed MiniMessage template + validation ────────────────────

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Title.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Title.kt
@@ -1,0 +1,22 @@
+package io.github.lmliam.kotventure.core.audience
+
+import net.kyori.adventure.audience.Audience
+
+/**
+ * Builds a screen [net.kyori.adventure.title.Title] from a [TitleScope] block and shows it on this
+ * [Audience].
+ *
+ * Set at least one of `title` or `subtitle` (either alone is fine — the other defaults to empty).
+ * When `times` is omitted, Adventure's default timings are used. To clear or reset a shown title,
+ * call Adventure's [Audience.clearTitle] or [Audience.resetTitle] directly.
+ *
+ * Works for any audience — a player, the console, or a forwarding audience over many members;
+ * audiences without a title surface ignore it.
+ *
+ * @throws IllegalStateException when the block sets neither `title` nor `subtitle`, or sets any
+ *   slot twice.
+ * @sample io.github.lmliam.kotventure.core.audience.titleSample
+ */
+public fun Audience.title(init: TitleScope.() -> Unit) {
+    showTitle(TitleBuilder().apply(init).build())
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleBuilder.kt
@@ -6,8 +6,6 @@ import io.github.lmliam.kotventure.core.dsl.once
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentLike
 import net.kyori.adventure.title.Title
-import kotlin.time.Duration
-import kotlin.time.toJavaDuration
 
 internal class TitleBuilder : TitleScope {
     private var title: Component? by once()
@@ -26,17 +24,8 @@ internal class TitleBuilder : TitleScope {
         subtitle = component.asComponent()
     }
 
-    override fun times(
-        fadeIn: Duration,
-        stay: Duration,
-        fadeOut: Duration,
-    ) {
-        times =
-            Title.Times.times(
-                fadeIn.toJavaDuration(),
-                stay.toJavaDuration(),
-                fadeOut.toJavaDuration(),
-            )
+    override fun times(init: TitleTimesScope.() -> Unit) {
+        times = TitleTimesBuilder().apply(init).build()
     }
 
     internal fun build(): Title {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleBuilder.kt
@@ -1,0 +1,52 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.dsl.once
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.title.Title
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+
+internal class TitleBuilder : TitleScope {
+    private var title: Component? by once()
+    private var subtitle: Component? by once()
+    private var times: Title.Times? by once()
+
+    override fun title(init: ComponentScope.() -> Unit) = title(component(init))
+
+    override fun <T : ComponentLike> title(component: T) {
+        title = component.asComponent()
+    }
+
+    override fun subtitle(init: ComponentScope.() -> Unit) = subtitle(component(init))
+
+    override fun <T : ComponentLike> subtitle(component: T) {
+        subtitle = component.asComponent()
+    }
+
+    override fun times(
+        fadeIn: Duration,
+        stay: Duration,
+        fadeOut: Duration,
+    ) {
+        times =
+            Title.Times.times(
+                fadeIn.toJavaDuration(),
+                stay.toJavaDuration(),
+                fadeOut.toJavaDuration(),
+            )
+    }
+
+    internal fun build(): Title {
+        check(title != null || subtitle != null) {
+            "At least one of 'title' or 'subtitle' must be set."
+        }
+        return Title.title(
+            title ?: Component.empty(),
+            subtitle ?: Component.empty(),
+            times ?: Title.DEFAULT_TIMES,
+        )
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleScope.kt
@@ -1,0 +1,57 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.ComponentLike
+import kotlin.time.Duration
+
+/**
+ * Scope for configuring a screen title shown via [Audience.title]: the main [title] line, an
+ * optional [subtitle], and optional fade [times].
+ *
+ * At least one of [title] or [subtitle] must be set before the block ends.
+ */
+@KotventureDslMarker
+public interface TitleScope {
+    /**
+     * Builds the main title line from a component DSL block.
+     *
+     * @throws IllegalStateException when the title is already set in this block.
+     */
+    public fun title(init: ComponentScope.() -> Unit)
+
+    /**
+     * Sets the main title line.
+     *
+     * @throws IllegalStateException when the title is already set in this block.
+     */
+    public fun <T : ComponentLike> title(component: T)
+
+    /**
+     * Builds the subtitle line from a component DSL block.
+     *
+     * @throws IllegalStateException when the subtitle is already set in this block.
+     */
+    public fun subtitle(init: ComponentScope.() -> Unit)
+
+    /**
+     * Sets the subtitle line.
+     *
+     * @throws IllegalStateException when the subtitle is already set in this block.
+     */
+    public fun <T : ComponentLike> subtitle(component: T)
+
+    /**
+     * Sets how long the title fades in, stays on screen, and fades out.
+     *
+     * When not set, Adventure's default timings (`Title.DEFAULT_TIMES`) are used.
+     *
+     * @throws IllegalStateException when times are already set in this block.
+     */
+    public fun times(
+        fadeIn: Duration,
+        stay: Duration,
+        fadeOut: Duration,
+    )
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleScope.kt
@@ -4,7 +4,6 @@ import io.github.lmliam.kotventure.core.component.ComponentScope
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.ComponentLike
-import kotlin.time.Duration
 
 /**
  * Scope for configuring a screen title shown via [Audience.title]: the main [title] line, an
@@ -43,15 +42,13 @@ public interface TitleScope {
     public fun <T : ComponentLike> subtitle(component: T)
 
     /**
-     * Sets how long the title fades in, stays on screen, and fades out.
+     * Configures fade-in, stay, and fade-out durations via [TitleTimesScope].
      *
-     * When not set, Adventure's default timings (`Title.DEFAULT_TIMES`) are used.
+     * Each timing may be set independently; any left unset uses Adventure's default for that slot
+     * (`Title.DEFAULT_TIMES`). When this block is omitted entirely, those same defaults apply.
      *
-     * @throws IllegalStateException when times are already set in this block.
+     * @throws IllegalStateException when times are already configured in this title block, or when
+     *   a timing slot is set twice inside [init].
      */
-    public fun times(
-        fadeIn: Duration,
-        stay: Duration,
-        fadeOut: Duration,
-    )
+    public fun times(init: TitleTimesScope.() -> Unit)
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleTimesBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleTimesBuilder.kt
@@ -1,0 +1,33 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.dsl.once
+import net.kyori.adventure.title.Title
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+
+internal class TitleTimesBuilder : TitleTimesScope {
+    private var fadeIn: Duration? by once()
+    private var stay: Duration? by once()
+    private var fadeOut: Duration? by once()
+
+    override fun fadeIn(duration: Duration) {
+        fadeIn = duration
+    }
+
+    override fun stay(duration: Duration) {
+        stay = duration
+    }
+
+    override fun fadeOut(duration: Duration) {
+        fadeOut = duration
+    }
+
+    internal fun build(): Title.Times {
+        val defaults = Title.DEFAULT_TIMES
+        return Title.Times.times(
+            fadeIn?.toJavaDuration() ?: defaults.fadeIn(),
+            stay?.toJavaDuration() ?: defaults.stay(),
+            fadeOut?.toJavaDuration() ?: defaults.fadeOut(),
+        )
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleTimesScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleTimesScope.kt
@@ -1,0 +1,34 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import kotlin.time.Duration
+
+/**
+ * Scope for configuring a title's fade-in, stay, and fade-out durations.
+ *
+ * Any slot left unset falls back to Adventure's default for that slot
+ * (`Title.DEFAULT_TIMES`).
+ */
+@KotventureDslMarker
+public interface TitleTimesScope {
+    /**
+     * Sets how long the title takes to fade in.
+     *
+     * @throws IllegalStateException when fade-in is already set in this block.
+     */
+    public fun fadeIn(duration: Duration)
+
+    /**
+     * Sets how long the title stays fully visible.
+     *
+     * @throws IllegalStateException when stay is already set in this block.
+     */
+    public fun stay(duration: Duration)
+
+    /**
+     * Sets how long the title takes to fade out.
+     *
+     * @throws IllegalStateException when fade-out is already set in this block.
+     */
+    public fun fadeOut(duration: Duration)
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/time/Ticks.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/time/Ticks.kt
@@ -1,0 +1,21 @@
+package io.github.lmliam.kotventure.core.time
+
+import net.kyori.adventure.util.Ticks
+import kotlin.time.Duration
+import kotlin.time.toKotlinDuration
+
+/**
+ * Duration of this many Minecraft game ticks (20 ticks = 1 second).
+ *
+ * @sample io.github.lmliam.kotventure.core.time.ticksSample
+ */
+public val Int.ticks: Duration
+    get() = Ticks.duration(toLong()).toKotlinDuration()
+
+/**
+ * Duration of this many Minecraft game ticks (20 ticks = 1 second).
+ *
+ * @sample io.github.lmliam.kotventure.core.time.ticksSample
+ */
+public val Long.ticks: Duration
+    get() = Ticks.duration(this).toKotlinDuration()

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/TitleSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/TitleSamples.kt
@@ -13,6 +13,10 @@ internal fun titleSample() {
             text("Welcome") { color(gold) }
         }
         subtitle { text("to the server") }
-        times(fadeIn = 1.ticks, stay = 3.seconds, fadeOut = 1.ticks)
+        times {
+            fadeIn(1.ticks)
+            stay(3.seconds)
+            fadeOut(1.ticks)
+        }
     }
 }

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/TitleSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/TitleSamples.kt
@@ -1,0 +1,18 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.core.time.ticks
+import kotlin.time.Duration.Companion.seconds
+
+internal fun titleSample() {
+    val audience = emptyAudience()
+
+    audience.title {
+        title {
+            text("Welcome") { color(gold) }
+        }
+        subtitle { text("to the server") }
+        times(fadeIn = 1.ticks, stay = 3.seconds, fadeOut = 1.ticks)
+    }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/time/TicksSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/time/TicksSamples.kt
@@ -1,0 +1,5 @@
+package io.github.lmliam.kotventure.core.time
+
+import kotlin.time.Duration
+
+internal fun ticksSample(): Duration = 20.ticks

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
@@ -19,6 +19,7 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.title.Title
 import net.kyori.adventure.title.TitlePart
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toKotlinDuration
 
 /**
  * Captures titles via [sendTitlePart], matching Adventure's default [Audience.showTitle]
@@ -91,13 +92,13 @@ class TitleDslTest :
                 }
 
                 val times =
-                    audience.titles
-                    .single()
-                    .times()
-                    .shouldNotBeNull()
-                times shouldHaveFadeIn defaults.fadeIn()
+                        audience.titles
+                                .single()
+                                .times()
+                                .shouldNotBeNull()
+                times shouldHaveFadeIn defaults.fadeIn().toKotlinDuration()
                 times shouldHaveStay 1.seconds
-                times shouldHaveFadeOut defaults.fadeOut()
+                times shouldHaveFadeOut defaults.fadeOut().toKotlinDuration()
             }
 
             "defaults subtitle to empty and times to DEFAULT_TIMES when only title is set" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
@@ -59,7 +59,11 @@ class TitleDslTest :
                         text("Welcome") { color(gold) }
                     }
                     subtitle { text("to the server") }
-                    times(fadeIn = 1.ticks, stay = 3.seconds, fadeOut = 1.ticks)
+                    times {
+                        fadeIn(1.ticks)
+                        stay(3.seconds)
+                        fadeOut(1.ticks)
+                    }
                 }
 
                 audience.titles shouldHaveSize 1
@@ -71,6 +75,27 @@ class TitleDslTest :
                 times.fadeIn() shouldBe 1.ticks.toJavaDuration()
                 times.stay() shouldBe 3.seconds.toJavaDuration()
                 times.fadeOut() shouldBe 1.ticks.toJavaDuration()
+            }
+
+            "defaults unset timing slots to DEFAULT_TIMES values" {
+                val audience = TitleRecordingAudience()
+                val defaults = Title.DEFAULT_TIMES
+
+                audience.title {
+                    title { text("Partial times") }
+                    times {
+                        stay(1.seconds)
+                    }
+                }
+
+                val times =
+                    audience.titles
+                    .single()
+                    .times()
+                    .shouldNotBeNull()
+                times.fadeIn() shouldBe defaults.fadeIn()
+                times.stay() shouldBe 1.seconds.toJavaDuration()
+                times.fadeOut() shouldBe defaults.fadeOut()
             }
 
             "defaults subtitle to empty and times to DEFAULT_TIMES when only title is set" {
@@ -151,12 +176,24 @@ class TitleDslTest :
                 }
             }
 
-            "rejects duplicate times" {
+            "rejects a duplicate times block" {
                 shouldThrow<IllegalStateException> {
                     TitleRecordingAudience().title {
                         title { text("a") }
-                        times(fadeIn = 1.ticks, stay = 1.seconds, fadeOut = 1.ticks)
-                        times(fadeIn = 2.ticks, stay = 2.seconds, fadeOut = 2.ticks)
+                        times { stay(1.seconds) }
+                        times { stay(2.seconds) }
+                    }
+                }
+            }
+
+            "rejects a duplicate timing slot inside times" {
+                shouldThrow<IllegalStateException> {
+                    TitleRecordingAudience().title {
+                        title { text("a") }
+                        times {
+                            fadeIn(1.ticks)
+                            fadeIn(2.ticks)
+                        }
                     }
                 }
             }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
@@ -19,7 +19,6 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.title.Title
 import net.kyori.adventure.title.TitlePart
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toKotlinDuration
 
 /**
  * Captures titles via [sendTitlePart], matching Adventure's default [Audience.showTitle]
@@ -96,9 +95,9 @@ class TitleDslTest :
                     .single()
                     .times()
                     .shouldNotBeNull()
-                times shouldHaveFadeIn defaults.fadeIn().toKotlinDuration()
+                times shouldHaveFadeIn defaults.fadeIn()
                 times shouldHaveStay 1.seconds
-                times shouldHaveFadeOut defaults.fadeOut().toKotlinDuration()
+                times shouldHaveFadeOut defaults.fadeOut()
             }
 
             "defaults subtitle to empty and times to DEFAULT_TIMES when only title is set" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
@@ -22,9 +22,8 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toKotlinDuration
 
 /**
- * Captures titles via [sendTitlePart], matching Adventure's default [Audience.showTitle]
- * (which fans out parts — including through [audienceOf] — rather than calling [Audience.showTitle]
- * on each member).
+ * Captures titles via [sendTitlePart], matching Adventure's default [Audience.showTitle].
+ * Kept local to the test for isolation and readability.
  */
 private class TitleRecordingAudience : Audience {
     val titles = mutableListOf<Title>()
@@ -44,6 +43,7 @@ private class TitleRecordingAudience : Audience {
                 subtitlePart = Component.empty()
                 timesPart = null
             }
+
             TitlePart.SUBTITLE -> subtitlePart = value as Component
             TitlePart.TIMES -> timesPart = value as Title.Times
             else -> error("Unexpected title part: $part")
@@ -54,26 +54,27 @@ private class TitleRecordingAudience : Audience {
 class TitleDslTest :
     StringSpec(
         {
+            fun record(block: TitleScope.() -> Unit): Title =
+                TitleRecordingAudience().also { it.title(block) }.titles.single()
+
             "builds and shows a title with subtitle and times" {
-                val audience = TitleRecordingAudience()
-
-                audience.title {
-                    title {
-                        text("Welcome") { color(gold) }
+                val shown =
+                    record {
+                        title {
+                            text("Welcome") { color(gold) }
+                        }
+                        subtitle { text("to the server") }
+                        times {
+                            fadeIn(1.ticks)
+                            stay(3.seconds)
+                            fadeOut(1.ticks)
+                        }
                     }
-                    subtitle { text("to the server") }
-                    times {
-                        fadeIn(1.ticks)
-                        stay(3.seconds)
-                        fadeOut(1.ticks)
-                    }
-                }
 
-                audience.titles shouldHaveSize 1
-                val shown = audience.titles.single()
                 shown.title().childAt(0) shouldContainText "Welcome"
                 shown.title().childAt(0) shouldHaveColor gold
                 shown.subtitle().childAt(0) shouldContainText "to the server"
+
                 val times = shown.times().shouldNotBeNull()
                 times shouldHaveFadeIn 1.ticks
                 times shouldHaveStay 3.seconds
@@ -81,63 +82,45 @@ class TitleDslTest :
             }
 
             "defaults unset timing slots to DEFAULT_TIMES values" {
-                val audience = TitleRecordingAudience()
                 val defaults = Title.DEFAULT_TIMES
 
-                audience.title {
-                    title { text("Partial times") }
-                    times {
-                        stay(1.seconds)
-                    }
-                }
-
                 val times =
-                        audience.titles
-                                .single()
-                                .times()
-                                .shouldNotBeNull()
+                    record {
+                        title { text("Partial times") }
+                        times { stay(1.seconds) }
+                    }.times().shouldNotBeNull()
+
                 times shouldHaveFadeIn defaults.fadeIn().toKotlinDuration()
                 times shouldHaveStay 1.seconds
                 times shouldHaveFadeOut defaults.fadeOut().toKotlinDuration()
             }
 
             "defaults subtitle to empty and times to DEFAULT_TIMES when only title is set" {
-                val audience = TitleRecordingAudience()
+                val shown = record { title { text("Solo") } }
 
-                audience.title {
-                    title { text("Solo") }
-                }
-
-                val shown = audience.titles.single()
                 shown.title().childAt(0) shouldContainText "Solo"
                 shown.subtitle() shouldBe Component.empty()
                 shown.times() shouldBe Title.DEFAULT_TIMES
             }
 
             "allows a subtitle-only title" {
-                val audience = TitleRecordingAudience()
+                val shown = record { subtitle { text("only subtitle") } }
 
-                audience.title {
-                    subtitle { text("only subtitle") }
-                }
-
-                val shown = audience.titles.single()
                 shown.title() shouldBe Component.empty()
                 shown.subtitle().childAt(0) shouldContainText "only subtitle"
                 shown.times() shouldBe Title.DEFAULT_TIMES
             }
 
             "accepts existing components for title and subtitle" {
-                val audience = TitleRecordingAudience()
                 val main = Component.text("Main")
                 val sub = Component.text("Sub")
 
-                audience.title {
-                    title(main)
-                    subtitle(sub)
-                }
+                val shown =
+                    record {
+                        title(main)
+                        subtitle(sub)
+                    }
 
-                val shown = audience.titles.single()
                 shown.title() shouldBe main
                 shown.subtitle() shouldBe sub
             }
@@ -146,59 +129,40 @@ class TitleDslTest :
                 val first = TitleRecordingAudience()
                 val second = TitleRecordingAudience()
 
-                audienceOf(first, second).title {
-                    title { text("Broadcast") }
-                }
+                audienceOf(first, second).title { title { text("Broadcast") } }
 
                 first.titles shouldHaveSize 1
                 second.titles shouldHaveSize 1
                 first.titles.single().title() shouldBe second.titles.single().title()
             }
 
-            "rejects a block with neither title nor subtitle" {
-                shouldThrow<IllegalStateException> {
-                    TitleRecordingAudience().title {}
-                }
-            }
-
-            "rejects a times-only block" {
-                shouldThrow<IllegalStateException> {
+            listOf(
+                "rejects a block with neither title nor subtitle" to { TitleRecordingAudience().title {} },
+                "rejects a times-only block" to {
                     TitleRecordingAudience().title {
                         times { stay(1.seconds) }
                     }
-                }
-            }
-
-            "rejects a duplicate title" {
-                shouldThrow<IllegalStateException> {
+                },
+                "rejects a duplicate title" to {
                     TitleRecordingAudience().title {
                         title { text("a") }
                         title { text("b") }
                     }
-                }
-            }
-
-            "rejects a duplicate subtitle" {
-                shouldThrow<IllegalStateException> {
+                },
+                "rejects a duplicate subtitle" to {
                     TitleRecordingAudience().title {
                         subtitle { text("a") }
                         subtitle { text("b") }
                     }
-                }
-            }
-
-            "rejects a duplicate times block" {
-                shouldThrow<IllegalStateException> {
+                },
+                "rejects a duplicate times block" to {
                     TitleRecordingAudience().title {
                         title { text("a") }
                         times { stay(1.seconds) }
                         times { stay(2.seconds) }
                     }
-                }
-            }
-
-            "rejects a duplicate timing slot inside times" {
-                shouldThrow<IllegalStateException> {
+                },
+                "rejects a duplicate timing slot inside times" to {
                     TitleRecordingAudience().title {
                         title { text("a") }
                         times {
@@ -206,6 +170,10 @@ class TitleDslTest :
                             fadeIn(2.ticks)
                         }
                     }
+                },
+            ).forEach { (name, action) ->
+                name {
+                    shouldThrow<IllegalStateException> { action() }
                 }
             }
         },

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
@@ -161,6 +161,14 @@ class TitleDslTest :
                 }
             }
 
+            "rejects a times-only block" {
+                shouldThrow<IllegalStateException> {
+                    TitleRecordingAudience().title {
+                        times { stay(1.seconds) }
+                    }
+                }
+            }
+
             "rejects a duplicate title" {
                 shouldThrow<IllegalStateException> {
                     TitleRecordingAudience().title {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
@@ -1,0 +1,164 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.core.time.ticks
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.title.Title
+import net.kyori.adventure.title.TitlePart
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+/**
+ * Captures titles via [sendTitlePart], matching Adventure's default [Audience.showTitle]
+ * (which fans out parts — including through [audienceOf] — rather than calling [Audience.showTitle]
+ * on each member).
+ */
+private class TitleRecordingAudience : Audience {
+    val titles = mutableListOf<Title>()
+    private var titlePart: Component = Component.empty()
+    private var subtitlePart: Component = Component.empty()
+    private var timesPart: Title.Times? = null
+
+    override fun <T : Any> sendTitlePart(
+        part: TitlePart<T>,
+        value: T,
+    ) {
+        when (part) {
+            TitlePart.TITLE -> {
+                titlePart = value as Component
+                titles += Title.title(titlePart, subtitlePart, timesPart)
+                titlePart = Component.empty()
+                subtitlePart = Component.empty()
+                timesPart = null
+            }
+            TitlePart.SUBTITLE -> subtitlePart = value as Component
+            TitlePart.TIMES -> timesPart = value as Title.Times
+            else -> error("Unexpected title part: $part")
+        }
+    }
+}
+
+class TitleDslTest :
+    StringSpec(
+        {
+            "builds and shows a title with subtitle and times" {
+                val audience = TitleRecordingAudience()
+
+                audience.title {
+                    title {
+                        text("Welcome") { color(gold) }
+                    }
+                    subtitle { text("to the server") }
+                    times(fadeIn = 1.ticks, stay = 3.seconds, fadeOut = 1.ticks)
+                }
+
+                audience.titles shouldHaveSize 1
+                val shown = audience.titles.single()
+                shown.title().childAt(0) shouldContainText "Welcome"
+                shown.title().childAt(0) shouldHaveColor gold
+                shown.subtitle().childAt(0) shouldContainText "to the server"
+                val times = shown.times().shouldNotBeNull()
+                times.fadeIn() shouldBe 1.ticks.toJavaDuration()
+                times.stay() shouldBe 3.seconds.toJavaDuration()
+                times.fadeOut() shouldBe 1.ticks.toJavaDuration()
+            }
+
+            "defaults subtitle to empty and times to DEFAULT_TIMES when only title is set" {
+                val audience = TitleRecordingAudience()
+
+                audience.title {
+                    title { text("Solo") }
+                }
+
+                val shown = audience.titles.single()
+                shown.title().childAt(0) shouldContainText "Solo"
+                shown.subtitle() shouldBe Component.empty()
+                shown.times() shouldBe Title.DEFAULT_TIMES
+            }
+
+            "allows a subtitle-only title" {
+                val audience = TitleRecordingAudience()
+
+                audience.title {
+                    subtitle { text("only subtitle") }
+                }
+
+                val shown = audience.titles.single()
+                shown.title() shouldBe Component.empty()
+                shown.subtitle().childAt(0) shouldContainText "only subtitle"
+                shown.times() shouldBe Title.DEFAULT_TIMES
+            }
+
+            "accepts existing components for title and subtitle" {
+                val audience = TitleRecordingAudience()
+                val main = Component.text("Main")
+                val sub = Component.text("Sub")
+
+                audience.title {
+                    title(main)
+                    subtitle(sub)
+                }
+
+                val shown = audience.titles.single()
+                shown.title() shouldBe main
+                shown.subtitle() shouldBe sub
+            }
+
+            "shows the same title to every member of a forwarding audience" {
+                val first = TitleRecordingAudience()
+                val second = TitleRecordingAudience()
+
+                audienceOf(first, second).title {
+                    title { text("Broadcast") }
+                }
+
+                first.titles shouldHaveSize 1
+                second.titles shouldHaveSize 1
+                first.titles.single().title() shouldBe second.titles.single().title()
+            }
+
+            "rejects a block with neither title nor subtitle" {
+                shouldThrow<IllegalStateException> {
+                    TitleRecordingAudience().title {}
+                }
+            }
+
+            "rejects a duplicate title" {
+                shouldThrow<IllegalStateException> {
+                    TitleRecordingAudience().title {
+                        title { text("a") }
+                        title { text("b") }
+                    }
+                }
+            }
+
+            "rejects a duplicate subtitle" {
+                shouldThrow<IllegalStateException> {
+                    TitleRecordingAudience().title {
+                        subtitle { text("a") }
+                        subtitle { text("b") }
+                    }
+                }
+            }
+
+            "rejects duplicate times" {
+                shouldThrow<IllegalStateException> {
+                    TitleRecordingAudience().title {
+                        title { text("a") }
+                        times(fadeIn = 1.ticks, stay = 1.seconds, fadeOut = 1.ticks)
+                        times(fadeIn = 2.ticks, stay = 2.seconds, fadeOut = 2.ticks)
+                    }
+                }
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
@@ -6,6 +6,7 @@ import io.github.lmliam.kotventure.core.time.ticks
 import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.title.shouldHaveTimes
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
@@ -16,7 +17,7 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.title.Title
 import net.kyori.adventure.title.TitlePart
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
+import kotlin.time.toKotlinDuration
 
 /**
  * Captures titles via [sendTitlePart], matching Adventure's default [Audience.showTitle]
@@ -71,10 +72,11 @@ class TitleDslTest :
                 shown.title().childAt(0) shouldContainText "Welcome"
                 shown.title().childAt(0) shouldHaveColor gold
                 shown.subtitle().childAt(0) shouldContainText "to the server"
-                val times = shown.times().shouldNotBeNull()
-                times.fadeIn() shouldBe 1.ticks.toJavaDuration()
-                times.stay() shouldBe 3.seconds.toJavaDuration()
-                times.fadeOut() shouldBe 1.ticks.toJavaDuration()
+                shown.times().shouldNotBeNull().shouldHaveTimes(
+                    fadeIn = 1.ticks,
+                    stay = 3.seconds,
+                    fadeOut = 1.ticks,
+                )
             }
 
             "defaults unset timing slots to DEFAULT_TIMES values" {
@@ -88,14 +90,15 @@ class TitleDslTest :
                     }
                 }
 
-                val times =
-                    audience.titles
+                audience.titles
                     .single()
                     .times()
                     .shouldNotBeNull()
-                times.fadeIn() shouldBe defaults.fadeIn()
-                times.stay() shouldBe 1.seconds.toJavaDuration()
-                times.fadeOut() shouldBe defaults.fadeOut()
+                    .shouldHaveTimes(
+                        fadeIn = defaults.fadeIn().toKotlinDuration(),
+                        stay = 1.seconds,
+                        fadeOut = defaults.fadeOut().toKotlinDuration(),
+                    )
             }
 
             "defaults subtitle to empty and times to DEFAULT_TIMES when only title is set" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
@@ -6,7 +6,9 @@ import io.github.lmliam.kotventure.core.time.ticks
 import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
-import io.github.lmliam.kotventure.test.title.shouldHaveTimes
+import io.github.lmliam.kotventure.test.title.shouldHaveFadeIn
+import io.github.lmliam.kotventure.test.title.shouldHaveFadeOut
+import io.github.lmliam.kotventure.test.title.shouldHaveStay
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
@@ -72,11 +74,10 @@ class TitleDslTest :
                 shown.title().childAt(0) shouldContainText "Welcome"
                 shown.title().childAt(0) shouldHaveColor gold
                 shown.subtitle().childAt(0) shouldContainText "to the server"
-                shown.times().shouldNotBeNull().shouldHaveTimes(
-                    fadeIn = 1.ticks,
-                    stay = 3.seconds,
-                    fadeOut = 1.ticks,
-                )
+                val times = shown.times().shouldNotBeNull()
+                times shouldHaveFadeIn 1.ticks
+                times shouldHaveStay 3.seconds
+                times shouldHaveFadeOut 1.ticks
             }
 
             "defaults unset timing slots to DEFAULT_TIMES values" {
@@ -90,15 +91,14 @@ class TitleDslTest :
                     }
                 }
 
-                audience.titles
+                val times =
+                    audience.titles
                     .single()
                     .times()
                     .shouldNotBeNull()
-                    .shouldHaveTimes(
-                        fadeIn = defaults.fadeIn().toKotlinDuration(),
-                        stay = 1.seconds,
-                        fadeOut = defaults.fadeOut().toKotlinDuration(),
-                    )
+                times shouldHaveFadeIn defaults.fadeIn().toKotlinDuration()
+                times shouldHaveStay 1.seconds
+                times shouldHaveFadeOut defaults.fadeOut().toKotlinDuration()
             }
 
             "defaults subtitle to empty and times to DEFAULT_TIMES when only title is set" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/time/TicksTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/time/TicksTest.kt
@@ -1,0 +1,24 @@
+package io.github.lmliam.kotventure.core.time
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class TicksTest :
+    StringSpec(
+        {
+            "maps one tick to 50 milliseconds" {
+                1.ticks shouldBe 50.milliseconds
+            }
+
+            "maps 20 ticks to one second" {
+                20.ticks shouldBe 1.seconds
+            }
+
+            "maps Long ticks the same way" {
+                1L.ticks shouldBe 50.milliseconds
+                20L.ticks shouldBe 1.seconds
+            }
+        },
+    )

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchers.kt
@@ -6,72 +6,36 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import net.kyori.adventure.title.Title
 import kotlin.time.Duration
-import kotlin.time.toJavaDuration
 import kotlin.time.toKotlinDuration
-import java.time.Duration as JavaDuration
 
 /**
  * Matches [Title.Times] whose fade-in equals [expected].
  *
- * Accepts [kotlin.time.Duration] so call sites can use `1.ticks` / `3.seconds` without
- * `toJavaDuration()`.
+ * Takes [kotlin.time.Duration] so call sites can use `1.ticks` / `3.seconds`; convert Adventure
+ * values (e.g. `Title.DEFAULT_TIMES.fadeIn()`) with [toKotlinDuration].
  */
-public fun haveFadeIn(expected: Duration): Matcher<Title.Times> =
-    timingMatcher("fade-in", expected.toJavaDuration()) { it.fadeIn() }
-
-/**
- * Matches [Title.Times] whose fade-in equals [expected].
- *
- * Accepts [java.time.Duration] so values from Adventure (e.g. `Title.DEFAULT_TIMES.fadeIn()`)
- * need no conversion.
- */
-public fun haveFadeIn(expected: JavaDuration): Matcher<Title.Times> = timingMatcher("fade-in", expected) { it.fadeIn() }
+public fun haveFadeIn(expected: Duration): Matcher<Title.Times> = timingMatcher("fade-in", expected) { it.fadeIn() }
 
 /**
  * Matches [Title.Times] whose stay equals [expected].
  *
- * Accepts [kotlin.time.Duration] so call sites can use `1.ticks` / `3.seconds` without
- * `toJavaDuration()`.
+ * Takes [kotlin.time.Duration] so call sites can use `1.ticks` / `3.seconds`; convert Adventure
+ * values (e.g. `Title.DEFAULT_TIMES.stay()`) with [toKotlinDuration].
  */
-public fun haveStay(expected: Duration): Matcher<Title.Times> =
-    timingMatcher("stay", expected.toJavaDuration()) { it.stay() }
-
-/**
- * Matches [Title.Times] whose stay equals [expected].
- *
- * Accepts [java.time.Duration] so values from Adventure need no conversion.
- */
-public fun haveStay(expected: JavaDuration): Matcher<Title.Times> = timingMatcher("stay", expected) { it.stay() }
+public fun haveStay(expected: Duration): Matcher<Title.Times> = timingMatcher("stay", expected) { it.stay() }
 
 /**
  * Matches [Title.Times] whose fade-out equals [expected].
  *
- * Accepts [kotlin.time.Duration] so call sites can use `1.ticks` / `3.seconds` without
- * `toJavaDuration()`.
+ * Takes [kotlin.time.Duration] so call sites can use `1.ticks` / `3.seconds`; convert Adventure
+ * values (e.g. `Title.DEFAULT_TIMES.fadeOut()`) with [toKotlinDuration].
  */
-public fun haveFadeOut(expected: Duration): Matcher<Title.Times> =
-    timingMatcher("fade-out", expected.toJavaDuration()) { it.fadeOut() }
-
-/**
- * Matches [Title.Times] whose fade-out equals [expected].
- *
- * Accepts [java.time.Duration] so values from Adventure need no conversion.
- */
-public fun haveFadeOut(expected: JavaDuration): Matcher<Title.Times> =
-    timingMatcher("fade-out", expected) { it.fadeOut() }
+public fun haveFadeOut(expected: Duration): Matcher<Title.Times> = timingMatcher("fade-out", expected) { it.fadeOut() }
 
 /**
  * Asserts this [Title.Times] has the given fade-in duration.
  */
 public infix fun Title.Times.shouldHaveFadeIn(expected: Duration): Title.Times =
-    apply {
-        this should haveFadeIn(expected)
-    }
-
-/**
- * Asserts this [Title.Times] has the given fade-in duration.
- */
-public infix fun Title.Times.shouldHaveFadeIn(expected: JavaDuration): Title.Times =
     apply {
         this should haveFadeIn(expected)
     }
@@ -85,25 +49,9 @@ public infix fun Title.Times.shouldNotHaveFadeIn(expected: Duration): Title.Time
     }
 
 /**
- * Asserts this [Title.Times] does not have the given fade-in duration.
- */
-public infix fun Title.Times.shouldNotHaveFadeIn(expected: JavaDuration): Title.Times =
-    apply {
-        this shouldNot haveFadeIn(expected)
-    }
-
-/**
  * Asserts this [Title.Times] has the given stay duration.
  */
 public infix fun Title.Times.shouldHaveStay(expected: Duration): Title.Times =
-    apply {
-        this should haveStay(expected)
-    }
-
-/**
- * Asserts this [Title.Times] has the given stay duration.
- */
-public infix fun Title.Times.shouldHaveStay(expected: JavaDuration): Title.Times =
     apply {
         this should haveStay(expected)
     }
@@ -117,25 +65,9 @@ public infix fun Title.Times.shouldNotHaveStay(expected: Duration): Title.Times 
     }
 
 /**
- * Asserts this [Title.Times] does not have the given stay duration.
- */
-public infix fun Title.Times.shouldNotHaveStay(expected: JavaDuration): Title.Times =
-    apply {
-        this shouldNot haveStay(expected)
-    }
-
-/**
  * Asserts this [Title.Times] has the given fade-out duration.
  */
 public infix fun Title.Times.shouldHaveFadeOut(expected: Duration): Title.Times =
-    apply {
-        this should haveFadeOut(expected)
-    }
-
-/**
- * Asserts this [Title.Times] has the given fade-out duration.
- */
-public infix fun Title.Times.shouldHaveFadeOut(expected: JavaDuration): Title.Times =
     apply {
         this should haveFadeOut(expected)
     }
@@ -148,29 +80,16 @@ public infix fun Title.Times.shouldNotHaveFadeOut(expected: Duration): Title.Tim
         this shouldNot haveFadeOut(expected)
     }
 
-/**
- * Asserts this [Title.Times] does not have the given fade-out duration.
- */
-public infix fun Title.Times.shouldNotHaveFadeOut(expected: JavaDuration): Title.Times =
-    apply {
-        this shouldNot haveFadeOut(expected)
-    }
-
 private fun timingMatcher(
     slot: String,
-    expected: JavaDuration,
-    actualOf: (Title.Times) -> JavaDuration,
+    expected: Duration,
+    actualOf: (Title.Times) -> java.time.Duration,
 ): Matcher<Title.Times> =
     Matcher { value ->
-        val actual = actualOf(value)
+        val actual = actualOf(value).toKotlinDuration()
         MatcherResult(
             actual == expected,
-            {
-                "Expected title $slot <${expected.toKotlinDuration()}>, " +
-                    "but was <${actual.toKotlinDuration()}>."
-            },
-            {
-                "Expected title $slot not to be <${expected.toKotlinDuration()}>."
-            },
+            { "Expected title $slot <$expected>, but was <$actual>." },
+            { "Expected title $slot not to be <$expected>." },
         )
     }

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchers.kt
@@ -1,0 +1,68 @@
+package io.github.lmliam.kotventure.test.title
+
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
+import net.kyori.adventure.title.Title
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+import kotlin.time.toKotlinDuration
+
+/**
+ * Matches [Title.Times] whose fade-in, stay, and fade-out equal the given Kotlin [Duration]s.
+ *
+ * Converts expectations at the assertion boundary so call sites can stay in `kotlin.time` (e.g.
+ * `1.ticks`, `3.seconds`) without calling `toJavaDuration()`.
+ */
+public fun haveTimes(
+    fadeIn: Duration,
+    stay: Duration,
+    fadeOut: Duration,
+): Matcher<Title.Times> =
+    Matcher { value ->
+        val expectedFadeIn = fadeIn.toJavaDuration()
+        val expectedStay = stay.toJavaDuration()
+        val expectedFadeOut = fadeOut.toJavaDuration()
+        val actualFadeIn = value.fadeIn()
+        val actualStay = value.stay()
+        val actualFadeOut = value.fadeOut()
+        MatcherResult(
+            actualFadeIn == expectedFadeIn &&
+                actualStay == expectedStay &&
+                actualFadeOut == expectedFadeOut,
+            {
+                "Expected title times <fadeIn=$fadeIn, stay=$stay, fadeOut=$fadeOut>, " +
+                    "but was <fadeIn=${actualFadeIn.toKotlinDuration()}, " +
+                    "stay=${actualStay.toKotlinDuration()}, " +
+                    "fadeOut=${actualFadeOut.toKotlinDuration()}>."
+            },
+            {
+                "Expected title times not to be <fadeIn=$fadeIn, stay=$stay, fadeOut=$fadeOut>."
+            },
+        )
+    }
+
+/**
+ * Asserts this [Title.Times] has the given fade-in, stay, and fade-out durations.
+ */
+public fun Title.Times.shouldHaveTimes(
+    fadeIn: Duration,
+    stay: Duration,
+    fadeOut: Duration,
+): Title.Times =
+    apply {
+        this should haveTimes(fadeIn, stay, fadeOut)
+    }
+
+/**
+ * Asserts this [Title.Times] does not have the given fade-in, stay, and fade-out durations.
+ */
+public fun Title.Times.shouldNotHaveTimes(
+    fadeIn: Duration,
+    stay: Duration,
+    fadeOut: Duration,
+): Title.Times =
+    apply {
+        this shouldNot haveTimes(fadeIn, stay, fadeOut)
+    }

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchers.kt
@@ -10,59 +10,92 @@ import kotlin.time.toJavaDuration
 import kotlin.time.toKotlinDuration
 
 /**
- * Matches [Title.Times] whose fade-in, stay, and fade-out equal the given Kotlin [Duration]s.
+ * Matches [Title.Times] whose fade-in equals [expected].
  *
- * Converts expectations at the assertion boundary so call sites can stay in `kotlin.time` (e.g.
- * `1.ticks`, `3.seconds`) without calling `toJavaDuration()`.
+ * Converts at the assertion boundary so call sites can stay in `kotlin.time` (e.g. `1.ticks`)
+ * without calling `toJavaDuration()`.
  */
-public fun haveTimes(
-    fadeIn: Duration,
-    stay: Duration,
-    fadeOut: Duration,
+public fun haveFadeIn(expected: Duration): Matcher<Title.Times> = timingMatcher("fade-in", expected) { it.fadeIn() }
+
+/**
+ * Matches [Title.Times] whose stay equals [expected].
+ *
+ * Converts at the assertion boundary so call sites can stay in `kotlin.time` without calling
+ * `toJavaDuration()`.
+ */
+public fun haveStay(expected: Duration): Matcher<Title.Times> = timingMatcher("stay", expected) { it.stay() }
+
+/**
+ * Matches [Title.Times] whose fade-out equals [expected].
+ *
+ * Converts at the assertion boundary so call sites can stay in `kotlin.time` without calling
+ * `toJavaDuration()`.
+ */
+public fun haveFadeOut(expected: Duration): Matcher<Title.Times> = timingMatcher("fade-out", expected) { it.fadeOut() }
+
+/**
+ * Asserts this [Title.Times] has the given fade-in duration.
+ */
+public infix fun Title.Times.shouldHaveFadeIn(expected: Duration): Title.Times =
+    apply {
+        this should haveFadeIn(expected)
+    }
+
+/**
+ * Asserts this [Title.Times] does not have the given fade-in duration.
+ */
+public infix fun Title.Times.shouldNotHaveFadeIn(expected: Duration): Title.Times =
+    apply {
+        this shouldNot haveFadeIn(expected)
+    }
+
+/**
+ * Asserts this [Title.Times] has the given stay duration.
+ */
+public infix fun Title.Times.shouldHaveStay(expected: Duration): Title.Times =
+    apply {
+        this should haveStay(expected)
+    }
+
+/**
+ * Asserts this [Title.Times] does not have the given stay duration.
+ */
+public infix fun Title.Times.shouldNotHaveStay(expected: Duration): Title.Times =
+    apply {
+        this shouldNot haveStay(expected)
+    }
+
+/**
+ * Asserts this [Title.Times] has the given fade-out duration.
+ */
+public infix fun Title.Times.shouldHaveFadeOut(expected: Duration): Title.Times =
+    apply {
+        this should haveFadeOut(expected)
+    }
+
+/**
+ * Asserts this [Title.Times] does not have the given fade-out duration.
+ */
+public infix fun Title.Times.shouldNotHaveFadeOut(expected: Duration): Title.Times =
+    apply {
+        this shouldNot haveFadeOut(expected)
+    }
+
+private fun timingMatcher(
+    slot: String,
+    expected: Duration,
+    actualOf: (Title.Times) -> java.time.Duration,
 ): Matcher<Title.Times> =
     Matcher { value ->
-        val expectedFadeIn = fadeIn.toJavaDuration()
-        val expectedStay = stay.toJavaDuration()
-        val expectedFadeOut = fadeOut.toJavaDuration()
-        val actualFadeIn = value.fadeIn()
-        val actualStay = value.stay()
-        val actualFadeOut = value.fadeOut()
+        val expectedJava = expected.toJavaDuration()
+        val actual = actualOf(value)
         MatcherResult(
-            actualFadeIn == expectedFadeIn &&
-                actualStay == expectedStay &&
-                actualFadeOut == expectedFadeOut,
+            actual == expectedJava,
             {
-                "Expected title times <fadeIn=$fadeIn, stay=$stay, fadeOut=$fadeOut>, " +
-                    "but was <fadeIn=${actualFadeIn.toKotlinDuration()}, " +
-                    "stay=${actualStay.toKotlinDuration()}, " +
-                    "fadeOut=${actualFadeOut.toKotlinDuration()}>."
+                "Expected title $slot <$expected>, but was <${actual.toKotlinDuration()}>."
             },
             {
-                "Expected title times not to be <fadeIn=$fadeIn, stay=$stay, fadeOut=$fadeOut>."
+                "Expected title $slot not to be <$expected>."
             },
         )
-    }
-
-/**
- * Asserts this [Title.Times] has the given fade-in, stay, and fade-out durations.
- */
-public fun Title.Times.shouldHaveTimes(
-    fadeIn: Duration,
-    stay: Duration,
-    fadeOut: Duration,
-): Title.Times =
-    apply {
-        this should haveTimes(fadeIn, stay, fadeOut)
-    }
-
-/**
- * Asserts this [Title.Times] does not have the given fade-in, stay, and fade-out durations.
- */
-public fun Title.Times.shouldNotHaveTimes(
-    fadeIn: Duration,
-    stay: Duration,
-    fadeOut: Duration,
-): Title.Times =
-    apply {
-        this shouldNot haveTimes(fadeIn, stay, fadeOut)
     }

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchers.kt
@@ -8,35 +8,70 @@ import net.kyori.adventure.title.Title
 import kotlin.time.Duration
 import kotlin.time.toJavaDuration
 import kotlin.time.toKotlinDuration
+import java.time.Duration as JavaDuration
 
 /**
  * Matches [Title.Times] whose fade-in equals [expected].
  *
- * Converts at the assertion boundary so call sites can stay in `kotlin.time` (e.g. `1.ticks`)
- * without calling `toJavaDuration()`.
+ * Accepts [kotlin.time.Duration] so call sites can use `1.ticks` / `3.seconds` without
+ * `toJavaDuration()`.
  */
-public fun haveFadeIn(expected: Duration): Matcher<Title.Times> = timingMatcher("fade-in", expected) { it.fadeIn() }
+public fun haveFadeIn(expected: Duration): Matcher<Title.Times> =
+    timingMatcher("fade-in", expected.toJavaDuration()) { it.fadeIn() }
+
+/**
+ * Matches [Title.Times] whose fade-in equals [expected].
+ *
+ * Accepts [java.time.Duration] so values from Adventure (e.g. `Title.DEFAULT_TIMES.fadeIn()`)
+ * need no conversion.
+ */
+public fun haveFadeIn(expected: JavaDuration): Matcher<Title.Times> = timingMatcher("fade-in", expected) { it.fadeIn() }
 
 /**
  * Matches [Title.Times] whose stay equals [expected].
  *
- * Converts at the assertion boundary so call sites can stay in `kotlin.time` without calling
+ * Accepts [kotlin.time.Duration] so call sites can use `1.ticks` / `3.seconds` without
  * `toJavaDuration()`.
  */
-public fun haveStay(expected: Duration): Matcher<Title.Times> = timingMatcher("stay", expected) { it.stay() }
+public fun haveStay(expected: Duration): Matcher<Title.Times> =
+    timingMatcher("stay", expected.toJavaDuration()) { it.stay() }
+
+/**
+ * Matches [Title.Times] whose stay equals [expected].
+ *
+ * Accepts [java.time.Duration] so values from Adventure need no conversion.
+ */
+public fun haveStay(expected: JavaDuration): Matcher<Title.Times> = timingMatcher("stay", expected) { it.stay() }
 
 /**
  * Matches [Title.Times] whose fade-out equals [expected].
  *
- * Converts at the assertion boundary so call sites can stay in `kotlin.time` without calling
+ * Accepts [kotlin.time.Duration] so call sites can use `1.ticks` / `3.seconds` without
  * `toJavaDuration()`.
  */
-public fun haveFadeOut(expected: Duration): Matcher<Title.Times> = timingMatcher("fade-out", expected) { it.fadeOut() }
+public fun haveFadeOut(expected: Duration): Matcher<Title.Times> =
+    timingMatcher("fade-out", expected.toJavaDuration()) { it.fadeOut() }
+
+/**
+ * Matches [Title.Times] whose fade-out equals [expected].
+ *
+ * Accepts [java.time.Duration] so values from Adventure need no conversion.
+ */
+public fun haveFadeOut(expected: JavaDuration): Matcher<Title.Times> =
+    timingMatcher("fade-out", expected) { it.fadeOut() }
 
 /**
  * Asserts this [Title.Times] has the given fade-in duration.
  */
 public infix fun Title.Times.shouldHaveFadeIn(expected: Duration): Title.Times =
+    apply {
+        this should haveFadeIn(expected)
+    }
+
+/**
+ * Asserts this [Title.Times] has the given fade-in duration.
+ */
+public infix fun Title.Times.shouldHaveFadeIn(expected: JavaDuration): Title.Times =
     apply {
         this should haveFadeIn(expected)
     }
@@ -50,9 +85,25 @@ public infix fun Title.Times.shouldNotHaveFadeIn(expected: Duration): Title.Time
     }
 
 /**
+ * Asserts this [Title.Times] does not have the given fade-in duration.
+ */
+public infix fun Title.Times.shouldNotHaveFadeIn(expected: JavaDuration): Title.Times =
+    apply {
+        this shouldNot haveFadeIn(expected)
+    }
+
+/**
  * Asserts this [Title.Times] has the given stay duration.
  */
 public infix fun Title.Times.shouldHaveStay(expected: Duration): Title.Times =
+    apply {
+        this should haveStay(expected)
+    }
+
+/**
+ * Asserts this [Title.Times] has the given stay duration.
+ */
+public infix fun Title.Times.shouldHaveStay(expected: JavaDuration): Title.Times =
     apply {
         this should haveStay(expected)
     }
@@ -66,9 +117,25 @@ public infix fun Title.Times.shouldNotHaveStay(expected: Duration): Title.Times 
     }
 
 /**
+ * Asserts this [Title.Times] does not have the given stay duration.
+ */
+public infix fun Title.Times.shouldNotHaveStay(expected: JavaDuration): Title.Times =
+    apply {
+        this shouldNot haveStay(expected)
+    }
+
+/**
  * Asserts this [Title.Times] has the given fade-out duration.
  */
 public infix fun Title.Times.shouldHaveFadeOut(expected: Duration): Title.Times =
+    apply {
+        this should haveFadeOut(expected)
+    }
+
+/**
+ * Asserts this [Title.Times] has the given fade-out duration.
+ */
+public infix fun Title.Times.shouldHaveFadeOut(expected: JavaDuration): Title.Times =
     apply {
         this should haveFadeOut(expected)
     }
@@ -81,21 +148,29 @@ public infix fun Title.Times.shouldNotHaveFadeOut(expected: Duration): Title.Tim
         this shouldNot haveFadeOut(expected)
     }
 
+/**
+ * Asserts this [Title.Times] does not have the given fade-out duration.
+ */
+public infix fun Title.Times.shouldNotHaveFadeOut(expected: JavaDuration): Title.Times =
+    apply {
+        this shouldNot haveFadeOut(expected)
+    }
+
 private fun timingMatcher(
     slot: String,
-    expected: Duration,
-    actualOf: (Title.Times) -> java.time.Duration,
+    expected: JavaDuration,
+    actualOf: (Title.Times) -> JavaDuration,
 ): Matcher<Title.Times> =
     Matcher { value ->
-        val expectedJava = expected.toJavaDuration()
         val actual = actualOf(value)
         MatcherResult(
-            actual == expectedJava,
+            actual == expected,
             {
-                "Expected title $slot <$expected>, but was <${actual.toKotlinDuration()}>."
+                "Expected title $slot <${expected.toKotlinDuration()}>, " +
+                    "but was <${actual.toKotlinDuration()}>."
             },
             {
-                "Expected title $slot not to be <$expected>."
+                "Expected title $slot not to be <${expected.toKotlinDuration()}>."
             },
         )
     }

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchersTest.kt
@@ -24,6 +24,14 @@ class TitleTimesMatchersTest :
                 times shouldHaveFadeOut 1.ticks
             }
 
+            "matches individual timing slots from java.time durations" {
+                val times = Title.DEFAULT_TIMES
+
+                times shouldHaveFadeIn Title.DEFAULT_TIMES.fadeIn()
+                times shouldHaveStay Title.DEFAULT_TIMES.stay()
+                times shouldHaveFadeOut Title.DEFAULT_TIMES.fadeOut()
+            }
+
             "reports a fade-in mismatch with expected and actual kotlin durations" {
                 val times =
                     Title.Times.times(

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchersTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.string.shouldContain
 import net.kyori.adventure.title.Title
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
+import kotlin.time.toKotlinDuration
 
 class TitleTimesMatchersTest :
     StringSpec(
@@ -24,12 +25,12 @@ class TitleTimesMatchersTest :
                 times shouldHaveFadeOut 1.ticks
             }
 
-            "matches individual timing slots from java.time durations" {
+            "matches Adventure values converted at the call site" {
                 val times = Title.DEFAULT_TIMES
 
-                times shouldHaveFadeIn Title.DEFAULT_TIMES.fadeIn()
-                times shouldHaveStay Title.DEFAULT_TIMES.stay()
-                times shouldHaveFadeOut Title.DEFAULT_TIMES.fadeOut()
+                times shouldHaveFadeIn Title.DEFAULT_TIMES.fadeIn().toKotlinDuration()
+                times shouldHaveStay Title.DEFAULT_TIMES.stay().toKotlinDuration()
+                times shouldHaveFadeOut Title.DEFAULT_TIMES.fadeOut().toKotlinDuration()
             }
 
             "reports a fade-in mismatch with expected and actual kotlin durations" {

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchersTest.kt
@@ -11,7 +11,7 @@ import kotlin.time.toJavaDuration
 class TitleTimesMatchersTest :
     StringSpec(
         {
-            "matches times built from Kotlin durations" {
+            "matches individual timing slots from Kotlin durations" {
                 val times =
                     Title.Times.times(
                         1.ticks.toJavaDuration(),
@@ -19,10 +19,12 @@ class TitleTimesMatchersTest :
                         1.ticks.toJavaDuration(),
                     )
 
-                times.shouldHaveTimes(fadeIn = 1.ticks, stay = 3.seconds, fadeOut = 1.ticks)
+                times shouldHaveFadeIn 1.ticks
+                times shouldHaveStay 3.seconds
+                times shouldHaveFadeOut 1.ticks
             }
 
-            "reports a timing mismatch with expected and actual kotlin durations" {
+            "reports a fade-in mismatch with expected and actual kotlin durations" {
                 val times =
                     Title.Times.times(
                         1.ticks.toJavaDuration(),
@@ -32,15 +34,13 @@ class TitleTimesMatchersTest :
 
                 val failure =
                     shouldThrow<AssertionError> {
-                        times.shouldHaveTimes(fadeIn = 2.ticks, stay = 3.seconds, fadeOut = 1.ticks)
+                        times shouldHaveFadeIn 2.ticks
                     }
 
-                failure.message shouldContain
-                    "Expected title times <fadeIn=100ms, stay=3s, fadeOut=50ms>"
-                failure.message shouldContain "fadeIn=50ms"
+                failure.message shouldContain "Expected title fade-in <100ms>, but was <50ms>."
             }
 
-            "matches the absence of the given times" {
+            "matches the absence of a given stay duration" {
                 val times =
                     Title.Times.times(
                         1.ticks.toJavaDuration(),
@@ -48,7 +48,7 @@ class TitleTimesMatchersTest :
                         1.ticks.toJavaDuration(),
                     )
 
-                times.shouldNotHaveTimes(fadeIn = 2.ticks, stay = 3.seconds, fadeOut = 1.ticks)
+                times shouldNotHaveStay 1.seconds
             }
         },
     )

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/title/TitleTimesMatchersTest.kt
@@ -1,0 +1,54 @@
+package io.github.lmliam.kotventure.test.title
+
+import io.github.lmliam.kotventure.core.time.ticks
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.title.Title
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+class TitleTimesMatchersTest :
+    StringSpec(
+        {
+            "matches times built from Kotlin durations" {
+                val times =
+                    Title.Times.times(
+                        1.ticks.toJavaDuration(),
+                        3.seconds.toJavaDuration(),
+                        1.ticks.toJavaDuration(),
+                    )
+
+                times.shouldHaveTimes(fadeIn = 1.ticks, stay = 3.seconds, fadeOut = 1.ticks)
+            }
+
+            "reports a timing mismatch with expected and actual kotlin durations" {
+                val times =
+                    Title.Times.times(
+                        1.ticks.toJavaDuration(),
+                        3.seconds.toJavaDuration(),
+                        1.ticks.toJavaDuration(),
+                    )
+
+                val failure =
+                    shouldThrow<AssertionError> {
+                        times.shouldHaveTimes(fadeIn = 2.ticks, stay = 3.seconds, fadeOut = 1.ticks)
+                    }
+
+                failure.message shouldContain
+                    "Expected title times <fadeIn=100ms, stay=3s, fadeOut=50ms>"
+                failure.message shouldContain "fadeIn=50ms"
+            }
+
+            "matches the absence of the given times" {
+                val times =
+                    Title.Times.times(
+                        1.ticks.toJavaDuration(),
+                        3.seconds.toJavaDuration(),
+                        1.ticks.toJavaDuration(),
+                    )
+
+                times.shouldNotHaveTimes(fadeIn = 2.ticks, stay = 3.seconds, fadeOut = 1.ticks)
+            }
+        },
+    )


### PR DESCRIPTION
## Summary

Adds the audience title send DSL and Minecraft tick duration helpers:

```kotlin
audience.title {
    title { text("Welcome") { color(gold) } }
    subtitle { text("to the server") }
    times {
        fadeIn(1.ticks)
        stay(3.seconds)
        // fadeOut defaults from Title.DEFAULT_TIMES
    }
}
```

- Wraps Adventure `Title.title(...)` / `Title.Times.times(...)` via `Audience.showTitle`
- Nested `times { fadeIn / stay / fadeOut }` — each slot optional; unset slots use that field from `Title.DEFAULT_TIMES`. Omitting `times` entirely uses full `DEFAULT_TIMES`
- At least one of `title` / `subtitle` required; omitted side is empty
- Singleton slots reject double assignment (`once()`)
- `Int.ticks` / `Long.ticks` → `kotlin.time.Duration` (Adventure `Ticks`, 50 ms/tick)
- Test matchers: `shouldHaveFadeIn` / `shouldHaveStay` / `shouldHaveFadeOut` take `kotlin.time.Duration` (Adventure `java.time` values bridge with `toKotlinDuration()` at the call site)

## Related Issues

Closes #35

## DSL Impact

- New: `Audience.title { … }` in `core.audience` (`TitleScope`, nested `TitleTimesScope`)
- New: `Int.ticks` / `Long.ticks` in `core.time`
- New: per-slot title times matchers in `test.title`
- **Sequence helper deferred** to #45 (animation engine) — see issue comment. `core` cannot honestly play titles over time without a scheduler.

## Rationale

Completes the DESIGN.md §5 title send surface alongside `message` / `actionBar` for Phase 2 audience UX.

## Testing

- `TitleDslTest` — full path, partial times, title-only, subtitle-only, ComponentLike overloads, DEFAULT_TIMES, ISE cases (neither title/subtitle, times-only block, duplicate slots / times / timing slots), `audienceOf` fan-out (records via `sendTitlePart` to match Adventure’s showTitle → parts fan-out)
- `TicksTest` — 1 tick = 50 ms, 20 ticks = 1 s, Int + Long
- `TitleTimesMatchersTest` — per-slot matchers, mismatch messaging
- Samples: `TitleSamples`, `TicksSamples` wired via `@sample`

## Checklist

- [x] Linked related issue
- [x] Samples + KDoc; DESIGN.md send sketch updated (no CHANGELOG hand-edit)
- [x] `./gradlew build` green