### PR TITLE
ci(ci): extract composites, gate dep-review, and document CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -38,6 +38,8 @@ Dependency and plugin coordinates live in [`gradle/libs.versions.toml`](../gradl
 versions there first, then consume them through catalog aliases or the existing Gradle helper scripts that delegate to
 the catalog.
 
+CI architecture (workflows, release-please heavy-CI gate, local composites): see [`docs/CI.md`](../docs/CI.md).
+
 ### Coverage threshold policy
 
 We use [Kover](https://github.com/Kotlin/kotlinx-kover) for code coverage. `koverVerify` is wired into `check`, so

--- a/.github/actions/publish-junit-report/action.yml
+++ b/.github/actions/publish-junit-report/action.yml
@@ -1,0 +1,27 @@
+name: Publish JUnit report
+description: Publish JUnit XML results as a GitHub Checks annotation summary.
+
+inputs:
+  check_name:
+    description: Name of the check run shown in the PR Checks UI.
+    required: true
+  report_paths:
+    description: Glob(s) of JUnit XML report files.
+    required: true
+  require_tests:
+    description: Fail when no test reports are found.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Publish JUnit test report
+      uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
+      with:
+        check_name: ${{ inputs.check_name }}
+        report_paths: ${{ inputs.report_paths }}
+        require_tests: ${{ inputs.require_tests }}
+        fail_on_failure: true
+        fail_on_parse_error: true
+        detailed_summary: true

--- a/.github/actions/setup-jdk-gradle/action.yml
+++ b/.github/actions/setup-jdk-gradle/action.yml
@@ -1,0 +1,20 @@
+name: Setup JDK and Gradle
+description: Install Temurin JDK and configure the Gradle action (dependency/build caches).
+
+inputs:
+  java-version:
+    description: JDK version for setup-java (matches the project toolchain by default).
+    required: false
+    default: '25'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+      with:
+        distribution: temurin
+        java-version: ${{ inputs.java-version }}
+
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,11 +17,45 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
+  # Root workflows (and any root-level action.yml). Dependabot does not recurse into
+  # .github/actions/* with directory: "/" alone — those are listed separately below.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "type: chore"
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup-jdk-gradle"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "type: chore"
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/publish-junit-report"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
     groups:
       github-actions:
         update-types:

--- a/.github/scripts/normalize-qodana-sarif.sh
+++ b/.github/scripts/normalize-qodana-sarif.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 sarif_file="${1:-${RUNNER_TEMP:-/tmp}/qodana/results/qodana.sarif.json}"
+tmp_file="${sarif_file}.tmp"
 
 if [[ ! -f "$sarif_file" ]]; then
   echo "Qodana SARIF not found at $sarif_file; skipping normalization."
@@ -14,6 +15,11 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required to normalize Qodana SARIF." >&2
   exit 1
 fi
+
+cleanup() {
+  rm -f "$tmp_file"
+}
+trap cleanup EXIT
 
 jq '
   def normalize_region:
@@ -37,5 +43,5 @@ jq '
     end;
 
   walk(if type == "object" and has("region") then .region |= normalize_region else . end)
-' "$sarif_file" > "${sarif_file}.tmp"
-mv "${sarif_file}.tmp" "$sarif_file"
+' "$sarif_file" > "$tmp_file"
+mv "$tmp_file" "$sarif_file"

--- a/.github/scripts/normalize-qodana-sarif.sh
+++ b/.github/scripts/normalize-qodana-sarif.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Normalize Qodana SARIF region coordinates so GitHub code scanning accepts them.
+# Some Qodana exports use startLine/startColumn of 0; GitHub expects 1-based values ≥ 1.
+set -euo pipefail
+
+sarif_file="${1:-${RUNNER_TEMP:-/tmp}/qodana/results/qodana.sarif.json}"
+
+if [[ ! -f "$sarif_file" ]]; then
+  echo "Qodana SARIF not found at $sarif_file; skipping normalization."
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to normalize Qodana SARIF." >&2
+  exit 1
+fi
+
+jq '
+  def normalize_region:
+    if type == "object" then
+      (
+        if has("startLine") and (.startLine | type == "number") and .startLine < 1 then
+          .startLine = 1
+        else
+          .
+        end
+      )
+      | (
+        if has("startColumn") and (.startColumn | type == "number") and .startColumn < 1 then
+          .startColumn = 1
+        else
+          .
+        end
+      )
+    else
+      .
+    end;
+
+  walk(if type == "object" and has("region") then .region |= normalize_region else . end)
+' "$sarif_file" > "${sarif_file}.tmp"
+mv "${sarif_file}.tmp" "$sarif_file"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,28 +39,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up JDK 25
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
-        with:
-          distribution: temurin
-          java-version: '25'
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+      - name: Set up JDK and Gradle
+        uses: ./.github/actions/setup-jdk-gradle
 
       - name: Run build, tests, coverage, and formatting checks
         run: ./gradlew build dokkaGenerate koverXmlReport koverHtmlReport spotlessCheck ktlintCheck --no-daemon
 
       - name: Publish JUnit test report
         if: always()
-        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
+        uses: ./.github/actions/publish-junit-report
         with:
           check_name: Gradle Test Report
           report_paths: modules/*/build/test-results/test/TEST-*.xml
-          require_tests: true
-          fail_on_failure: true
-          fail_on_parse_error: true
-          detailed_summary: true
 
       - name: Upload test results and reports
         if: always()

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,20 +11,10 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
-  gate:
-    name: Heavy CI gate
-    uses: ./.github/workflows/heavy-ci-gate.yml
-    permissions:
-      contents: read
-      pull-requests: read
-
   dependency-review:
     name: Review Dependency Changes
-    needs: gate
-    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,10 +11,20 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  gate:
+    name: Heavy CI gate
+    uses: ./.github/workflows/heavy-ci-gate.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   dependency-review:
     name: Review Dependency Changes
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -58,40 +58,7 @@ jobs:
       - name: Normalize Qodana SARIF regions
         if: always()
         shell: bash
-        run: |
-          set -euo pipefail
-
-          sarif_file="${RUNNER_TEMP}/qodana/results/qodana.sarif.json"
-
-          if [[ ! -f "$sarif_file" ]]; then
-            echo "Qodana SARIF not found at $sarif_file; skipping normalization."
-            exit 0
-          fi
-
-          jq '
-            def normalize_region:
-              if type == "object" then
-                (
-                  if has("startLine") and (.startLine | type == "number") and .startLine < 1 then
-                    .startLine = 1
-                  else
-                    .
-                  end
-                )
-                | (
-                  if has("startColumn") and (.startColumn | type == "number") and .startColumn < 1 then
-                    .startColumn = 1
-                  else
-                    .
-                  end
-                )
-              else
-                .
-              end;
-
-            walk(if type == "object" and has("region") then .region |= normalize_region else . end)
-          ' "$sarif_file" > "${sarif_file}.tmp"
-          mv "${sarif_file}.tmp" "$sarif_file"
+        run: bash .github/scripts/normalize-qodana-sarif.sh
 
       - name: Upload Qodana results to code scanning
         if: always()

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Normalize Qodana SARIF regions
         if: always()
         shell: bash
-        run: bash .github/scripts/normalize-qodana-sarif.sh
+        run: bash .github/scripts/normalize-qodana-sarif.sh "${{ runner.temp }}/qodana/results/qodana.sarif.json"
 
       - name: Upload Qodana results to code scanning
         if: always()

--- a/.github/workflows/vanilla-conformance.yml
+++ b/.github/workflows/vanilla-conformance.yml
@@ -9,6 +9,8 @@ on:
       - 'gradle/vanilla-conformance.gradle'
       - 'buildSrc/**'
       - '.github/workflows/vanilla-conformance.yml'
+      - '.github/actions/setup-jdk-gradle/**'
+      - '.github/actions/publish-junit-report/**'
   schedule:
     - cron: '17 4 * * 1'
   workflow_dispatch:
@@ -33,25 +35,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up JDK 25
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
-        with:
-          distribution: temurin
-          java-version: '25'
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+      - name: Set up JDK and Gradle
+        uses: ./.github/actions/setup-jdk-gradle
 
       - name: Run vanilla conformance suites
         run: ./gradlew :core:vanillaConformanceTest --no-daemon
 
       - name: Publish JUnit test report
         if: always()
-        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
+        uses: ./.github/actions/publish-junit-report
         with:
           check_name: Vanilla Conformance Report
           report_paths: modules/core/build/test-results/vanillaConformanceTest/TEST-*.xml
-          require_tests: true
-          fail_on_failure: true
-          fail_on_parse_error: true
-          detailed_summary: true

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,94 @@
+# Continuous integration
+
+How GitHub Actions is organized for Kotventure, when heavy jobs run, and where shared pieces live.
+
+For local development commands, see [CONTRIBUTING.md](../.github/CONTRIBUTING.md). For release automation, see
+[RELEASING.md](./RELEASING.md). For Minecraft selector conformance, see
+[vanilla-conformance.md](./vanilla-conformance.md).
+
+## Workflow map
+
+| Workflow | Triggers | Purpose |
+|----------|----------|---------|
+| **Build** | PR → `master`, push → `master` | `./gradlew build` (tests, Spotless/ktlint, Kover), Dokka, coverage artifacts |
+| **Qodana** | PR, push `master`, weekly schedule, `workflow_dispatch` | Static analysis + SARIF to code scanning |
+| **Vanilla Conformance** | Path-filtered PRs, weekly schedule, `workflow_dispatch` | MC-backed selector tests |
+| **Dependency Security Review** | PR → `master` | `dependency-review-action` on dependency changes |
+| **Conventional Titles** | `pull_request_target`, push `master` | PR title + commit subjects (`verb(area): …`) |
+| **Labeler** | `pull_request_target` | Path → `area:*` labels |
+| **Release Please** | push `master` | Opens/updates release PRs; tags/releases after merge |
+| **OpenSSF Scorecard** | push `master`, schedule, `workflow_dispatch` | Supply-chain scorecard + SARIF |
+| **Heavy CI gate** | `workflow_call` only | Shared skip logic for pure release-please PRs |
+
+## Heavy CI gate
+
+Reusable workflow: [`.github/workflows/heavy-ci-gate.yml`](../.github/workflows/heavy-ci-gate.yml).
+
+**Used by:** Build, Qodana, Dependency Security Review.
+
+### When heavy CI is skipped
+
+All of the following:
+
+1. Event is a `pull_request`, and
+2. Head branch starts with `release-please--`, and
+3. The PR changes **only** these files (allow-list):
+   - `CHANGELOG.md`
+   - `.release-please-manifest.json`
+   - `gradle/libs.versions.toml`
+
+That set matches what release-please is configured to touch (`release-please-config.json` + the manifest).
+
+### When heavy CI still runs on a release-please branch
+
+If the PR includes **any other path** (manual commits that fix code, workflows, docs outside the allow-list, etc.), the
+gate sets `run=true` and Build / Qodana / Dependency Review execute as usual.
+
+**Not gated:** Conventional Titles, Labeler (cheap and useful on release PRs), Vanilla Conformance (path-filtered;
+release-please PRs do not match those paths).
+
+### Keeping the allow-list in sync
+
+If you add `extra-files` (or otherwise expand what release-please edits), update the allow-list in
+`heavy-ci-gate.yml` **in the same PR** as the config change.
+
+Author-based “is this a bot?” detection is intentionally **not** used: release-please may attribute commits to a human
+token.
+
+## Local composite actions
+
+| Action | Path | Used by |
+|--------|------|---------|
+| **setup-jdk-gradle** | [`.github/actions/setup-jdk-gradle`](../.github/actions/setup-jdk-gradle/action.yml) | Build, Vanilla Conformance |
+| **publish-junit-report** | [`.github/actions/publish-junit-report`](../.github/actions/publish-junit-report/action.yml) | Build, Vanilla Conformance |
+
+- **Checkout stays explicit** in each workflow (Qodana needs a custom `ref` and full history; Build uses `fetch-depth: 0`;
+  Vanilla uses the default depth).
+- Prefer these composites when adding another Gradle-backed job so JDK/Gradle and JUnit report pins stay centralized.
+
+## Scripts
+
+| Script | Role |
+|--------|------|
+| [`.github/scripts/validate-conventional-title.sh`](../.github/scripts/validate-conventional-title.sh) | Title/commit subject format |
+| [`.github/scripts/normalize-qodana-sarif.sh`](../.github/scripts/normalize-qodana-sarif.sh) | Fix 0-based SARIF regions for GitHub code scanning |
+
+## Action pins and Dependabot
+
+Third-party actions are **SHA-pinned** with a version comment (e.g. `# v7.0.0`). Dependabot’s `github-actions` ecosystem
+opens weekly grouped PRs for minor/patch bumps (see [`.github/dependabot.yml`](../.github/dependabot.yml)).
+
+Shared pins for Temurin, setup-gradle, and the JUnit report action live in the composite actions above — bump them there
+when Dependabot (or a maintainer) updates those versions.
+
+## Re-running CI
+
+- Use **Re-run failed jobs** / **Re-run all jobs** on the Actions run for the PR or push.
+- Build does not currently expose `workflow_dispatch` (empty commits still work if you need a fresh push run).
+- Qodana and Vanilla Conformance support `workflow_dispatch` for manual runs.
+
+## Related docs
+
+- [RELEASING.md](./RELEASING.md) — release-please token, version policy, branch protection notes
+- [vanilla-conformance.md](./vanilla-conformance.md) — local and CI conformance runs
+- [DESIGN.md](./DESIGN.md) — product architecture (not CI wiring)

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -3,7 +3,7 @@
 How GitHub Actions is organized for Kotventure, when heavy jobs run, and where shared pieces live.
 
 For local development commands, see [CONTRIBUTING.md](../.github/CONTRIBUTING.md). For release automation, see
-[RELEASING.md](./RELEASING.md). For Minecraft selector conformance, see
+[RELEASING.md](./RELEASING.md). For Minecraft vanilla conformance, see
 [vanilla-conformance.md](./vanilla-conformance.md).
 
 ## Workflow map
@@ -11,20 +11,23 @@ For local development commands, see [CONTRIBUTING.md](../.github/CONTRIBUTING.md
 | Workflow | Triggers | Purpose |
 |----------|----------|---------|
 | **Build** | PR → `master`, push → `master` | `./gradlew build` (tests, Spotless/ktlint, Kover), Dokka, coverage artifacts |
-| **Qodana** | PR, push `master`, weekly schedule, `workflow_dispatch` | Static analysis + SARIF to code scanning |
+| **Qodana** | PR → `master`, push `master`, weekly schedule, `workflow_dispatch` | Static analysis + SARIF to code scanning |
 | **Vanilla Conformance** | Path-filtered PRs, weekly schedule, `workflow_dispatch` | MC-backed selector tests |
-| **Dependency Security Review** | PR → `master` | `dependency-review-action` on dependency changes |
+| **Dependency Security Review** | PR → `master` | `dependency-review-action` on every PR (manifest-focused analysis) |
 | **Conventional Titles** | `pull_request_target`, push `master` | PR title + commit subjects (`verb(area): …`) |
 | **Labeler** | `pull_request_target` | Path → `area:*` labels |
 | **Release Please** | push `master` | Opens/updates release PRs; tags/releases after merge |
-| **OpenSSF Scorecard** | push `master`, schedule, `workflow_dispatch` | Supply-chain scorecard + SARIF |
+| **OpenSSF Scorecard** | push `master`, schedule, `branch_protection_rule`, `workflow_dispatch` | Supply-chain scorecard + SARIF |
 | **Heavy CI gate** | `workflow_call` only | Shared skip logic for pure release-please PRs |
 
 ## Heavy CI gate
 
 Reusable workflow: [`.github/workflows/heavy-ci-gate.yml`](../.github/workflows/heavy-ci-gate.yml).
 
-**Used by:** Build, Qodana, Dependency Security Review.
+**Used by:** Build, Qodana.
+
+Dependency Security Review is **not** gated: it is cheap and should still run when release-please touches
+`gradle/libs.versions.toml` (even for a project-version bump, the full file is on the allow-list).
 
 ### When heavy CI is skipped
 
@@ -42,10 +45,10 @@ That set matches what release-please is configured to touch (`release-please-con
 ### When heavy CI still runs on a release-please branch
 
 If the PR includes **any other path** (manual commits that fix code, workflows, docs outside the allow-list, etc.), the
-gate sets `run=true` and Build / Qodana / Dependency Review execute as usual.
+gate sets `run=true` and Build / Qodana execute as usual.
 
-**Not gated:** Conventional Titles, Labeler (cheap and useful on release PRs), Vanilla Conformance (path-filtered;
-release-please PRs do not match those paths).
+**Not gated:** Dependency Security Review, Conventional Titles, Labeler (cheap and useful on release PRs), Vanilla
+Conformance (path-filtered; release-please PRs do not match those paths).
 
 ### Keeping the allow-list in sync
 
@@ -78,8 +81,14 @@ token.
 Third-party actions are **SHA-pinned** with a version comment (e.g. `# v7.0.0`). Dependabot’s `github-actions` ecosystem
 opens weekly grouped PRs for minor/patch bumps (see [`.github/dependabot.yml`](../.github/dependabot.yml)).
 
-Shared pins for Temurin, setup-gradle, and the JUnit report action live in the composite actions above — bump them there
-when Dependabot (or a maintainer) updates those versions.
+Dependabot only scans `github-actions` entries for the directories listed in that file. Root `directory: "/"` covers
+workflows; **composite pins** are covered by separate entries for:
+
+- `/.github/actions/setup-jdk-gradle`
+- `/.github/actions/publish-junit-report`
+
+When adding a new composite that `uses:` third-party actions, add a matching Dependabot directory so pins stay
+auto-updatable.
 
 ## Re-running CI
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -37,9 +37,9 @@ as human-authored PRs. If the repository falls back to `GITHUB_TOKEN`, release-p
 will
 suppress workflows triggered by that token's PR, tag, and release events.
 
-**Heavy CI on pure Release PRs:** Build, Qodana, and Dependency Review are skipped when the Release PR only changes
-the release-please allow-listed files (changelog, manifest, project version). Conventional Titles and Labeler still run.
-Manual commits that touch other paths re-enable heavy CI. See [CI.md](./CI.md).
+**Heavy CI on pure Release PRs:** Build and Qodana are skipped when the Release PR only changes the release-please
+allow-listed files (changelog, manifest, project version in `gradle/libs.versions.toml`). Dependency Review, Conventional
+Titles, and Labeler still run. Manual commits that touch other paths re-enable Build/Qodana. See [CI.md](./CI.md).
 
 ## Publishing Coordination
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -37,6 +37,10 @@ as human-authored PRs. If the repository falls back to `GITHUB_TOKEN`, release-p
 will
 suppress workflows triggered by that token's PR, tag, and release events.
 
+**Heavy CI on pure Release PRs:** Build, Qodana, and Dependency Review are skipped when the Release PR only changes
+the release-please allow-listed files (changelog, manifest, project version). Conventional Titles and Labeler still run.
+Manual commits that touch other paths re-enable heavy CI. See [CI.md](./CI.md).
+
 ## Publishing Coordination
 
 This workflow creates GitHub Releases and tags only. Maven Central publishing remains explicit and is tracked separately


### PR DESCRIPTION
## Summary

Implements **CI-R1–R6**:

| ID | Change |
|----|--------|
| **R1** | Local composite `.github/actions/setup-jdk-gradle` (JDK + Gradle only; checkout stays explicit) |
| **R2** | Local composite `.github/actions/publish-junit-report` |
| **R3** | `.github/scripts/normalize-qodana-sarif.sh` replaces inline jq in Qodana |
| **R4** | Shared pins concentrated in composites; Dependabot guidance in `docs/CI.md` |
| **R5** | Dependency Review uses `heavy-ci-gate` (same as Build/Qodana after #250) |
| **R6** | New [`docs/CI.md`](docs/CI.md) + links from CONTRIBUTING and RELEASING |

Vanilla path filters also include the new composite paths so composite-only edits re-run conformance.

## Type of change

- [x] chore / build / ci
- [x] docs

## Testing

- `bash -n .github/scripts/normalize-qodana-sarif.sh`
- Smoke-tested SARIF normalize: `startLine`/`startColumn` `0` → `1`; missing file exits 0
- PR CI: Build, Dependency Review, Qodana (and Titles/Labeler)

## Checklist

- [x] Title and commit subjects follow `verb(area): something`
- [x] No product Kotlin changes
- [x] Docs updated (`docs/CI.md`, CONTRIBUTING, RELEASING)