### PR TITLE
refactor(color): hide ColorGradient constructor behind gradient factories

### DIFF
--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
@@ -9,9 +9,12 @@ import kotlin.math.min
 /**
  * Immutable color gradient that interpolates across an ordered list of at least two [TextColor] stops.
  *
+ * Create instances with [gradient]; the constructor is internal so construction has a single public
+ * entry point.
+ *
  * @throws IllegalArgumentException if fewer than two stops are supplied.
  */
-public class ColorGradient public constructor(
+public class ColorGradient internal constructor(
     stops: Iterable<TextColor>,
 ) {
     /** The gradient's color stops, in order, as a defensive immutable copy. */
@@ -44,6 +47,8 @@ public class ColorGradient public constructor(
 /**
  * Creates a [ColorGradient] from two or more color stops.
  *
+ * This is the public construction entry for [ColorGradient].
+ *
  * @sample io.github.lmliam.kotventure.core.color.gradientSample
  *
  * @throws IllegalArgumentException if fewer than two stops are supplied.
@@ -52,6 +57,8 @@ public fun gradient(vararg stops: TextColor): ColorGradient = ColorGradient(stop
 
 /**
  * Creates a [ColorGradient] from an iterable of two or more color stops.
+ *
+ * This is the public construction entry for [ColorGradient] when stops are already a collection.
  *
  * @throws IllegalArgumentException if fewer than two stops are supplied.
  */

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/color/GradientDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/color/GradientDslTest.kt
@@ -2,6 +2,7 @@ package io.github.lmliam.kotventure.core.color
 
 import io.github.lmliam.kotventure.core.component.component
 import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
 import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
@@ -14,6 +15,21 @@ import net.kyori.adventure.text.format.NamedTextColor
 class GradientDslTest :
     StringSpec(
         {
+            "constructs gradients only through the gradient factories" {
+                assertDoesNotCompile(
+                    "ColorGradientConstructorVisibilityTest.kt",
+                    """
+                    import io.github.lmliam.kotventure.core.color.ColorGradient
+                    import net.kyori.adventure.text.format.NamedTextColor
+
+                    fun invalid() {
+                        ColorGradient(listOf(NamedTextColor.RED, NamedTextColor.BLUE))
+                    }
+                    """.trimIndent(),
+                    "Cannot access",
+                )
+            }
+
             "renders a multi stop gradient as one styled child per code point" {
                 val message = gradientText("abcde", red, gold, aqua)
 


### PR DESCRIPTION
## Summary

Audit finding **F-COL-3** (Option B): public construction of `ColorGradient` was dual-entry (`ColorGradient(...)` + `gradient(...)`).

- Constructor is now **`internal`**
- Public creation is only via **`gradient(vararg)`** / **`gradient(Iterable)`**
- Type remains public for holding/passing (e.g. `TextScope.gradient(ColorGradient)`, `colorAt`)
- Compile-fail test locks constructor visibility for out-of-module callers

**Source-breaking** for any consumer that called `ColorGradient(...)` directly (pre-alpha; factories already the documented path).

## Related issues

N/A — audit-driven quality slice.

## Type of change

- [x] refactor — internal construction visibility; factories unchanged

## Testing

- `./gradlew :core:test --tests 'io.github.lmliam.kotventure.core.color.*'`
- New kctfork compile-fail: `ColorGradient(...)` → `Cannot access`

## Checklist

- [x] Title and commit subjects follow `verb(area): something`
- [x] Tests updated (compile-fail for constructor)
- [x] Not a behavioural DSL change (no CHANGELOG/user docs required beyond KDoc)