### PR TITLE
ci(build): enable configuration cache and speed up CI Gradle

### DIFF
--- a/.github/scripts/vanilla-fixture-cache-key.sh
+++ b/.github/scripts/vanilla-fixture-cache-key.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Reads MC version + server bundle SHA-1 from gradle/vanilla-conformance.gradle and prints
+# GitHub Actions outputs: version, sha1, key.
+set -euo pipefail
+
+pins_file="${1:-gradle/vanilla-conformance.gradle}"
+if [[ ! -f "$pins_file" ]]; then
+  echo "Missing fixture pins file: $pins_file" >&2
+  exit 1
+fi
+
+version="$(sed -n "s/^final String targetMinecraftVersion = '\\([^']*\\)'$/\\1/p" "$pins_file")"
+sha1="$(sed -n "s/^final String serverBundleSha1 = '\\([^']*\\)'$/\\1/p" "$pins_file")"
+
+if [[ -z "$version" || -z "$sha1" ]]; then
+  echo "Could not parse targetMinecraftVersion / serverBundleSha1 from $pins_file" >&2
+  exit 1
+fi
+if [[ ! "$sha1" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "serverBundleSha1 is not a 40-char hex SHA-1: $sha1" >&2
+  exit 1
+fi
+
+{
+  echo "version=$version"
+  echo "sha1=$sha1"
+  echo "key=vanilla-mc-${version}-${sha1}"
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         uses: ./.github/actions/setup-jdk-gradle
 
       - name: Run build, tests, coverage, and formatting checks
-        run: ./gradlew build dokkaGenerate koverXmlReport koverHtmlReport spotlessCheck ktlintCheck --no-daemon
+        run: ./gradlew build dokkaGenerate koverXmlReport koverHtmlReport spotlessCheck ktlintCheck
 
       - name: Publish JUnit test report
         if: always()

--- a/.github/workflows/vanilla-conformance.yml
+++ b/.github/workflows/vanilla-conformance.yml
@@ -8,6 +8,7 @@ on:
       - 'modules/core/**'
       - 'gradle/vanilla-conformance.gradle'
       - 'buildSrc/**'
+      - '.github/scripts/vanilla-fixture-cache-key.sh'
       - '.github/workflows/vanilla-conformance.yml'
       - '.github/actions/setup-jdk-gradle/**'
       - '.github/actions/publish-junit-report/**'
@@ -40,23 +41,7 @@ jobs:
 
       - name: Resolve Minecraft fixture cache key
         id: fixture
-        run: |
-          set -euo pipefail
-          version="$(sed -n "s/^final String targetMinecraftVersion = '\\([^']*\\)'$/\\1/p" gradle/vanilla-conformance.gradle)"
-          sha1="$(sed -n "s/^final String serverBundleSha1 = '\\([^']*\\)'$/\\1/p" gradle/vanilla-conformance.gradle)"
-          if [[ -z "$version" || -z "$sha1" ]]; then
-            echo "Could not parse targetMinecraftVersion / serverBundleSha1 from gradle/vanilla-conformance.gradle" >&2
-            exit 1
-          fi
-          if [[ ! "$sha1" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "serverBundleSha1 is not a 40-char hex SHA-1: $sha1" >&2
-            exit 1
-          fi
-          {
-            echo "version=$version"
-            echo "sha1=$sha1"
-            echo "key=vanilla-mc-${version}-${sha1}"
-          } >> "$GITHUB_OUTPUT"
+        run: .github/scripts/vanilla-fixture-cache-key.sh >> "$GITHUB_OUTPUT"
 
       - name: Cache Minecraft conformance fixtures
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/vanilla-conformance.yml
+++ b/.github/workflows/vanilla-conformance.yml
@@ -38,11 +38,49 @@ jobs:
       - name: Set up JDK and Gradle
         uses: ./.github/actions/setup-jdk-gradle
 
+      - name: Resolve Minecraft fixture cache key
+        id: fixture
+        run: |
+          set -euo pipefail
+          version="$(sed -n "s/^final String targetMinecraftVersion = '\\([^']*\\)'$/\\1/p" gradle/vanilla-conformance.gradle)"
+          sha1="$(sed -n "s/^final String serverBundleSha1 = '\\([^']*\\)'$/\\1/p" gradle/vanilla-conformance.gradle)"
+          if [[ -z "$version" || -z "$sha1" ]]; then
+            echo "Could not parse targetMinecraftVersion / serverBundleSha1 from gradle/vanilla-conformance.gradle" >&2
+            exit 1
+          fi
+          if [[ ! "$sha1" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "serverBundleSha1 is not a 40-char hex SHA-1: $sha1" >&2
+            exit 1
+          fi
+          {
+            echo "version=$version"
+            echo "sha1=$sha1"
+            echo "key=vanilla-mc-${version}-${sha1}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Cache Minecraft conformance fixtures
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: modules/core/build/vanilla-conformance
-          key: vanilla-mc-26.2-823e2250d24b3ddac457a60c92a6a941943fcd6a
+          key: ${{ steps.fixture.outputs.key }}
+
+      - name: Verify restored fixture checksum
+        run: |
+          set -euo pipefail
+          version="${{ steps.fixture.outputs.version }}"
+          expected="${{ steps.fixture.outputs.sha1 }}"
+          bundle="modules/core/build/vanilla-conformance/${version}/server-${version}-bundle.jar"
+          if [[ ! -f "$bundle" ]]; then
+            echo "No cached server bundle at $bundle; Gradle will download and verify."
+            exit 0
+          fi
+          actual="$(shasum -a 1 "$bundle" | awk '{ print $1 }')"
+          if [[ "$actual" != "$expected" ]]; then
+            echo "Cached fixture SHA-1 mismatch (expected $expected, got $actual); removing corrupted cache entry."
+            rm -f "$bundle"
+            exit 0
+          fi
+          echo "Cached fixture SHA-1 matches $expected."
 
       - name: Run vanilla conformance suites
         run: ./gradlew :core:vanillaConformanceTest

--- a/.github/workflows/vanilla-conformance.yml
+++ b/.github/workflows/vanilla-conformance.yml
@@ -38,8 +38,14 @@ jobs:
       - name: Set up JDK and Gradle
         uses: ./.github/actions/setup-jdk-gradle
 
+      - name: Cache Minecraft conformance fixtures
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: modules/core/build/vanilla-conformance
+          key: vanilla-mc-26.2-823e2250d24b3ddac457a60c92a6a941943fcd6a
+
       - name: Run vanilla conformance suites
-        run: ./gradlew :core:vanillaConformanceTest --no-daemon
+        run: ./gradlew :core:vanillaConformanceTest
 
       - name: Publish JUnit test report
         if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ plugins {
 group = 'io.github.lmliam.kotventure'
 version = libs.versions.project.get()
 
+// Root needs repositories for aggregated Kover agent/report resolution (CI runs
+// koverXmlReport / koverHtmlReport on the root project).
+apply from: rootProject.file('gradle/repositories.gradle')
+
 subprojects {
     group = rootProject.group
     version = rootProject.version

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -106,11 +106,11 @@ New composites that pin third-party actions need a matching Dependabot directory
 
 | Mechanism | Where |
 |-----------|--------|
-| Configuration cache + build cache | `gradle.properties` (`org.gradle.configuration-cache`, `org.gradle.caching`) |
-| Dependency / wrapper caches | `setup-gradle` via `.github/actions/setup-jdk-gradle` |
-| Minecraft conformance fixtures | `actions/cache` on `modules/core/build/vanilla-conformance` (key = MC version + SHA-1 from `gradle/vanilla-conformance.gradle`) |
+| Configuration cache + local build cache | `gradle.properties` (`org.gradle.configuration-cache`, `org.gradle.caching`); CI restores Gradle caches via `setup-gradle` in `.github/actions/setup-jdk-gradle` |
+| Dependency / wrapper caches | `setup-gradle` defaults in `.github/actions/setup-jdk-gradle` |
+| Minecraft conformance fixtures | `actions/cache` on `modules/core/build/vanilla-conformance`; cache key is derived at runtime from `targetMinecraftVersion` and `serverBundleSha1` in `gradle/vanilla-conformance.gradle`. Restored bundles are SHA-1 re-checked before Gradle runs. |
 
-The Gradle Build job checks out full git history so Spotless `ratchetFrom 'origin/master'` works.
+The Gradle Build job checks out full git history so Spotless `ratchetFrom 'origin/master'` works. Job splits and remote build cache stay deferred until wall-clock needs them.
 
 ## Re-running CI
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -102,6 +102,16 @@ Third-party actions are SHA-pinned with a version comment. Dependabot updates (`
 
 New composites that pin third-party actions need a matching Dependabot directory.
 
+## Performance
+
+| Mechanism | Where |
+|-----------|--------|
+| Configuration cache + build cache | `gradle.properties` (`org.gradle.configuration-cache`, `org.gradle.caching`) |
+| Dependency / wrapper caches | `setup-gradle` via `.github/actions/setup-jdk-gradle` |
+| Minecraft conformance fixtures | `actions/cache` on `modules/core/build/vanilla-conformance` (key = MC version + SHA-1 from `gradle/vanilla-conformance.gradle`) |
+
+The Gradle Build job checks out full git history so Spotless `ratchetFrom 'origin/master'` works.
+
 ## Re-running CI
 
 - **Re-run failed jobs** / **Re-run all jobs** on an Actions run.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,6 @@ kotlin.code.style=official
 # Build performance (safe defaults; behaviour-neutral).
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 # Dokka V2 plugin API.
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 apply plugin: 'maven-publish'
 
 def jitpackBuild = System.getenv('JITPACK') == 'true'
@@ -20,13 +22,6 @@ def moduleDescription = objects.property(String)
 def publicationArtifactId = "kotventure-${moduleName}"
 def repositoryUrl = 'https://github.com/LMLiam/Kotventure'
 
-def actualGroupId = objects.property(String)
-def actualArtifactId = objects.property(String)
-def actualVersion = objects.property(String)
-def actualPomName = objects.property(String)
-def actualPomDescription = objects.property(String)
-def actualPomUrl = objects.property(String)
-
 afterEvaluate {
     if (project.description != null) {
         moduleDescription.set(project.description)
@@ -40,14 +35,6 @@ afterEvaluate {
             throw new GradleException("${modulePath} must apply java or java-platform to publish Maven metadata.")
         }
     }
-
-    def publication = publishing.publications.getByName('maven')
-    actualGroupId.set(publication.groupId)
-    actualArtifactId.set(publication.artifactId)
-    actualVersion.set(publication.version)
-    actualPomName.set(publication.pom.name.getOrNull() ?: '')
-    actualPomDescription.set(publication.pom.description.getOrNull() ?: '')
-    actualPomUrl.set(publication.pom.url.getOrNull() ?: '')
 }
 
 publishing {
@@ -66,9 +53,10 @@ publishing {
     }
 }
 
+// Configuration-cache safe: verify the generated POM file, not a snapshot of the Publication object.
 tasks.register('verifyMavenPublicationMetadata') {
     group = 'verification'
-    description = 'Verifies the Maven publication coordinates and POM metadata.'
+    description = 'Verifies the generated Maven POM coordinates and metadata.'
 
     def expectedGroup = publicationGroup
     def expectedArtifactId = publicationArtifactId
@@ -76,42 +64,53 @@ tasks.register('verifyMavenPublicationMetadata') {
     def expectedName = moduleName
     def expectedUrl = repositoryUrl
     def expectedDescription = moduleDescription
+    def pomFile = layout.buildDirectory.file('publications/maven/pom-default.xml')
 
+    dependsOn tasks.named('generatePomFileForMavenPublication')
     inputs.property('expectedGroup', expectedGroup)
     inputs.property('expectedArtifactId', expectedArtifactId)
     inputs.property('expectedVersion', expectedVersion)
     inputs.property('expectedName', expectedName)
     inputs.property('expectedUrl', expectedUrl)
     inputs.property('expectedDescription', expectedDescription)
-    inputs.property('actualGroupId', actualGroupId)
-    inputs.property('actualArtifactId', actualArtifactId)
-    inputs.property('actualVersion', actualVersion)
-    inputs.property('actualPomName', actualPomName)
-    inputs.property('actualPomDescription', actualPomDescription)
-    inputs.property('actualPomUrl', actualPomUrl)
+    inputs.file(pomFile)
 
     doLast {
-        if (actualGroupId.get() != expectedGroup) {
-            throw new GradleException("${modulePath} publishes group '${actualGroupId.get()}', expected '${expectedGroup}'.")
-        }
-        if (actualArtifactId.get() != expectedArtifactId) {
-            throw new GradleException("${modulePath} publishes artifact '${actualArtifactId.get()}', expected '${expectedArtifactId}'.")
-        }
-        if (actualVersion.get() != expectedVersion) {
-            throw new GradleException("${modulePath} publishes version '${actualVersion.get()}', expected '${expectedVersion}'.")
-        }
-        if (actualPomName.get() != expectedName) {
-            throw new GradleException("${modulePath} POM name must be '${expectedName}'.")
-        }
         def descriptionValue = expectedDescription.getOrNull()
         if (descriptionValue == null || descriptionValue.isBlank()) {
             throw new GradleException("${modulePath} must define a project description for publication.")
         }
-        if (actualPomDescription.get() != descriptionValue) {
+
+        def pomPath = pomFile.get().asFile
+        if (!pomPath.isFile()) {
+            throw new GradleException("${modulePath} missing generated POM at ${pomPath}.")
+        }
+
+        def pom = new XmlSlurper().parse(pomPath)
+        def actualGroup = pom.groupId.text()
+        def actualArtifact = pom.artifactId.text()
+        def actualVersion = pom.version.text()
+        def actualName = pom.name.text()
+        def actualDescription = pom.description.text()
+        def actualUrl = pom.url.text()
+
+        if (actualGroup != expectedGroup) {
+            throw new GradleException("${modulePath} POM groupId is '${actualGroup}', expected '${expectedGroup}'.")
+        }
+        if (actualArtifact != expectedArtifactId) {
+            throw new GradleException("${modulePath} POM artifactId is '${actualArtifact}', expected '${expectedArtifactId}'.")
+        }
+        if (actualVersion != expectedVersion) {
+            throw new GradleException("${modulePath} POM version is '${actualVersion}', expected '${expectedVersion}'.")
+        }
+        if (actualName != expectedName) {
+            throw new GradleException("${modulePath} POM name is '${actualName}', expected '${expectedName}'.")
+        }
+        if (actualDescription != descriptionValue) {
             throw new GradleException("${modulePath} POM description must match the project description.")
         }
-        if (actualPomUrl.get() != expectedUrl) {
-            throw new GradleException("${modulePath} POM URL must be '${expectedUrl}'.")
+        if (actualUrl != expectedUrl) {
+            throw new GradleException("${modulePath} POM URL is '${actualUrl}', expected '${expectedUrl}'.")
         }
     }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -2,9 +2,9 @@ import groovy.xml.XmlSlurper
 
 apply plugin: 'maven-publish'
 
-def jitpackBuild = System.getenv('JITPACK') == 'true'
+def jitpackBuild = providers.environmentVariable('JITPACK').orNull == 'true'
 def jitpackEnvironmentValue = { String name ->
-    def value = System.getenv(name)
+    def value = providers.environmentVariable(name).orNull
     if (value == null || value.isBlank()) {
         throw new GradleException("JitPack publication requires the ${name} environment variable.")
     }
@@ -18,23 +18,16 @@ def publicationVersion = jitpackBuild
         : rootProject.version.toString()
 def moduleName = project.name
 def modulePath = project.path
-def moduleDescription = objects.property(String)
 def publicationArtifactId = "kotventure-${moduleName}"
 def repositoryUrl = 'https://github.com/LMLiam/Kotventure'
 
-afterEvaluate {
-    if (project.description != null) {
-        moduleDescription.set(project.description)
+// Lazy: module build scripts set `description` after root `subprojects {}` applies this script.
+def publicationDescription = providers.provider {
+    def value = project.description?.toString()?.trim()
+    if (!value) {
+        throw new GradleException("${modulePath} must define a project description for publication.")
     }
-    publishing.publications.named('maven') {
-        if (pluginManager.hasPlugin('java-platform')) {
-            from components.javaPlatform
-        } else if (pluginManager.hasPlugin('java')) {
-            from components.java
-        } else {
-            throw new GradleException("${modulePath} must apply java or java-platform to publish Maven metadata.")
-        }
-    }
+    value
 }
 
 publishing {
@@ -46,14 +39,25 @@ publishing {
 
             pom {
                 name = moduleName
-                description.set(moduleDescription)
+                description = publicationDescription
                 url = repositoryUrl
             }
         }
     }
 }
 
-// Configuration-cache safe: verify the generated POM file, not a snapshot of the Publication object.
+// Wire the software component when the matching plugin is applied (no afterEvaluate).
+pluginManager.withPlugin('java') {
+    publishing.publications.named('maven') {
+        from components.java
+    }
+}
+pluginManager.withPlugin('java-platform') {
+    publishing.publications.named('maven') {
+        from components.javaPlatform
+    }
+}
+
 tasks.register('verifyMavenPublicationMetadata') {
     group = 'verification'
     description = 'Verifies the generated Maven POM coordinates and metadata.'
@@ -62,8 +66,9 @@ tasks.register('verifyMavenPublicationMetadata') {
     def expectedArtifactId = publicationArtifactId
     def expectedVersion = publicationVersion
     def expectedName = moduleName
+    def expectedDescription = publicationDescription
     def expectedUrl = repositoryUrl
-    def expectedDescription = moduleDescription
+    def pathLabel = modulePath
     def pomFile = layout.buildDirectory.file('publications/maven/pom-default.xml')
 
     dependsOn tasks.named('generatePomFileForMavenPublication')
@@ -71,46 +76,30 @@ tasks.register('verifyMavenPublicationMetadata') {
     inputs.property('expectedArtifactId', expectedArtifactId)
     inputs.property('expectedVersion', expectedVersion)
     inputs.property('expectedName', expectedName)
-    inputs.property('expectedUrl', expectedUrl)
     inputs.property('expectedDescription', expectedDescription)
+    inputs.property('expectedUrl', expectedUrl)
     inputs.file(pomFile)
 
     doLast {
-        def descriptionValue = expectedDescription.getOrNull()
-        if (descriptionValue == null || descriptionValue.isBlank()) {
-            throw new GradleException("${modulePath} must define a project description for publication.")
-        }
-
         def pomPath = pomFile.get().asFile
         if (!pomPath.isFile()) {
-            throw new GradleException("${modulePath} missing generated POM at ${pomPath}.")
+            throw new GradleException("${pathLabel} missing generated POM at ${pomPath}.")
         }
 
         def pom = new XmlSlurper().parse(pomPath)
-        def actualGroup = pom.groupId.text()
-        def actualArtifact = pom.artifactId.text()
-        def actualVersion = pom.version.text()
-        def actualName = pom.name.text()
-        def actualDescription = pom.description.text()
-        def actualUrl = pom.url.text()
-
-        if (actualGroup != expectedGroup) {
-            throw new GradleException("${modulePath} POM groupId is '${actualGroup}', expected '${expectedGroup}'.")
-        }
-        if (actualArtifact != expectedArtifactId) {
-            throw new GradleException("${modulePath} POM artifactId is '${actualArtifact}', expected '${expectedArtifactId}'.")
-        }
-        if (actualVersion != expectedVersion) {
-            throw new GradleException("${modulePath} POM version is '${actualVersion}', expected '${expectedVersion}'.")
-        }
-        if (actualName != expectedName) {
-            throw new GradleException("${modulePath} POM name is '${actualName}', expected '${expectedName}'.")
-        }
-        if (actualDescription != descriptionValue) {
-            throw new GradleException("${modulePath} POM description must match the project description.")
-        }
-        if (actualUrl != expectedUrl) {
-            throw new GradleException("${modulePath} POM URL is '${actualUrl}', expected '${expectedUrl}'.")
+        def expectedByField = [
+                groupId    : expectedGroup,
+                artifactId : expectedArtifactId,
+                version    : expectedVersion,
+                name       : expectedName,
+                description: expectedDescription.get(),
+                url        : expectedUrl,
+        ]
+        expectedByField.each { field, expected ->
+            def actual = pom."$field".text()
+            if (actual != expected) {
+                throw new GradleException("${pathLabel} POM ${field} is '${actual}', expected '${expected}'.")
+            }
         }
     }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -20,6 +20,13 @@ def moduleDescription = objects.property(String)
 def publicationArtifactId = "kotventure-${moduleName}"
 def repositoryUrl = 'https://github.com/LMLiam/Kotventure'
 
+def actualGroupId = objects.property(String)
+def actualArtifactId = objects.property(String)
+def actualVersion = objects.property(String)
+def actualPomName = objects.property(String)
+def actualPomDescription = objects.property(String)
+def actualPomUrl = objects.property(String)
+
 afterEvaluate {
     if (project.description != null) {
         moduleDescription.set(project.description)
@@ -33,6 +40,14 @@ afterEvaluate {
             throw new GradleException("${modulePath} must apply java or java-platform to publish Maven metadata.")
         }
     }
+
+    def publication = publishing.publications.getByName('maven')
+    actualGroupId.set(publication.groupId)
+    actualArtifactId.set(publication.artifactId)
+    actualVersion.set(publication.version)
+    actualPomName.set(publication.pom.name.getOrNull() ?: '')
+    actualPomDescription.set(publication.pom.description.getOrNull() ?: '')
+    actualPomUrl.set(publication.pom.url.getOrNull() ?: '')
 }
 
 publishing {
@@ -55,32 +70,48 @@ tasks.register('verifyMavenPublicationMetadata') {
     group = 'verification'
     description = 'Verifies the Maven publication coordinates and POM metadata.'
 
+    def expectedGroup = publicationGroup
+    def expectedArtifactId = publicationArtifactId
+    def expectedVersion = publicationVersion
+    def expectedName = moduleName
+    def expectedUrl = repositoryUrl
+    def expectedDescription = moduleDescription
+
+    inputs.property('expectedGroup', expectedGroup)
+    inputs.property('expectedArtifactId', expectedArtifactId)
+    inputs.property('expectedVersion', expectedVersion)
+    inputs.property('expectedName', expectedName)
+    inputs.property('expectedUrl', expectedUrl)
+    inputs.property('expectedDescription', expectedDescription)
+    inputs.property('actualGroupId', actualGroupId)
+    inputs.property('actualArtifactId', actualArtifactId)
+    inputs.property('actualVersion', actualVersion)
+    inputs.property('actualPomName', actualPomName)
+    inputs.property('actualPomDescription', actualPomDescription)
+    inputs.property('actualPomUrl', actualPomUrl)
+
     doLast {
-        def publication = publishing.publications.findByName('maven')
-        if (publication == null) {
-            throw new GradleException("${modulePath} does not define a Maven publication named 'maven'.")
+        if (actualGroupId.get() != expectedGroup) {
+            throw new GradleException("${modulePath} publishes group '${actualGroupId.get()}', expected '${expectedGroup}'.")
         }
-        if (publication.groupId != publicationGroup) {
-            throw new GradleException("${modulePath} publishes group '${publication.groupId}', expected '${publicationGroup}'.")
+        if (actualArtifactId.get() != expectedArtifactId) {
+            throw new GradleException("${modulePath} publishes artifact '${actualArtifactId.get()}', expected '${expectedArtifactId}'.")
         }
-        if (publication.artifactId != publicationArtifactId) {
-            throw new GradleException("${modulePath} publishes artifact '${publication.artifactId}', expected '${publicationArtifactId}'.")
+        if (actualVersion.get() != expectedVersion) {
+            throw new GradleException("${modulePath} publishes version '${actualVersion.get()}', expected '${expectedVersion}'.")
         }
-        if (publication.version != publicationVersion) {
-            throw new GradleException("${modulePath} publishes version '${publication.version}', expected '${publicationVersion}'.")
+        if (actualPomName.get() != expectedName) {
+            throw new GradleException("${modulePath} POM name must be '${expectedName}'.")
         }
-        if (publication.pom.name.getOrNull() != moduleName) {
-            throw new GradleException("${modulePath} POM name must be '${moduleName}'.")
-        }
-        def expectedDescription = moduleDescription.getOrNull()
-        if (expectedDescription == null || expectedDescription.isBlank()) {
+        def descriptionValue = expectedDescription.getOrNull()
+        if (descriptionValue == null || descriptionValue.isBlank()) {
             throw new GradleException("${modulePath} must define a project description for publication.")
         }
-        if (publication.pom.description.getOrNull() != expectedDescription) {
+        if (actualPomDescription.get() != descriptionValue) {
             throw new GradleException("${modulePath} POM description must match the project description.")
         }
-        if (publication.pom.url.getOrNull() != repositoryUrl) {
-            throw new GradleException("${modulePath} POM URL must be '${repositoryUrl}'.")
+        if (actualPomUrl.get() != expectedUrl) {
+            throw new GradleException("${modulePath} POM URL must be '${expectedUrl}'.")
         }
     }
 }

--- a/gradle/tasks/bom-consumer.gradle
+++ b/gradle/tasks/bom-consumer.gradle
@@ -59,20 +59,26 @@ dependencies {
     }
 }
 
-def bomConsumerVerificationFiles = configurations.bomConsumerVerification
+def bomPublishTasks = bomConsumerModules.collect { moduleName ->
+    ":${moduleName}:publishMavenPublicationToBomConsumerLocalRepository"
+} + [':bom:publishMavenPublicationToBomConsumerLocalRepository']
+
+// FileCollection only — do not capture Configuration in the task for configuration-cache serialization.
+def bomConsumerResolvedFiles = objects.fileCollection()
+bomConsumerResolvedFiles.builtBy(bomPublishTasks)
+bomConsumerResolvedFiles.from(configurations.bomConsumerVerification)
 
 tasks.register('verifyBomConsumerVersionlessDependencies') {
     group = 'verification'
     description = 'Verifies that a consumer importing kotventure-bom can omit per-artifact versions.'
 
-    bomConsumerModules.each { moduleName ->
-        dependsOn ":${moduleName}:publishMavenPublicationToBomConsumerLocalRepository"
+    bomPublishTasks.each { taskPath ->
+        dependsOn taskPath
     }
-    dependsOn ':bom:publishMavenPublicationToBomConsumerLocalRepository'
 
-    def expectedVersion = bomConsumerVersion
-    def expectedArtifacts = bomConsumerArtifacts
-    def resolvedFiles = bomConsumerVerificationFiles
+    def expectedVersion = bomConsumerVersion.toString()
+    def expectedArtifacts = bomConsumerArtifacts.collect { it.toString() }
+    def resolvedFiles = bomConsumerResolvedFiles
 
     inputs.property('expectedVersion', expectedVersion)
     inputs.property('expectedArtifacts', expectedArtifacts)

--- a/gradle/tasks/bom-consumer.gradle
+++ b/gradle/tasks/bom-consumer.gradle
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 def bomConsumerModules = [
         'core',
         'minimessage',
@@ -10,12 +12,6 @@ def bomConsumerArtifacts = bomConsumerModules.collect { moduleName ->
 }
 def bomConsumerRepositoryDir = rootProject.layout.buildDirectory.dir('bom-consumer-m2')
 
-repositories {
-    maven {
-        url = bomConsumerRepositoryDir
-    }
-    mavenCentral()
-}
 def jitpackBuild = providers.environmentVariable('JITPACK').orNull == 'true'
 def jitpackEnvironmentValue = { String name ->
     def value = providers.environmentVariable(name).orNull
@@ -44,57 +40,83 @@ subprojects { subproject ->
     }
 }
 
-configurations {
-    bomConsumerVerification {
-        canBeConsumed = false
-        canBeResolved = true
-        description = 'Resolves Kotventure modules through the published BOM without per-artifact versions.'
-    }
-}
-
-dependencies {
-    bomConsumerVerification platform("${bomConsumerGroup}:kotventure-bom:${bomConsumerVersion}")
-    bomConsumerArtifacts.each { artifactName ->
-        bomConsumerVerification "${bomConsumerGroup}:${artifactName}"
-    }
-}
-
 def bomPublishTasks = bomConsumerModules.collect { moduleName ->
     ":${moduleName}:publishMavenPublicationToBomConsumerLocalRepository"
 } + [':bom:publishMavenPublicationToBomConsumerLocalRepository']
 
-// FileCollection only — do not capture Configuration in the task for configuration-cache serialization.
-def bomConsumerResolvedFiles = objects.fileCollection()
-bomConsumerResolvedFiles.builtBy(bomPublishTasks)
-bomConsumerResolvedFiles.from(configurations.bomConsumerVerification)
-
+// Configuration-cache safe: verify published local-m2 layout + BOM POM managed GAVs.
+// Do not resolve a versionless configuration as task file inputs — CC fingerprints those
+// before publish tasks run, which fails on a clean tree (and on CI).
 tasks.register('verifyBomConsumerVersionlessDependencies') {
     group = 'verification'
-    description = 'Verifies that a consumer importing kotventure-bom can omit per-artifact versions.'
+    description = 'Verifies that the published BOM manages versionless Kotventure module coordinates.'
 
     bomPublishTasks.each { taskPath ->
         dependsOn taskPath
     }
 
+    def expectedGroup = bomConsumerGroup.toString()
     def expectedVersion = bomConsumerVersion.toString()
     def expectedArtifacts = bomConsumerArtifacts.collect { it.toString() }
-    def resolvedFiles = bomConsumerResolvedFiles
+    def repositoryDir = bomConsumerRepositoryDir
 
+    inputs.property('expectedGroup', expectedGroup)
     inputs.property('expectedVersion', expectedVersion)
     inputs.property('expectedArtifacts', expectedArtifacts)
-    inputs.files(resolvedFiles)
+    inputs.dir(repositoryDir)
 
     doLast {
-        def resolvedNames = resolvedFiles.files.collect { file -> file.name.toString() }.toSet()
-        def missingArtifacts = expectedArtifacts.findAll { artifactName ->
-            def expectedJar = "${artifactName}-${expectedVersion}.jar".toString()
-            !resolvedNames.any { name -> name == expectedJar }
+        def repoRoot = repositoryDir.get().asFile
+        def groupPath = expectedGroup.replace('.', '/')
+        def bomPomFile = new File(
+                repoRoot,
+                "${groupPath}/kotventure-bom/${expectedVersion}/kotventure-bom-${expectedVersion}.pom"
+        )
+        if (!bomPomFile.isFile()) {
+            throw new GradleException("BOM consumer verification missing published BOM POM: ${bomPomFile}")
         }
-        if (!missingArtifacts.isEmpty()) {
+
+        def managedByArtifact = [:]
+        def pom = new XmlSlurper().parse(bomPomFile)
+        pom.dependencyManagement.dependencies.dependency.each { dependency ->
+            def groupId = dependency.groupId.text()
+            def artifactId = dependency.artifactId.text()
+            def version = dependency.version.text()
+            if (groupId == expectedGroup && expectedArtifacts.contains(artifactId)) {
+                managedByArtifact[artifactId] = version
+            }
+        }
+
+        def missingManaged = expectedArtifacts.findAll { artifactName ->
+            !managedByArtifact.containsKey(artifactName)
+        }
+        if (!missingManaged.isEmpty()) {
             throw new GradleException(
-                    "BOM consumer verification did not resolve versionless artifacts " +
-                            "(expected version '${expectedVersion}'): ${missingArtifacts.join(', ')}. " +
-                            "Resolved files: ${resolvedNames.sort().join(', ')}"
+                    "BOM POM does not manage Kotventure artifacts (group '${expectedGroup}'): " +
+                            "${missingManaged.join(', ')}"
+            )
+        }
+
+        def mismatchedManaged = managedByArtifact.findAll { artifactName, managedVersion ->
+            managedVersion != expectedVersion
+        }
+        if (!mismatchedManaged.isEmpty()) {
+            throw new GradleException(
+                    "BOM POM manages unexpected versions (expected '${expectedVersion}'): ${mismatchedManaged}"
+            )
+        }
+
+        def missingJars = expectedArtifacts.findAll { artifactName ->
+            def jar = new File(
+                    repoRoot,
+                    "${groupPath}/${artifactName}/${expectedVersion}/${artifactName}-${expectedVersion}.jar"
+            )
+            !jar.isFile()
+        }
+        if (!missingJars.isEmpty()) {
+            throw new GradleException(
+                    "BOM consumer local repository is missing module jars for version " +
+                            "'${expectedVersion}': ${missingJars.join(', ')}"
             )
         }
     }

--- a/gradle/tasks/bom-consumer.gradle
+++ b/gradle/tasks/bom-consumer.gradle
@@ -5,7 +5,7 @@ def bomConsumerModules = [
         'minimessage',
         'serializer',
         'test',
-        'test-snapshot'
+        'test-snapshot',
 ]
 def bomConsumerArtifacts = bomConsumerModules.collect { moduleName ->
     "kotventure-${moduleName}".toString()
@@ -44,16 +44,18 @@ def bomPublishTasks = bomConsumerModules.collect { moduleName ->
     ":${moduleName}:publishMavenPublicationToBomConsumerLocalRepository"
 } + [':bom:publishMavenPublicationToBomConsumerLocalRepository']
 
-// Configuration-cache safe: verify published local-m2 layout + BOM POM managed GAVs.
-// Do not resolve a versionless configuration as task file inputs — CC fingerprints those
-// before publish tasks run, which fails on a clean tree (and on CI).
+/**
+ * Configuration-cache safe BOM check.
+ *
+ * Do not resolve a versionless consumer configuration as task file inputs: configuration-cache
+ * fingerprints those inputs before publish tasks run, which fails on a clean tree (and on CI).
+ * Instead, depend on the local-m2 publish tasks and assert the published BOM POM + module jars.
+ */
 tasks.register('verifyBomConsumerVersionlessDependencies') {
     group = 'verification'
-    description = 'Verifies that the published BOM manages versionless Kotventure module coordinates.'
+    description = 'Verifies that the published BOM manages Kotventure module coordinates at the project version.'
 
-    bomPublishTasks.each { taskPath ->
-        dependsOn taskPath
-    }
+    dependsOn bomPublishTasks
 
     def expectedGroup = bomConsumerGroup.toString()
     def expectedVersion = bomConsumerVersion.toString()
@@ -68,28 +70,29 @@ tasks.register('verifyBomConsumerVersionlessDependencies') {
     doLast {
         def repoRoot = repositoryDir.get().asFile
         def groupPath = expectedGroup.replace('.', '/')
-        def bomPomFile = new File(
-                repoRoot,
-                "${groupPath}/kotventure-bom/${expectedVersion}/kotventure-bom-${expectedVersion}.pom"
-        )
+        def coordinateDir = { String artifactId ->
+            new File(repoRoot, "${groupPath}/${artifactId}/${expectedVersion}")
+        }
+        def coordinateFile = { String artifactId, String extension ->
+            new File(coordinateDir(artifactId), "${artifactId}-${expectedVersion}.${extension}")
+        }
+
+        def bomPomFile = coordinateFile('kotventure-bom', 'pom')
         if (!bomPomFile.isFile()) {
             throw new GradleException("BOM consumer verification missing published BOM POM: ${bomPomFile}")
         }
 
-        def managedByArtifact = [:]
+        def managedVersions = [:]
         def pom = new XmlSlurper().parse(bomPomFile)
         pom.dependencyManagement.dependencies.dependency.each { dependency ->
             def groupId = dependency.groupId.text()
             def artifactId = dependency.artifactId.text()
-            def version = dependency.version.text()
             if (groupId == expectedGroup && expectedArtifacts.contains(artifactId)) {
-                managedByArtifact[artifactId] = version
+                managedVersions[artifactId] = dependency.version.text()
             }
         }
 
-        def missingManaged = expectedArtifacts.findAll { artifactName ->
-            !managedByArtifact.containsKey(artifactName)
-        }
+        def missingManaged = expectedArtifacts - managedVersions.keySet()
         if (!missingManaged.isEmpty()) {
             throw new GradleException(
                     "BOM POM does not manage Kotventure artifacts (group '${expectedGroup}'): " +
@@ -97,8 +100,8 @@ tasks.register('verifyBomConsumerVersionlessDependencies') {
             )
         }
 
-        def mismatchedManaged = managedByArtifact.findAll { artifactName, managedVersion ->
-            managedVersion != expectedVersion
+        def mismatchedManaged = managedVersions.findAll { artifactId, version ->
+            version != expectedVersion
         }
         if (!mismatchedManaged.isEmpty()) {
             throw new GradleException(
@@ -106,12 +109,8 @@ tasks.register('verifyBomConsumerVersionlessDependencies') {
             )
         }
 
-        def missingJars = expectedArtifacts.findAll { artifactName ->
-            def jar = new File(
-                    repoRoot,
-                    "${groupPath}/${artifactName}/${expectedVersion}/${artifactName}-${expectedVersion}.jar"
-            )
-            !jar.isFile()
+        def missingJars = expectedArtifacts.findAll { artifactId ->
+            !coordinateFile(artifactId, 'jar').isFile()
         }
         if (!missingJars.isEmpty()) {
             throw new GradleException(

--- a/gradle/tasks/bom-consumer.gradle
+++ b/gradle/tasks/bom-consumer.gradle
@@ -59,6 +59,8 @@ dependencies {
     }
 }
 
+def bomConsumerVerificationFiles = configurations.bomConsumerVerification
+
 tasks.register('verifyBomConsumerVersionlessDependencies') {
     group = 'verification'
     description = 'Verifies that a consumer importing kotventure-bom can omit per-artifact versions.'
@@ -68,32 +70,26 @@ tasks.register('verifyBomConsumerVersionlessDependencies') {
     }
     dependsOn ':bom:publishMavenPublicationToBomConsumerLocalRepository'
 
+    def expectedVersion = bomConsumerVersion
+    def expectedArtifacts = bomConsumerArtifacts
+    def resolvedFiles = bomConsumerVerificationFiles
+
+    inputs.property('expectedVersion', expectedVersion)
+    inputs.property('expectedArtifacts', expectedArtifacts)
+    inputs.files(resolvedFiles)
+
     doLast {
-        def expectedGroup = bomConsumerGroup
-        def expectedVersion = bomConsumerVersion
-        def resolvedVersions = [:]
-
-        configurations.bomConsumerVerification.incoming.resolutionResult.allComponents.each { component ->
-            def moduleVersion = component.moduleVersion
-            if (moduleVersion != null &&
-                    moduleVersion.group == expectedGroup &&
-                    bomConsumerArtifacts.contains(moduleVersion.name)) {
-                resolvedVersions[moduleVersion.name] = moduleVersion.version
-            }
-        }
-
-        def missingArtifacts = bomConsumerArtifacts.findAll { artifactName ->
-            !resolvedVersions.containsKey(artifactName)
+        def resolvedNames = resolvedFiles.files.collect { file -> file.name.toString() }.toSet()
+        def missingArtifacts = expectedArtifacts.findAll { artifactName ->
+            def expectedJar = "${artifactName}-${expectedVersion}.jar".toString()
+            !resolvedNames.any { name -> name == expectedJar }
         }
         if (!missingArtifacts.isEmpty()) {
-            throw new GradleException("BOM consumer verification did not resolve: ${missingArtifacts.join(', ')}")
-        }
-
-        def mismatchedVersions = resolvedVersions.findAll { artifactName, resolvedVersion ->
-            resolvedVersion != expectedVersion
-        }
-        if (!mismatchedVersions.isEmpty()) {
-            throw new GradleException("BOM consumer verification resolved unexpected versions: ${mismatchedVersions}")
+            throw new GradleException(
+                    "BOM consumer verification did not resolve versionless artifacts " +
+                            "(expected version '${expectedVersion}'): ${missingArtifacts.join(', ')}. " +
+                            "Resolved files: ${resolvedNames.sort().join(', ')}"
+            )
         }
     }
 }

--- a/gradle/tasks/release-automation.gradle
+++ b/gradle/tasks/release-automation.gradle
@@ -7,24 +7,30 @@ tasks.register('verifyReleaseVersionConsistency') {
     group = 'verification'
     description = 'Verifies the project version is consistent across the catalog, the project, and the release manifest.'
 
-    doLast {
-        def catalogVersion = rootProject.extensions
-                .getByType(VersionCatalogsExtension)
-                .named('libs')
-                .findVersion('project')
-                .orElseThrow { new GradleException('gradle/libs.versions.toml must define versions.project.') }
-                .requiredVersion
+    def catalogVersion = rootProject.extensions
+            .getByType(VersionCatalogsExtension)
+            .named('libs')
+            .findVersion('project')
+            .orElseThrow { new GradleException('gradle/libs.versions.toml must define versions.project.') }
+            .requiredVersion
+    def projectVersion = rootProject.version.toString()
+    def manifestFile = rootProject.layout.projectDirectory.file('.release-please-manifest.json')
 
-        if (rootProject.version.toString() != catalogVersion) {
-            throw new GradleException("Root project version '${rootProject.version}' must match versions.project '${catalogVersion}'.")
+    inputs.property('catalogVersion', catalogVersion)
+    inputs.property('projectVersion', projectVersion)
+    inputs.file(manifestFile)
+
+    doLast {
+        if (projectVersion != catalogVersion) {
+            throw new GradleException("Root project version '${projectVersion}' must match versions.project '${catalogVersion}'.")
         }
 
-        def manifestFile = rootProject.file('.release-please-manifest.json')
-        if (!manifestFile.isFile()) {
+        def manifestPath = manifestFile.asFile
+        if (!manifestPath.isFile()) {
             throw new GradleException('Missing required release file: .release-please-manifest.json')
         }
 
-        def manifestVersion = new JsonSlurper().parse(manifestFile)['.']
+        def manifestVersion = new JsonSlurper().parse(manifestPath)['.']
         if (manifestVersion != catalogVersion) {
             throw new GradleException(".release-please-manifest.json version '${manifestVersion}' must match versions.project '${catalogVersion}'.")
         }

--- a/gradle/tasks/release-automation.gradle
+++ b/gradle/tasks/release-automation.gradle
@@ -21,8 +21,9 @@ tasks.register('verifyReleaseVersionConsistency') {
     inputs.file(manifestFile)
 
     doLast {
+        def mismatches = []
         if (projectVersion != catalogVersion) {
-            throw new GradleException("Root project version '${projectVersion}' must match versions.project '${catalogVersion}'.")
+            mismatches << "root project version '${projectVersion}' vs versions.project '${catalogVersion}'"
         }
 
         def manifestPath = manifestFile.asFile
@@ -32,7 +33,13 @@ tasks.register('verifyReleaseVersionConsistency') {
 
         def manifestVersion = new JsonSlurper().parse(manifestPath)['.']
         if (manifestVersion != catalogVersion) {
-            throw new GradleException(".release-please-manifest.json version '${manifestVersion}' must match versions.project '${catalogVersion}'.")
+            mismatches << ".release-please-manifest.json '${manifestVersion}' vs versions.project '${catalogVersion}'"
+        }
+
+        if (!mismatches.isEmpty()) {
+            throw new GradleException(
+                    "Release version consistency check failed:\n - ${mismatches.join('\n - ')}"
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements caching / Gradle performance work from the CI audit:

| Item | Change |
|------|--------|
| Configuration cache | `org.gradle.configuration-cache=true`; CC-safe publish / release / BOM verification |
| Vanilla fixtures | `actions/cache` on `modules/core/build/vanilla-conformance`; key derived from `gradle/vanilla-conformance.gradle` via `.github/scripts/vanilla-fixture-cache-key.sh`; SHA-1 re-check on restore |
| Daemon | Removed `--no-daemon` from Build and Vanilla (`setup-gradle` manages the daemon) |
| Job split / remote cache | **Deferred** — Build is still ~minutes; remote cache not needed yet |
| fetch-depth | Gradle job keeps full history for Spotless `ratchetFrom 'origin/master'` |
| setup-gradle caches | Unchanged (defaults already on) |

### Gradle quality notes

- **`publish.gradle`**: no `afterEvaluate`; software components via `pluginManager.withPlugin`; description via lazy `Provider` (module scripts set it after root `subprojects {}` applies this file); verification parses the generated `pom-default.xml`.
- **`bom-consumer.gradle`**: does not resolve unpublished configurations as task inputs (CC fingerprint trap on clean CI); asserts published BOM managed GAVs + module jars in local m2.
- **`release-automation.gradle`**: plain inputs + single mismatch report for catalog / project / manifest versions.
- Root `repositories.gradle` applied so aggregated Kover report tasks can resolve the agent.

Local verification: full CI Gradle command green with configuration cache **stored** then **reused**.

## Type of change

- [x] chore / build / ci
- [x] docs

## Testing

```bash
./gradlew build dokkaGenerate koverXmlReport koverHtmlReport spotlessCheck ktlintCheck
# second run: Configuration cache entry reused
```

## Checklist

- [x] Title and commit subjects follow `verb(area): something`
- [x] No audit IDs or workflow header comments