### PR TITLE
ci(build): skip heavy CI on pure release-please PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,20 @@ concurrency:
 permissions:
   checks: write
   contents: read
+  pull-requests: read
 
 jobs:
+  gate:
+    name: Heavy CI gate
+    uses: ./.github/workflows/heavy-ci-gate.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   build:
     name: Build, Test, and Lint
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/heavy-ci-gate.yml
+++ b/.github/workflows/heavy-ci-gate.yml
@@ -1,0 +1,79 @@
+# Reusable gate for expensive CI (build, Qodana, …).
+#
+# Skips pure release-please automation PRs (version + changelog only).
+# Still runs when a release-please branch has non-release file changes
+# (manual commits that touch real code/docs beyond the release bump).
+name: Heavy CI gate
+
+on:
+  workflow_call:
+    outputs:
+      run:
+        description: Whether heavy CI should run
+        value: ${{ jobs.gate.outputs.run }}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gate:
+    name: Decide
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - name: Decide whether heavy CI should run
+        id: decide
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const ALWAYS = () => {
+              core.setOutput('run', 'true');
+            };
+
+            if (context.eventName !== 'pull_request') {
+              core.info(`Event ${context.eventName}: always run heavy CI.`);
+              ALWAYS();
+              return;
+            }
+
+            const headRef = context.payload.pull_request.head.ref;
+            if (!headRef.startsWith('release-please--')) {
+              core.info(`Branch ${headRef}: not a release-please PR; run heavy CI.`);
+              ALWAYS();
+              return;
+            }
+
+            // Files release-please is configured to touch on this repo.
+            // Keep in sync with release-please-config.json (+ the manifest).
+            const releaseOnlyFiles = new Set([
+              'CHANGELOG.md',
+              '.release-please-manifest.json',
+              'gradle/libs.versions.toml',
+            ]);
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const unexpected = files
+              .map((file) => file.filename)
+              .filter((name) => !releaseOnlyFiles.has(name));
+
+            if (unexpected.length === 0) {
+              core.info(
+                'Pure release-please PR (changelog/version files only); skip heavy CI.',
+              );
+              core.setOutput('run', 'false');
+              return;
+            }
+
+            core.info(
+              `Release-please PR has non-release changes; run heavy CI: ${unexpected.join(', ')}`,
+            );
+            ALWAYS();

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -22,8 +22,17 @@ permissions:
   security-events: write
 
 jobs:
+  gate:
+    name: Heavy CI gate
+    uses: ./.github/workflows/heavy-ci-gate.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   qodana:
     name: Qodana
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary

Stop **Build** and **Qodana** from burning minutes on pure [release-please](https://github.com/googleapis/release-please) automation PRs (`release-please--branches--master`), while still running them if someone manually commits real changes onto that PR.

### How the gate decides

| Situation | Heavy CI |
|-----------|----------|
| `push` to `master`, `workflow_dispatch`, `schedule` | **Run** |
| Normal feature PR | **Run** |
| `release-please--*` PR with only `CHANGELOG.md`, `.release-please-manifest.json`, `gradle/libs.versions.toml` | **Skip** |
| `release-please--*` PR that also touches other files (manual follow-up commits) | **Run** |

Path allow-list matches what release-please is configured to edit (`release-please-config.json` + the manifest). Author-based “bot commit” detection is intentionally **not** used: this repo’s release-please token attributes commits to a human account.

Shared logic lives in `.github/workflows/heavy-ci-gate.yml` and is called from `build.yml` and `qodana.yml`.

## Type of change

- [x] chore / build / ci

## Testing

- YAML structure validated locally
- Behaviour is event-driven; verify on next pure release-please PR (gate job green, build/qodana skipped) and by pushing a non-release file to that branch (build/qodana should run)

## Checklist

- [x] Title and commit subjects follow `verb(area): something`
- [x] Does not weaken required checks for normal PRs