### PR TITLE
feat(audience): add the book dsl

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -183,6 +183,16 @@ player.show(dragon)
 player.hide(dragon)
 val raid = player.bossBar { name { text("Raid") } }   // build + show; keep for hide/updates
 
+val rules = book {
+    title { text("Server Rules") }
+    author { text("Staff") }
+    page { text("Be kind.") }
+}
+player.open(rules)
+player.book {
+    page { text("One-shot welcome") }
+}
+
 // Managed (timed) boss bars — context(ticker) once; `over` opts into lifecycle management
 // val ticker = paperTicker(plugin)   // platform-provided; ManualTicker in tests
 context(ticker) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Book.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Book.kt
@@ -1,0 +1,27 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.book.BookScope
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.inventory.Book
+import io.github.lmliam.kotventure.core.book.book as buildBook
+
+/**
+ * Opens [book] for this [Audience], forwarding to Adventure's [Audience.openBook].
+ *
+ * @sample io.github.lmliam.kotventure.core.audience.audienceOpenBookSample
+ */
+public fun Audience.open(book: Book): Unit = openBook(book)
+
+/**
+ * Builds a [Book] from [init] and opens it on this [Audience].
+ *
+ * Works for any audience — a player, the console, or a forwarding audience over many members;
+ * audiences without a book surface ignore it. For a reusable book shared across opens, prefer
+ * [book][io.github.lmliam.kotventure.core.book.book] then [open].
+ *
+ * @throws IllegalStateException when `title` or `author` is set twice inside [init].
+ * @sample io.github.lmliam.kotventure.core.audience.audienceBookSample
+ */
+public fun Audience.book(init: BookScope.() -> Unit) {
+    open(buildBook(init))
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TitleBuilder.kt
@@ -2,6 +2,7 @@ package io.github.lmliam.kotventure.core.audience
 
 import io.github.lmliam.kotventure.core.component.ComponentScope
 import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.component.emptyComponent
 import io.github.lmliam.kotventure.core.dsl.once
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentLike
@@ -33,8 +34,8 @@ internal class TitleBuilder : TitleScope {
             "At least one of 'title' or 'subtitle' must be set."
         }
         return Title.title(
-            title ?: Component.empty(),
-            subtitle ?: Component.empty(),
+            title ?: emptyComponent(),
+            subtitle ?: emptyComponent(),
             times ?: Title.DEFAULT_TIMES,
         )
     }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/book/Book.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/book/Book.kt
@@ -1,0 +1,18 @@
+package io.github.lmliam.kotventure.core.book
+
+import net.kyori.adventure.inventory.Book
+
+/**
+ * Builds an Adventure [Book] from a [BookScope] block without opening it.
+ *
+ * Use this when one book is shared across audiences or held for later
+ * [open][io.github.lmliam.kotventure.core.audience.open]. For a one-shot build-and-open, prefer
+ * [Audience.book][io.github.lmliam.kotventure.core.audience.book].
+ *
+ * Title and author default to empty components when unset; pages may be empty. Each of title and
+ * author may be set at most once.
+ *
+ * @throws IllegalStateException when `title` or `author` is set twice.
+ * @sample io.github.lmliam.kotventure.core.book.bookSample
+ */
+public fun book(init: BookScope.() -> Unit): Book = BookBuilder().apply(init).build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/book/BookBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/book/BookBuilder.kt
@@ -2,6 +2,7 @@ package io.github.lmliam.kotventure.core.book
 
 import io.github.lmliam.kotventure.core.component.ComponentScope
 import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.component.emptyComponent
 import io.github.lmliam.kotventure.core.dsl.once
 import net.kyori.adventure.inventory.Book
 import net.kyori.adventure.text.Component
@@ -40,8 +41,8 @@ internal class BookBuilder : BookScope {
 
     internal fun build(): Book =
         Book.book(
-            title ?: Component.empty(),
-            author ?: Component.empty(),
+            title ?: emptyComponent(),
+            author ?: emptyComponent(),
             pages.toList(),
         )
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/book/BookBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/book/BookBuilder.kt
@@ -1,0 +1,47 @@
+package io.github.lmliam.kotventure.core.book
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.dsl.once
+import net.kyori.adventure.inventory.Book
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+
+internal class BookBuilder : BookScope {
+    private var title: Component? by once()
+    private var author: Component? by once()
+    private val pages = mutableListOf<Component>()
+
+    override fun title(init: ComponentScope.() -> Unit): Unit = title(component(init))
+
+    override fun <T : ComponentLike> title(component: T) {
+        title = component.asComponent()
+    }
+
+    override fun author(init: ComponentScope.() -> Unit): Unit = author(component(init))
+
+    override fun <T : ComponentLike> author(component: T) {
+        author = component.asComponent()
+    }
+
+    override fun page(init: ComponentScope.() -> Unit): Unit = page(component(init))
+
+    override fun <T : ComponentLike> page(component: T) {
+        pages += component.asComponent()
+    }
+
+    override fun pages(vararg pages: ComponentLike) {
+        pages.forEach { page(it) }
+    }
+
+    override fun pages(pages: Iterable<ComponentLike>) {
+        pages.forEach { page(it) }
+    }
+
+    internal fun build(): Book =
+        Book.book(
+            title ?: Component.empty(),
+            author ?: Component.empty(),
+            pages.toList(),
+        )
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/book/BookScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/book/BookScope.kt
@@ -1,0 +1,70 @@
+package io.github.lmliam.kotventure.core.book
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.inventory.Book
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Configures an Adventure [Book]: optional [title] and [author], and zero or more [page]s.
+ *
+ * Unset title and author default to [net.kyori.adventure.text.Component.empty]. Pages accumulate
+ * in call order via [page] or bulk [pages]. Title and author may each be set at most once.
+ *
+ * @sample io.github.lmliam.kotventure.core.book.bookSample
+ */
+@KotventureDslMarker
+public interface BookScope {
+    /**
+     * Builds the book title from a component DSL block.
+     *
+     * @throws IllegalStateException when the title is already set in this block.
+     */
+    public fun title(init: ComponentScope.() -> Unit)
+
+    /**
+     * Sets the book title.
+     *
+     * @throws IllegalStateException when the title is already set in this block.
+     */
+    public fun <T : ComponentLike> title(component: T)
+
+    /**
+     * Builds the book author from a component DSL block.
+     *
+     * @throws IllegalStateException when the author is already set in this block.
+     */
+    public fun author(init: ComponentScope.() -> Unit)
+
+    /**
+     * Sets the book author.
+     *
+     * @throws IllegalStateException when the author is already set in this block.
+     */
+    public fun <T : ComponentLike> author(component: T)
+
+    /**
+     * Appends a page built from a component DSL block.
+     *
+     * Pages are kept in call order. Components that exceed the client page limit are truncated
+     * client-side (Adventure does not reflow to the next page).
+     */
+    public fun page(init: ComponentScope.() -> Unit)
+
+    /**
+     * Appends [component] as a page.
+     *
+     * Pages are kept in call order.
+     */
+    public fun <T : ComponentLike> page(component: T)
+
+    /**
+     * Appends each of [pages] as a page, in order.
+     */
+    public fun pages(vararg pages: ComponentLike)
+
+    /**
+     * Appends each of [pages] as a page, in iteration order.
+     */
+    public fun pages(pages: Iterable<ComponentLike>)
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
@@ -1,5 +1,6 @@
 package io.github.lmliam.kotventure.core.color
 
+import io.github.lmliam.kotventure.core.component.emptyComponent
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.TextColor
 import kotlin.math.floor
@@ -80,7 +81,7 @@ public fun gradientText(
 ): Component {
     val children = gradientTextChildren(value, gradient)
     if (children.isEmpty()) {
-        return Component.empty()
+        return emptyComponent()
     }
 
     val builder = Component.text()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/Component.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/component/Component.kt
@@ -3,10 +3,23 @@ package io.github.lmliam.kotventure.core.component
 import net.kyori.adventure.text.Component
 
 /**
+ * Returns Adventure's empty [Component] (empty content, no children, no style).
+ *
+ * Prefer this over [Component.empty] in Kotventure call sites, and over an empty
+ * [component] `{ }` block: the empty builder happens to collapse to the same singleton today, but
+ * that is an implementation detail of Adventure's text builder, not the intended API for "no text".
+ *
+ * @sample io.github.lmliam.kotventure.core.component.emptyComponentSample
+ */
+public fun emptyComponent(): Component = Component.empty()
+
+/**
  * Builds an Adventure [Component] from a Kotventure component DSL block.
  *
  * The block runs against a [ComponentScope] rooted at an empty text component, so its children and
  * styling become the returned component's.
+ *
+ * @sample io.github.lmliam.kotventure.core.component.componentScopeSample
  */
 public fun component(init: ComponentScope.() -> Unit): Component =
     ComponentBuilder(Component.text()).apply(init).build()

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/BookSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/BookSamples.kt
@@ -1,0 +1,25 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.book.book
+import io.github.lmliam.kotventure.core.text.text
+
+internal fun audienceOpenBookSample() {
+    val audience = emptyAudience()
+    val rules =
+        book {
+            title { text("Server Rules") }
+            author { text("Staff") }
+            page { text("Be kind.") }
+        }
+
+    audience.open(rules)
+}
+
+internal fun audienceBookSample() {
+    val audience = emptyAudience()
+
+    audience.book {
+        title { text("Welcome") }
+        page { text("Hello!") }
+    }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/book/BookSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/book/BookSamples.kt
@@ -1,0 +1,19 @@
+package io.github.lmliam.kotventure.core.book
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.text.text
+
+internal fun bookSample() {
+    book {
+        title {
+            text("Server Rules") { color(gold) }
+        }
+        author { text("Staff") }
+        page {
+            text("1. Be kind")
+            newline()
+            text("2. No griefing")
+        }
+        page { text("Contact staff for help.") }
+    }
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/component/ComponentScopeSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/component/ComponentScopeSamples.kt
@@ -4,6 +4,10 @@ import io.github.lmliam.kotventure.core.color.aqua
 import io.github.lmliam.kotventure.core.keybind.keybind
 import io.github.lmliam.kotventure.core.text.text
 
+internal fun emptyComponentSample() {
+    emptyComponent()
+}
+
 internal fun componentScopeSample() {
     component {
         text("Hello ") { color(aqua) }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/BookDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/BookDslTest.kt
@@ -1,0 +1,83 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.book.book
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.test.book.shouldHavePageCount
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.inventory.Book
+
+private class BookRecordingAudience : Audience {
+    val opened = mutableListOf<Book>()
+
+    override fun openBook(book: Book) {
+        opened += book
+    }
+}
+
+class BookDslTest :
+    StringSpec(
+        {
+            "opens a prebuilt book" {
+                val audience = BookRecordingAudience()
+                val rules =
+                    book {
+                        title { text("Rules") }
+                        page { text("Be kind") }
+                    }
+
+                audience.open(rules)
+
+                audience.opened shouldHaveSize 1
+                audience.opened.single() shouldBe rules
+            }
+
+            "builds and opens a book in one expression" {
+                val audience = BookRecordingAudience()
+
+                audience.book {
+                    title { text("Welcome") }
+                    page { text("Hello!") }
+                }
+
+                audience.opened shouldHaveSize 1
+                val opened = audience.opened.single()
+                opened.title().childAt(0) shouldContainText "Welcome"
+                opened shouldHavePageCount 1
+                opened.pages().single().childAt(0) shouldContainText "Hello!"
+            }
+
+            "forwards open to every member of a composite audience" {
+                val first = BookRecordingAudience()
+                val second = BookRecordingAudience()
+                val rules =
+                    book {
+                        page { text("Shared") }
+                    }
+
+                audienceOf(first, second).open(rules)
+
+                first.opened shouldHaveSize 1
+                second.opened shouldHaveSize 1
+                first.opened.single() shouldBe rules
+                second.opened.single() shouldBe rules
+            }
+
+            "forwards book build-and-open to every member" {
+                val first = BookRecordingAudience()
+                val second = BookRecordingAudience()
+
+                audienceOf(first, second).book {
+                    page { text("Hello") }
+                }
+
+                first.opened shouldHaveSize 1
+                second.opened shouldHaveSize 1
+                first.opened.single() shouldBe second.opened.single()
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TitleDslTest.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.kotventure.core.audience
 
 import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.component.emptyComponent
 import io.github.lmliam.kotventure.core.text.text
 import io.github.lmliam.kotventure.core.time.ticks
 import io.github.lmliam.kotventure.test.text.childAt
@@ -27,8 +28,8 @@ import kotlin.time.toKotlinDuration
  */
 private class TitleRecordingAudience : Audience {
     val titles = mutableListOf<Title>()
-    private var titlePart: Component = Component.empty()
-    private var subtitlePart: Component = Component.empty()
+    private var titlePart: Component = emptyComponent()
+    private var subtitlePart: Component = emptyComponent()
     private var timesPart: Title.Times? = null
 
     override fun <T : Any> sendTitlePart(
@@ -39,8 +40,8 @@ private class TitleRecordingAudience : Audience {
             TitlePart.TITLE -> {
                 titlePart = value as Component
                 titles += Title.title(titlePart, subtitlePart, timesPart)
-                titlePart = Component.empty()
-                subtitlePart = Component.empty()
+                titlePart = emptyComponent()
+                subtitlePart = emptyComponent()
                 timesPart = null
             }
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/book/BookDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/book/BookDslTest.kt
@@ -1,0 +1,111 @@
+package io.github.lmliam.kotventure.core.book
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.test.book.shouldHaveAuthor
+import io.github.lmliam.kotventure.test.book.shouldHavePageCount
+import io.github.lmliam.kotventure.test.book.shouldHavePages
+import io.github.lmliam.kotventure.test.book.shouldHaveTitle
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+
+class BookDslTest :
+    StringSpec(
+        {
+            "builds a fully configured book" {
+                val built =
+                    book {
+                        title {
+                            text("Server Rules") { color(gold) }
+                        }
+                        author { text("Staff") }
+                        page {
+                            text("1. Be kind")
+                            newline()
+                            text("2. No griefing")
+                        }
+                        page { text("Contact staff for help.") }
+                    }
+
+                built.title().childAt(0) shouldContainText "Server Rules"
+                built.title().childAt(0) shouldHaveColor gold
+                built.author().childAt(0) shouldContainText "Staff"
+                built shouldHavePageCount 2
+                built.pages()[0].childAt(0) shouldContainText "1. Be kind"
+                built.pages()[1].childAt(0) shouldContainText "Contact staff for help."
+            }
+
+            "defaults produce empty title, author, and pages" {
+                val built = book {}
+
+                built shouldHaveTitle Component.empty()
+                built shouldHaveAuthor Component.empty()
+                built shouldHavePageCount 0
+                built shouldHavePages emptyList()
+            }
+
+            "accepts ComponentLike overloads for title, author, and page" {
+                val title = Component.text("T")
+                val author = Component.text("A")
+                val page = Component.text("P")
+
+                val built =
+                    book {
+                        title(title)
+                        author(author)
+                        page(page)
+                    }
+
+                built shouldHaveTitle title
+                built shouldHaveAuthor author
+                built shouldHavePages listOf(page)
+            }
+
+            "bulk pages preserve order after earlier page calls" {
+                val first = Component.text("first")
+                val second = Component.text("second")
+                val third = Component.text("third")
+
+                val fromVararg =
+                    book {
+                        page(first)
+                        pages(second, third)
+                    }
+                fromVararg shouldHavePages listOf(first, second, third)
+
+                val fromIterable =
+                    book {
+                        page(first)
+                        pages(listOf(second, third))
+                    }
+                fromIterable shouldHavePages listOf(first, second, third)
+            }
+
+            "rejects a second title" {
+                val failure =
+                    shouldThrow<IllegalStateException> {
+                        book {
+                            title { text("A") }
+                            title { text("B") }
+                        }
+                    }
+                failure.message shouldBe "'title' is already set."
+            }
+
+            "rejects a second author" {
+                val failure =
+                    shouldThrow<IllegalStateException> {
+                        book {
+                            author { text("A") }
+                            author { text("B") }
+                        }
+                    }
+                failure.message shouldBe "'author' is already set."
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/text/ComponentDslTest.kt
@@ -8,6 +8,7 @@ import io.github.lmliam.kotventure.core.color.green
 import io.github.lmliam.kotventure.core.color.red
 import io.github.lmliam.kotventure.core.color.yellow
 import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.component.emptyComponent
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
 import io.github.lmliam.kotventure.core.key.key
 import io.github.lmliam.kotventure.core.keybind.keybind
@@ -50,6 +51,7 @@ import io.github.lmliam.kotventure.test.text.shouldNotHaveDecoration
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.BlockNBTComponent
 import net.kyori.adventure.text.Component
@@ -60,6 +62,10 @@ import net.kyori.adventure.text.format.TextDecoration
 class ComponentDslTest :
     StringSpec(
         {
+            "emptyComponent returns Adventure's empty component" {
+                emptyComponent() shouldBeSameInstanceAs Component.empty()
+            }
+
             "builds a text component with content" {
                 val component =
                     component {

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/MiniMessageValidator.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/validation/MiniMessageValidator.kt
@@ -1,7 +1,7 @@
 package io.github.lmliam.kotventure.minimessage.validation
 
+import io.github.lmliam.kotventure.core.component.emptyComponent
 import io.github.lmliam.kotventure.minimessage.placeholder.MiniMessagePlaceholder
-import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.minimessage.ParsingException
 import net.kyori.adventure.text.minimessage.tag.Tag
@@ -92,7 +92,7 @@ private fun buildPlaceholderMismatchDiagnostics(
 /** Resolves placeholder names as self-closing tags for the strict malformed-tag pass. */
 private fun buildPlaceholderNameResolver(placeholders: List<MiniMessagePlaceholder<*>>): TagResolver {
     if (placeholders.isEmpty()) return TagResolver.empty()
-    val selfClosingTag = Tag.selfClosingInserting(Component.empty())
+    val selfClosingTag = Tag.selfClosingInserting(emptyComponent())
     val resolvers = placeholders.map { TagResolver.resolver(it.name, selfClosingTag) }
     return TagResolver.resolver(*resolvers.toTypedArray())
 }

--- a/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/book/BookMatchers.kt
+++ b/modules/test/src/main/kotlin/io/github/lmliam/kotventure/test/book/BookMatchers.kt
@@ -1,0 +1,177 @@
+package io.github.lmliam.kotventure.test.book
+
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
+import net.kyori.adventure.inventory.Book
+import net.kyori.adventure.text.Component
+
+/**
+ * Matches a [Book] whose title equals [expected].
+ */
+public fun haveTitle(expected: Component): Matcher<Book> =
+    Matcher { value ->
+        val actual = value.title()
+        MatcherResult(
+            actual == expected,
+            { "Expected book title <$expected>, but was <$actual>." },
+            { "Expected book title not to be <$expected>." },
+        )
+    }
+
+/**
+ * Matches a [Book] whose author equals [expected].
+ */
+public fun haveAuthor(expected: Component): Matcher<Book> =
+    Matcher { value ->
+        val actual = value.author()
+        MatcherResult(
+            actual == expected,
+            { "Expected book author <$expected>, but was <$actual>." },
+            { "Expected book author not to be <$expected>." },
+        )
+    }
+
+/**
+ * Matches a [Book] with exactly [expected] pages.
+ */
+public fun havePageCount(expected: Int): Matcher<Book> =
+    Matcher { value ->
+        val actual = value.pages().size
+        MatcherResult(
+            actual == expected,
+            { "Expected book page count <$expected>, but was <$actual>." },
+            { "Expected book page count not to be <$expected>." },
+        )
+    }
+
+/**
+ * Matches a [Book] whose page at [index] equals [expected].
+ */
+public fun havePageAt(
+    index: Int,
+    expected: Component,
+): Matcher<Book> =
+    Matcher { value ->
+        val pages = value.pages()
+        if (index !in pages.indices) {
+            MatcherResult(
+                false,
+                {
+                    "Expected book page at index <$index>, but page count was <${pages.size}>."
+                },
+                { "Expected book not to have page at index <$index>." },
+            )
+        } else {
+            val actual = pages[index]
+            MatcherResult(
+                actual == expected,
+                {
+                    "Expected book page at index <$index> to be <$expected>, but was <$actual>."
+                },
+                {
+                    "Expected book page at index <$index> not to be <$expected>."
+                },
+            )
+        }
+    }
+
+/**
+ * Matches a [Book] whose pages equal [expected] in order.
+ */
+public fun havePages(expected: List<Component>): Matcher<Book> =
+    Matcher { value ->
+        val actual = value.pages()
+        MatcherResult(
+            actual == expected,
+            { "Expected book pages <$expected>, but was <$actual>." },
+            { "Expected book pages not to be <$expected>." },
+        )
+    }
+
+/**
+ * Asserts this [Book] has title [expected].
+ */
+public infix fun Book.shouldHaveTitle(expected: Component): Book =
+    apply {
+        this should haveTitle(expected)
+    }
+
+/**
+ * Asserts this [Book] does not have title [expected].
+ */
+public infix fun Book.shouldNotHaveTitle(expected: Component): Book =
+    apply {
+        this shouldNot haveTitle(expected)
+    }
+
+/**
+ * Asserts this [Book] has author [expected].
+ */
+public infix fun Book.shouldHaveAuthor(expected: Component): Book =
+    apply {
+        this should haveAuthor(expected)
+    }
+
+/**
+ * Asserts this [Book] does not have author [expected].
+ */
+public infix fun Book.shouldNotHaveAuthor(expected: Component): Book =
+    apply {
+        this shouldNot haveAuthor(expected)
+    }
+
+/**
+ * Asserts this [Book] has exactly [expected] pages.
+ */
+public infix fun Book.shouldHavePageCount(expected: Int): Book =
+    apply {
+        this should havePageCount(expected)
+    }
+
+/**
+ * Asserts this [Book] does not have exactly [expected] pages.
+ */
+public infix fun Book.shouldNotHavePageCount(expected: Int): Book =
+    apply {
+        this shouldNot havePageCount(expected)
+    }
+
+/**
+ * Asserts this [Book] has page [expected] at [index].
+ */
+public fun Book.shouldHavePageAt(
+    index: Int,
+    expected: Component,
+): Book =
+    apply {
+        this should havePageAt(index, expected)
+    }
+
+/**
+ * Asserts this [Book] does not have page [expected] at [index].
+ */
+public fun Book.shouldNotHavePageAt(
+    index: Int,
+    expected: Component,
+): Book =
+    apply {
+        this shouldNot havePageAt(index, expected)
+    }
+
+/**
+ * Asserts this [Book] has pages [expected] in order.
+ */
+public infix fun Book.shouldHavePages(expected: List<Component>): Book =
+    apply {
+        this should havePages(expected)
+    }
+
+/**
+ * Asserts this [Book] does not have pages [expected] in order.
+ */
+public infix fun Book.shouldNotHavePages(expected: List<Component>): Book =
+    apply {
+        this shouldNot havePages(expected)
+    }

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/book/BookMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/book/BookMatchersTest.kt
@@ -1,0 +1,119 @@
+package io.github.lmliam.kotventure.test.book
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.string.shouldContain
+import net.kyori.adventure.inventory.Book
+import net.kyori.adventure.text.Component
+
+class BookMatchersTest :
+    StringSpec(
+        {
+            fun book(
+                title: Component = Component.empty(),
+                author: Component = Component.empty(),
+                pages: List<Component> = emptyList(),
+            ): Book = Book.book(title, author, pages)
+
+            "matches title, author, page count, page at index, and full pages" {
+                val title = Component.text("Rules")
+                val author = Component.text("Staff")
+                val page0 = Component.text("Be kind")
+                val page1 = Component.text("No griefing")
+                val subject = book(title, author, listOf(page0, page1))
+
+                subject shouldHaveTitle title
+                subject shouldHaveAuthor author
+                subject shouldHavePageCount 2
+                subject.shouldHavePageAt(0, page0)
+                subject.shouldHavePageAt(1, page1)
+                subject shouldHavePages listOf(page0, page1)
+                subject shouldNotHaveTitle Component.text("Other")
+                subject shouldNotHaveAuthor Component.text("Other")
+                subject shouldNotHavePageCount 1
+                subject.shouldNotHavePageAt(0, page1)
+                subject shouldNotHavePages listOf(page1, page0)
+            }
+
+            "matches an empty book" {
+                val subject = book()
+                subject shouldHaveTitle Component.empty()
+                subject shouldHaveAuthor Component.empty()
+                subject shouldHavePageCount 0
+                subject shouldHavePages emptyList()
+            }
+
+            "reports a title mismatch with expected and actual values" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        book(title = Component.text("A")) shouldHaveTitle Component.text("B")
+                    }
+
+                failure.message shouldContain "Expected book title"
+                failure.message shouldContain "A"
+                failure.message shouldContain "B"
+            }
+
+            "reports when title unexpectedly matches" {
+                val title = Component.text("Rules")
+                val failure =
+                    shouldThrow<AssertionError> {
+                        book(title = title) shouldNotHaveTitle title
+                    }
+
+                failure.message shouldContain "Expected book title not to be"
+            }
+
+            "reports an author mismatch with expected and actual values" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        book(author = Component.text("A")) shouldHaveAuthor
+                            Component.text("B")
+                    }
+
+                failure.message shouldContain "Expected book author"
+            }
+
+            "reports a page count mismatch" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        book(pages = listOf(Component.text("p"))) shouldHavePageCount 2
+                    }
+
+                failure.message shouldContain
+                    "Expected book page count <2>, but was <1>."
+            }
+
+            "reports a page-at-index mismatch" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        book(pages = listOf(Component.text("A"))).shouldHavePageAt(
+                            0,
+                            Component.text("B"),
+                        )
+                    }
+
+                failure.message shouldContain "Expected book page at index <0>"
+            }
+
+            "reports a missing page index" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        book().shouldHavePageAt(0, Component.text("x"))
+                    }
+
+                failure.message shouldContain
+                    "Expected book page at index <0>, but page count was <0>."
+            }
+
+            "reports a pages mismatch" {
+                val failure =
+                    shouldThrow<AssertionError> {
+                        book(pages = listOf(Component.text("A"))) shouldHavePages
+                            listOf(Component.text("B"))
+                    }
+
+                failure.message shouldContain "Expected book pages"
+            }
+        },
+    )

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/book/BookMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/book/BookMatchersTest.kt
@@ -1,5 +1,6 @@
 package io.github.lmliam.kotventure.test.book
 
+import io.github.lmliam.kotventure.core.component.emptyComponent
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.string.shouldContain
@@ -10,8 +11,8 @@ class BookMatchersTest :
     StringSpec(
         {
             fun book(
-                title: Component = Component.empty(),
-                author: Component = Component.empty(),
+                title: Component = emptyComponent(),
+                author: Component = emptyComponent(),
                 pages: List<Component> = emptyList(),
             ): Book = Book.book(title, author, pages)
 

--- a/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/book/BookMatchersTest.kt
+++ b/modules/test/src/test/kotlin/io/github/lmliam/kotventure/test/book/BookMatchersTest.kt
@@ -69,7 +69,7 @@ class BookMatchersTest :
                 val failure =
                     shouldThrow<AssertionError> {
                         book(author = Component.text("A")) shouldHaveAuthor
-                            Component.text("B")
+                                Component.text("B")
                     }
 
                 failure.message shouldContain "Expected book author"
@@ -82,7 +82,7 @@ class BookMatchersTest :
                     }
 
                 failure.message shouldContain
-                    "Expected book page count <2>, but was <1>."
+                        "Expected book page count <2>, but was <1>."
             }
 
             "reports a page-at-index mismatch" {
@@ -104,14 +104,14 @@ class BookMatchersTest :
                     }
 
                 failure.message shouldContain
-                    "Expected book page at index <0>, but page count was <0>."
+                        "Expected book page at index <0>, but page count was <0>."
             }
 
             "reports a pages mismatch" {
                 val failure =
                     shouldThrow<AssertionError> {
                         book(pages = listOf(Component.text("A"))) shouldHavePages
-                            listOf(Component.text("B"))
+                                listOf(Component.text("B"))
                     }
 
                 failure.message shouldContain "Expected book pages"


### PR DESCRIPTION
## Summary

Adds a written-book DSL wrapping Adventure `Book` / `Audience.openBook`.

```kotlin
val rules = book {
    title { text("Server Rules") { color(gold) } }
    author { text("Staff") }
    page {
        text("1. Be kind")
        newline()
        text("2. No griefing")
    }
    pages(extraPage)
}
player.open(rules)

player.book {
    page { text("One-shot welcome") }
}
```

## Related Issues

Closes #38

## DSL Impact

- **`core.book`** — `book { }`, `BookScope` with once-assign `title`/`author`, accumulating `page`/`pages`, Adventure-parity empty defaults
- **`Audience.open(Book)`** — type-overloaded open verb → `openBook`
- **`Audience.book { }`** — one-shot build-and-open (returns `Unit`; no hide lifecycle)
- **`test.book`** — thin matchers: title, author, page count, page-at-index, full pages

## Rationale

Plugins need multi-page books without dropping to raw Adventure factories. This matches the audience noun family (`message` / `actionBar` / `title` / `bossBar`) while keeping reusable build separate from open.

## Testing

- `BookMatchersTest` — matcher happy paths and failure messages
- `core.book.BookDslTest` — full book, defaults, ComponentLike overloads, bulk pages order, double title/author rejection
- `core.audience.BookDslTest` — `open`, one-shot `book { }`, composite audience forwarding
- Samples for KDoc `@sample`; `docs/DESIGN.md` sending examples
- `./gradlew build` green

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run