### PR TITLE
ci(ci): harden master rules, CodeQL, and workflow trust

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,9 @@
 # Default owner for everything in the repo.
 * @LMLiam
+
+# CI and automation surfaces — explicit code-owner review when rules require it.
+.github/workflows/ @LMLiam
+.github/actions/ @LMLiam
+.github/scripts/ @LMLiam
+.github/dependabot.yml @LMLiam
+.github/code-paths-filter.yml @LMLiam

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  checks: write
   contents: read
   pull-requests: read
 
@@ -71,6 +70,9 @@ jobs:
     if: needs.gate.outputs.run == 'true' && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      checks: write
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build for CodeQL
         if: matrix.build-mode == 'manual'
-        run: ./gradlew classes testClasses -x test
+        run: ./gradlew classes testClasses -x test -Pkotlin.incremental=false --no-build-cache --rerun-tasks
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,111 @@
+name: CodeQL
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'modules/**'
+      - 'gradle/**'
+      - 'build.gradle'
+      - 'settings.gradle'
+      - 'gradle.properties'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'buildSrc/**'
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'qodana.yaml'
+      - 'jitpack.yml'
+      - 'release-please-config.json'
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/scripts/**'
+      - '.github/dependabot.yml'
+      - '.github/code-paths-filter.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'modules/**'
+      - 'gradle/**'
+      - 'build.gradle'
+      - 'settings.gradle'
+      - 'gradle.properties'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'buildSrc/**'
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'qodana.yaml'
+      - 'jitpack.yml'
+      - 'release-please-config.json'
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/scripts/**'
+      - '.github/dependabot.yml'
+      - '.github/code-paths-filter.yml'
+  schedule:
+    - cron: '23 5 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: Heavy CI gate
+    uses: ./.github/workflows/heavy-ci-gate.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: java-kotlin
+            build-mode: manual
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Set up JDK and Gradle
+        if: matrix.build-mode == 'manual'
+        uses: ./.github/actions/setup-jdk-gradle
+
+      - name: Build for CodeQL
+        if: matrix.build-mode == 'manual'
+        run: ./gradlew classes testClasses -x test
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -33,10 +33,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  checks: write
   contents: read
-  pull-requests: write
-  security-events: write
 
 jobs:
   gate:
@@ -52,6 +49,11 @@ jobs:
     if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+      security-events: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,7 +10,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: { }
+permissions:
+  contents: read
 
 jobs:
   scorecard:

--- a/.github/workflows/vanilla-conformance.yml
+++ b/.github/workflows/vanilla-conformance.yml
@@ -21,7 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  checks: write
   contents: read
 
 jobs:
@@ -29,6 +28,9 @@ jobs:
     name: Vanilla conformance
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      checks: write
+      contents: read
 
     steps:
       - name: Checkout

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -85,7 +85,8 @@ When adding release-please `extra-files`, update the gate allow-list in the same
 
 Workflow: [`.github/workflows/codeql.yml`](../.github/workflows/codeql.yml).
 
-- **Languages:** `actions` (build mode `none`) and `java-kotlin` (manual `./gradlew classes testClasses -x test`).
+- **Languages:** `actions` (build mode `none`) and `java-kotlin` (manual `./gradlew classes testClasses -x test`
+  with `--rerun-tasks --no-build-cache` so the extractor sees a real compile).
 - **Path filters** on PR/push match the Build/Qodana code path list; weekly schedule and `workflow_dispatch` always run.
 - Results upload to GitHub code scanning (same surface as Qodana/Scorecard SARIF).
 
@@ -93,7 +94,7 @@ Workflow: [`.github/workflows/codeql.yml`](../.github/workflows/codeql.yml).
 
 | Action | Path | Used by |
 |--------|------|---------|
-| **setup-jdk-gradle** | [`.github/actions/setup-jdk-gradle`](../.github/actions/setup-jdk-gradle/action.yml) | Build, Vanilla Conformance |
+| **setup-jdk-gradle** | [`.github/actions/setup-jdk-gradle`](../.github/actions/setup-jdk-gradle/action.yml) | Build, Vanilla Conformance, CodeQL (`java-kotlin`) |
 | **publish-junit-report** | [`.github/actions/publish-junit-report`](../.github/actions/publish-junit-report/action.yml) | Build, Vanilla Conformance |
 
 Checkout stays per-workflow (Qodana custom `ref` / history; Build uses full history on both parallel jobs).

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -12,13 +12,14 @@ For local development commands, see [CONTRIBUTING.md](../.github/CONTRIBUTING.md
 |----------|----------|---------|
 | **Build** | PR → `master`, push → `master` | Parallel format/lint + Gradle verify when code paths change; required check always reports |
 | **Qodana** | PR → `master` (path-filtered), weekly schedule, `workflow_dispatch` | Static analysis + SARIF to code scanning |
+| **CodeQL** | PR/push → `master` (path-filtered), weekly schedule, `workflow_dispatch` | Code scanning for Actions and Java/Kotlin |
 | **Vanilla Conformance** | Path-filtered PRs, weekly schedule, `workflow_dispatch` | MC-backed selector tests |
 | **Dependency Security Review** | PR → `master` | `dependency-review-action` |
 | **Conventional Titles** | `pull_request_target`, push `master` | PR title + commit subjects (`verb(area): …`) |
 | **Labeler** | `pull_request_target` | Path → `area:*` labels |
 | **Release Please** | push `master` | Opens/updates release PRs; tags/releases after merge |
 | **OpenSSF Scorecard** | weekly schedule, `branch_protection_rule`, `workflow_dispatch` | Supply-chain scorecard + SARIF |
-| **Heavy CI gate** | `workflow_call` only | Skip pure release-please PRs for Build and Qodana |
+| **Heavy CI gate** | `workflow_call` only | Skip pure release-please PRs for Build, Qodana, and CodeQL |
 
 ## When workflows run
 
@@ -51,21 +52,21 @@ Gradle does not run for docs-only / template-only changes. Markdown under `modul
 
 ### Push vs PR
 
-| Event | Build workflow | Lint + Gradle jobs | Qodana |
-|-------|:--------------:|:------------------:|:------:|
-| PR (code paths) | ✓ | ✓ | ✓ |
-| PR (docs/process only) | ✓ | — | — |
-| Push to `master` (code paths) | ✓ | ✓ | — |
-| Push to `master` (docs only) | ✓ | — | — |
-| Weekly schedule | — | — | ✓ |
-| `workflow_dispatch` | — | — | ✓ |
+| Event | Build workflow | Lint + Gradle jobs | Qodana | CodeQL |
+|-------|:--------------:|:------------------:|:------:|:------:|
+| PR (code paths) | ✓ | ✓ | ✓ | ✓ |
+| PR (docs/process only) | ✓ | — | — | — |
+| Push to `master` (code paths) | ✓ | ✓ | — | ✓ |
+| Push to `master` (docs only) | ✓ | — | — | — |
+| Weekly schedule | — | — | ✓ | ✓ |
+| `workflow_dispatch` | — | — | ✓ | ✓ |
 
 ### Heavy CI gate (release-please)
 
 Workflow: [`.github/workflows/heavy-ci-gate.yml`](../.github/workflows/heavy-ci-gate.yml).  
-**Used by:** Build, Qodana. Dependency Review is not gated.
+**Used by:** Build, Qodana, CodeQL. Dependency Review is not gated.
 
-Skips Build’s lint/Gradle jobs and Qodana when all of:
+Skips Build’s lint/Gradle jobs, Qodana, and CodeQL when all of:
 
 1. Event is a `pull_request`
 2. Head branch starts with `release-please--`
@@ -76,9 +77,17 @@ Skips Build’s lint/Gradle jobs and Qodana when all of:
 
 On Build, the required check still reports success when the gate skips the lint and Gradle jobs.
 
-If the PR has any other path change, Build/Qodana run when code paths match.
+If the PR has any other path change, Build/Qodana/CodeQL run when code paths match.
 
 When adding release-please `extra-files`, update the gate allow-list in the same PR.
+
+### CodeQL
+
+Workflow: [`.github/workflows/codeql.yml`](../.github/workflows/codeql.yml).
+
+- **Languages:** `actions` (build mode `none`) and `java-kotlin` (manual `./gradlew classes testClasses -x test`).
+- **Path filters** on PR/push match the Build/Qodana code path list; weekly schedule and `workflow_dispatch` always run.
+- Results upload to GitHub code scanning (same surface as Qodana/Scorecard SARIF).
 
 ## Local composite actions
 
@@ -107,6 +116,29 @@ Third-party actions are SHA-pinned with a version comment. Dependabot updates (`
 
 New composites that pin third-party actions need a matching Dependabot directory.
 
+## Branch protection (`master`)
+
+Repository ruleset **Master** (default branch):
+
+- Block force-push, branch deletion, and direct pushes (updates only via PR).
+- Pull requests: one approving review, code-owner review, dismiss stale reviews, resolve conversations, squash only.
+- Required status checks (must pass before merge):
+  - `Build, Test, and Lint`
+  - `Validate Pull Request Title`
+  - `Validate Commit Subjects`
+  - `Review Dependency Changes`
+- Code scanning gate for Qodana (`QDJVM`) alerts at medium-or-higher security / errors severity.
+- Maintainer bypass remains configured for emergency overrides.
+
+[CODEOWNERS](../.github/CODEOWNERS) assigns `@LMLiam` as default owner and explicitly for `.github/workflows/`,
+`.github/actions/`, `.github/scripts/`, and related CI config so code-owner review covers automation changes.
+
+## Dependency review
+
+Workflow: [`.github/workflows/dependency-review.yml`](../.github/workflows/dependency-review.yml). Runs on every PR to
+`master` (not heavy-CI-gated). Fails on **moderate** or higher severity advisories for scopes
+`runtime`, `development`, and `unknown`.
+
 ## Performance
 
 | Mechanism | Where |
@@ -126,7 +158,7 @@ New composites that pin third-party actions need a matching Dependabot directory
 ## Re-running CI
 
 - **Re-run failed jobs** / **Re-run all jobs** on an Actions run.
-- Qodana, Vanilla Conformance, and Scorecard also support `workflow_dispatch`.
+- Qodana, CodeQL, Vanilla Conformance, and Scorecard also support `workflow_dispatch`.
 
 ## Related docs
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -42,7 +42,8 @@ falls back to `GITHUB_TOKEN`, release-please can still open PRs, but GitHub will
 token's PR, tag, and release events.
 
 Pure release-please PRs (changelog, manifest, and `gradle/libs.versions.toml` only) skip Build/Qodana/CodeQL heavy work;
-Dependency Review, titles, and labels still run (and remain required). See [CI.md](./CI.md).
+Dependency Review and conventional title/commit checks still run and remain required. Labels still apply. See
+[CI.md](./CI.md).
 
 ## Publishing Coordination
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -11,8 +11,13 @@ The `Release Please` workflow runs on pushes to `master`. It reads `release-plea
 
 The workflow uses the `RELEASE_PLEASE_TOKEN` secret when it is configured, falling back to `GITHUB_TOKEN` otherwise.
 Prefer `RELEASE_PLEASE_TOKEN` for normal releases because PRs, tags, and releases created with the built-in
-`GITHUB_TOKEN` do not trigger follow-up workflows. Use a fine-grained PAT or GitHub App token for the GitHub Actions bot
-with repository access and the ability to write contents, issues, and pull requests.
+`GITHUB_TOKEN` do not trigger follow-up workflows.
+
+`RELEASE_PLEASE_TOKEN` is typically a fine-grained personal access token (or GitHub App installation token) with
+repository access to write contents, issues, and pull requests. Commits and PRs created with a **personal** PAT are
+attributed to that user account, so they look like human activity rather than a bot identity. Heavy CI therefore uses a
+**path-based** release-please gate (branch prefix + allow-listed files), not bot-actor detection — see [CI.md](./CI.md).
+A dedicated GitHub App or machine user token keeps the same workflow shape while making automation identity clearer.
 
 ## Version Policy
 
@@ -28,17 +33,16 @@ When adjusting release automation, verify the policy still matches [ROADMAP.md](
 
 ## Branch Protection
 
-Keep `master` protected and release through the Release PR. Branch protection must allow the GitHub Actions bot or the
-release bot behind `RELEASE_PLEASE_TOKEN` to create and update the Release PR branch, apply release labels, and merge
-only after the required checks pass.
+Keep `master` protected and release through the Release PR. The **Master** ruleset requires a PR, reviews, and the
+status checks listed in [CI.md](./CI.md) (including `Build, Test, and Lint` and Dependency Review). Release automation
+must create and update the Release PR branch and apply release labels; merge only after those required checks pass.
 
-If branch protection requires all PR checks, use `RELEASE_PLEASE_TOKEN` so the Release PR triggers the same CI workflows
-as human-authored PRs. If the repository falls back to `GITHUB_TOKEN`, release-please can still open PRs, but GitHub
-will
-suppress workflows triggered by that token's PR, tag, and release events.
+Use `RELEASE_PLEASE_TOKEN` so the Release PR triggers the same CI workflows as human-authored PRs. If the repository
+falls back to `GITHUB_TOKEN`, release-please can still open PRs, but GitHub will suppress workflows triggered by that
+token's PR, tag, and release events.
 
-Pure release-please PRs (changelog, manifest, and `gradle/libs.versions.toml` only) skip Build/Qodana Gradle work;
-Dependency Review, titles, and labels still run. See [CI.md](./CI.md).
+Pure release-please PRs (changelog, manifest, and `gradle/libs.versions.toml` only) skip Build/Qodana/CodeQL heavy work;
+Dependency Review, titles, and labels still run (and remain required). See [CI.md](./CI.md).
 
 ## Publishing Coordination
 


### PR DESCRIPTION
## Summary

Security & trust slice for Kotventure CI:

- **Master ruleset** (applied via API, documented here): required status checks
  - `Build, Test, and Lint`
  - `Validate Pull Request Title`
  - `Validate Commit Subjects`
  - `Review Dependency Changes`
  - Keep existing PR rules, force-push/delete blocks, QDJVM code-scanning gate, and maintainer always-bypass
- **CodeQL** workflow for `actions` + `java-kotlin` (path-filtered, heavy-CI-gated, weekly schedule)
- **Least-privilege** workflow permissions: write scopes moved to the jobs that need them (Build/Qodana/Vanilla/Scorecard)
- **CODEOWNERS**: explicit ownership for `.github/workflows|actions|scripts` and related CI config
- **Docs**: `docs/CI.md` for what ships; `docs/RELEASING.md` for honest `RELEASE_PLEASE_TOKEN` identity (human-looking PAT; path-based gate is intentional)
- **Dependency review**: keep strict `runtime,development,unknown` + moderate fail (documented)

## Test plan

- [ ] PR shows required checks: Build aggregator, title, commit subjects, dependency review
- [ ] CodeQL starts for both languages; java-kotlin build step succeeds
- [ ] Docs-only change still gets always-green `Build, Test, and Lint`
- [ ] Pure release-please allow-list would skip CodeQL via heavy gate (Dependency Review still required)
- [ ] No workflow needs broader permissions than before

## Notes

- Ruleset update is live on the repo (not a file in git). Scorecard may improve on branch-protection once it re-runs; not claiming “done” without a fresh Scorecard result.
- CodeQL is **not** a required merge check yet (noise/cost first).