### PR TITLE
feat(theme): add ThemeRegistry replace and unregister for hot-reload

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -156,6 +156,8 @@ object Brand : Theme("brand") {
 }
 val themes = ThemeRegistry()
 themes.register(Brand)                       // explicit startup wiring
+// themes.replace(BrandV2, default = true)   // hot-reload under the same name
+// themes.unregister("brand")                // remove; clears default if it was default
 text("Title") styled Brand.header            // compile-checked property
 themes.theme("brand")?.style("header")       // dynamic interop lookup
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -157,7 +157,8 @@ object Brand : Theme("brand") {
 val themes = ThemeRegistry()
 themes.register(Brand)                       // explicit startup wiring
 // themes.replace(BrandV2, default = true)   // hot-reload under the same name
-// themes.unregister("brand")                // remove; clears default if it was default
+// themes.unregister(Brand)                  // preferred: remove by object reference
+// themes.unregister("brand")                // string bridge for dynamic/interop names
 text("Title") styled Brand.header            // compile-checked property
 themes.theme("brand")?.style("header")       // dynamic interop lookup
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/Theme.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/Theme.kt
@@ -17,7 +17,8 @@ import io.github.lmliam.kotventure.core.style.style as buildStyle
  * @sample io.github.lmliam.kotventure.core.theme.themeSample
  *
  * Runtime lookups require explicit registration: add the theme to a [ThemeRegistry] during
- * startup. Declaring a theme does not register it.
+ * startup (or later via [ThemeRegistry.replace] for hot-reload). Declaring a theme does not
+ * register it.
  */
 public abstract class Theme(
     public override val name: String,

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistry.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistry.kt
@@ -9,6 +9,9 @@ import kotlin.concurrent.withLock
  * Direct Kotlin callers should prefer compile-checked theme properties such as `Brand.header`.
  * This registry exists for dynamic lookup and interop cases where the theme name is only known
  * at runtime.
+ *
+ * Lifecycle: [register] fails on duplicate names; [replace] and [unregister] support hot-reload
+ * workflows where a theme is swapped or removed after startup.
  */
 public class ThemeRegistry {
     private val lock = ReentrantLock()
@@ -25,8 +28,7 @@ public class ThemeRegistry {
         provider: T,
         default: Boolean = false,
     ): T {
-        val providerName = provider.name
-        require(providerName.isNotBlank()) { "Theme provider name must not be blank." }
+        val providerName = requireProviderName(provider)
         lock.withLock {
             require(providerName !in providers) {
                 "Theme provider '$providerName' is already registered."
@@ -41,6 +43,48 @@ public class ThemeRegistry {
         }
         return provider
     }
+
+    /**
+     * Registers [provider], replacing any existing provider with the same name.
+     *
+     * Use this for hot-reload: a second registration of the same name is intentional. When
+     * [default] is `true`, [provider] becomes the sole default (any previous default is cleared).
+     * When [default] is `false` and this replaces the previous default under the same name, the
+     * default is cleared; a different theme that was already default is left unchanged.
+     *
+     * @return [provider]
+     * @throws IllegalArgumentException when the provider name is blank.
+     */
+    public fun <T : ThemeProvider> replace(
+        provider: T,
+        default: Boolean = false,
+    ): T {
+        val providerName = requireProviderName(provider)
+        lock.withLock {
+            val previous = providers.put(providerName, provider)
+            when {
+                default -> defaultProvider = provider
+                previous != null && defaultProvider === previous -> defaultProvider = null
+            }
+        }
+        return provider
+    }
+
+    /**
+     * Removes the theme registered as [name].
+     *
+     * When the removed provider was the default theme, the default is cleared.
+     *
+     * @return the removed provider, or null when [name] was not registered.
+     */
+    public fun unregister(name: String): ThemeProvider? =
+        lock.withLock {
+            val removed = providers.remove(name) ?: return@withLock null
+            if (defaultProvider === removed) {
+                defaultProvider = null
+            }
+            removed
+        }
 
     /**
      * Returns the theme provider registered as [name], or null when none exists.
@@ -58,4 +102,10 @@ public class ThemeRegistry {
         lock.withLock {
             defaultProvider
         }
+
+    private fun requireProviderName(provider: ThemeProvider): String {
+        val providerName = provider.name
+        require(providerName.isNotBlank()) { "Theme provider name must not be blank." }
+        return providerName
+    }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistry.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistry.kt
@@ -11,7 +11,8 @@ import kotlin.concurrent.withLock
  * at runtime.
  *
  * Lifecycle: [register] fails on duplicate names; [replace] and [unregister] support hot-reload
- * workflows where a theme is swapped or removed after startup.
+ * workflows where a theme is swapped or removed after startup. Prefer unregistering with the
+ * theme object (`themes.unregister(Brand)`) when it is available.
  */
 public class ThemeRegistry {
     private val lock = ReentrantLock()
@@ -71,7 +72,30 @@ public class ThemeRegistry {
     }
 
     /**
+     * Removes [provider] when it is the instance currently registered under [ThemeProvider.name].
+     *
+     * Prefer this overload when the theme object is known (`themes.unregister(Brand)`). After
+     * [replace] has installed a different instance under the same name, this is a no-op.
+     *
+     * When the removed provider was the default theme, the default is cleared.
+     *
+     * @return [provider] when it was removed, or null when it is not the registered instance.
+     */
+    public fun <T : ThemeProvider> unregister(provider: T): T? =
+        lock.withLock {
+            val current = providers[provider.name]
+            if (current !== provider) {
+                return@withLock null
+            }
+            removeRegistered(provider.name, provider)
+            provider
+        }
+
+    /**
      * Removes the theme registered as [name].
+     *
+     * Prefer [unregister] with the theme object when available; this overload is for dynamic
+     * lookup and interop where only the name is known.
      *
      * When the removed provider was the default theme, the default is cleared.
      *
@@ -79,10 +103,8 @@ public class ThemeRegistry {
      */
     public fun unregister(name: String): ThemeProvider? =
         lock.withLock {
-            val removed = providers.remove(name) ?: return@withLock null
-            if (defaultProvider === removed) {
-                defaultProvider = null
-            }
+            val removed = providers[name] ?: return@withLock null
+            removeRegistered(name, removed)
             removed
         }
 
@@ -102,6 +124,16 @@ public class ThemeRegistry {
         lock.withLock {
             defaultProvider
         }
+
+    private fun removeRegistered(
+        name: String,
+        removed: ThemeProvider,
+    ) {
+        providers.remove(name)
+        if (defaultProvider === removed) {
+            defaultProvider = null
+        }
+    }
 
     private fun requireProviderName(provider: ThemeProvider): String {
         val providerName = provider.name

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeLookupTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeLookupTest.kt
@@ -64,6 +64,118 @@ class ThemeLookupTest :
                     registry.register(TestThemeProvider("server"), default = true)
                 }
             }
+
+            "unregisters a theme by name and returns the removed provider" {
+                val registry = ThemeRegistry()
+                val provider = TestThemeProvider("brand")
+
+                registry.register(provider)
+
+                registry.unregister("brand") shouldBe provider
+                registry.theme("brand").shouldBeNull()
+            }
+
+            "unregister returns null when the name is not registered" {
+                ThemeRegistry().unregister("missing").shouldBeNull()
+            }
+
+            "unregister clears the default when the default theme is removed" {
+                val registry = ThemeRegistry()
+                val provider = TestThemeProvider("brand")
+
+                registry.register(provider, default = true)
+
+                registry.unregister("brand") shouldBe provider
+                registry.defaultTheme().shouldBeNull()
+            }
+
+            "unregister leaves another default intact when removing a non-default theme" {
+                val registry = ThemeRegistry()
+                val brand = TestThemeProvider("brand")
+                val server = TestThemeProvider("server")
+
+                registry.register(brand, default = true)
+                registry.register(server)
+
+                registry.unregister("server") shouldBe server
+                registry.defaultTheme() shouldBe brand
+            }
+
+            "replace swaps a theme under the same name" {
+                val registry = ThemeRegistry()
+                val original = TestThemeProvider("brand")
+                val reloaded = TestThemeProvider("brand")
+
+                registry.register(original)
+                registry.replace(reloaded)
+
+                registry.theme("brand") shouldBe reloaded
+            }
+
+            "replace inserts a theme that was not previously registered" {
+                val registry = ThemeRegistry()
+                val provider = TestThemeProvider("brand")
+
+                registry.replace(provider)
+
+                registry.theme("brand") shouldBe provider
+            }
+
+            "replace with default promotes the provider to the sole default" {
+                val registry = ThemeRegistry()
+                val brand = TestThemeProvider("brand")
+                val server = TestThemeProvider("server")
+
+                registry.register(brand, default = true)
+                registry.replace(server, default = true)
+
+                registry.defaultTheme() shouldBe server
+                registry.theme("brand") shouldBe brand
+            }
+
+            "replace without default clears default when replacing the default theme" {
+                val registry = ThemeRegistry()
+                val original = TestThemeProvider("brand")
+                val reloaded = TestThemeProvider("brand")
+
+                registry.register(original, default = true)
+                registry.replace(reloaded)
+
+                registry.theme("brand") shouldBe reloaded
+                registry.defaultTheme().shouldBeNull()
+            }
+
+            "replace without default leaves a different default theme intact" {
+                val registry = ThemeRegistry()
+                val brand = TestThemeProvider("brand")
+                val server = TestThemeProvider("server")
+                val serverReload = TestThemeProvider("server")
+
+                registry.register(brand, default = true)
+                registry.register(server)
+                registry.replace(serverReload)
+
+                registry.theme("server") shouldBe serverReload
+                registry.defaultTheme() shouldBe brand
+            }
+
+            "replace rejects blank provider names" {
+                shouldThrow<IllegalArgumentException> {
+                    ThemeRegistry().replace(TestThemeProvider(" "))
+                }
+            }
+
+            "hot-reload keeps a theme as default when replace sets default true" {
+                val registry = ThemeRegistry()
+                val original = TestThemeProvider("brand")
+                val reloaded = TestThemeProvider("brand")
+
+                registry.register(original, default = true)
+                registry.replace(reloaded, default = true)
+
+                registry.theme("brand") shouldBe reloaded
+                registry.defaultTheme() shouldBe reloaded
+            }
         },
     )
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeLookupTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeLookupTest.kt
@@ -65,6 +65,16 @@ class ThemeLookupTest :
                 }
             }
 
+            "unregisters a theme by object reference and returns the removed provider" {
+                val registry = ThemeRegistry()
+                val provider = TestThemeProvider("brand")
+
+                registry.register(provider)
+
+                registry.unregister(provider) shouldBe provider
+                registry.theme("brand").shouldBeNull()
+            }
+
             "unregisters a theme by name and returns the removed provider" {
                 val registry = ThemeRegistry()
                 val provider = TestThemeProvider("brand")
@@ -75,11 +85,37 @@ class ThemeLookupTest :
                 registry.theme("brand").shouldBeNull()
             }
 
-            "unregister returns null when the name is not registered" {
+            "unregister by object returns null when a different instance owns the name" {
+                val registry = ThemeRegistry()
+                val original = TestThemeProvider("brand")
+                val reloaded = TestThemeProvider("brand")
+
+                registry.register(original)
+                registry.replace(reloaded)
+
+                registry.unregister(original).shouldBeNull()
+                registry.theme("brand") shouldBe reloaded
+            }
+
+            "unregister by object returns null when the provider was never registered" {
+                ThemeRegistry().unregister(TestThemeProvider("brand")).shouldBeNull()
+            }
+
+            "unregister by name returns null when the name is not registered" {
                 ThemeRegistry().unregister("missing").shouldBeNull()
             }
 
-            "unregister clears the default when the default theme is removed" {
+            "unregister by object clears the default when the default theme is removed" {
+                val registry = ThemeRegistry()
+                val provider = TestThemeProvider("brand")
+
+                registry.register(provider, default = true)
+
+                registry.unregister(provider) shouldBe provider
+                registry.defaultTheme().shouldBeNull()
+            }
+
+            "unregister by name clears the default when the default theme is removed" {
                 val registry = ThemeRegistry()
                 val provider = TestThemeProvider("brand")
 
@@ -97,7 +133,7 @@ class ThemeLookupTest :
                 registry.register(brand, default = true)
                 registry.register(server)
 
-                registry.unregister("server") shouldBe server
+                registry.unregister(server) shouldBe server
                 registry.defaultTheme() shouldBe brand
             }
 


### PR DESCRIPTION
## Summary

Audit finding **F-THM-3**: theme lifecycle for hot-loaded themes.

`ThemeRegistry` gains:

| API | Behaviour |
|-----|-----------|
| `replace(provider, default = false)` | Upsert by name; `default = true` becomes sole default; replacing the previous default with `default = false` clears default |
| `unregister(name)` | Removes by name; returns the provider or `null`; clears default when that provider was default |

`register` is unchanged (still rejects duplicates and a second default) so startup wiring stays strict; hot-reload uses `replace` / `unregister` explicitly.

## Related issues

N/A — audit-driven quality/feature slice.

## Type of change

- [x] feat — new capability on `ThemeRegistry`

## Testing

- `./gradlew :core:test --tests 'io.github.lmliam.kotventure.core.theme.*'`
- Coverage: unregister missing/present, default clearing, replace insert/swap, default promotion, leave other default intact, blank name rejection, hot-reload with `default = true`

## Checklist

- [x] Title and commit subjects follow `verb(area): something`
- [x] Tests added
- [x] KDoc on public API
- [x] `docs/DESIGN.md` theme sample notes hot-reload (`CHANGELOG` is release-please-owned)