### PR TITLE
ci(ci): Build dispatch, job summaries, and check taxonomy

### DIFF
--- a/.github/scripts/write-gradle-job-summary.sh
+++ b/.github/scripts/write-gradle-job-summary.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file="${1:-}"
+
+{
+  echo "## CI job summary"
+  echo
+  echo "### Toolchain"
+  if command -v java >/dev/null 2>&1; then
+    echo "- Java: $(java -version 2>&1 | head -n 1 | tr -d '\r')"
+  else
+    echo "- Java: (not on PATH)"
+  fi
+
+  if [[ -x ./gradlew ]]; then
+    gradle_ver="$(./gradlew --version 2>/dev/null | awk '/^Gradle / { print $2; exit }' || true)"
+    echo "- Gradle: ${gradle_ver:-unknown}"
+  else
+    echo "- Gradle: (wrapper missing)"
+  fi
+
+  if [[ -f gradle/libs.versions.toml ]]; then
+    kotlin_ver="$(awk -F'"' '/^kotlin[[:space:]]*=/ { print $2; exit }' gradle/libs.versions.toml || true)"
+    echo "- Kotlin: ${kotlin_ver:-unknown}"
+  else
+    echo "- Kotlin: (catalog missing)"
+  fi
+
+  if [[ -n "${GITHUB_EVENT_NAME:-}" ]]; then
+    echo
+    echo "### Run"
+    echo "- Event: \`${GITHUB_EVENT_NAME}\`"
+    if [[ -n "${GRADLE_TASKS:-}" ]]; then
+      echo "- Gradle tasks: \`${GRADLE_TASKS}\`"
+    fi
+  fi
+
+  if [[ -n "${log_file}" && -f "${log_file}" ]] && grep -qE '> Task .+ FAILED' "${log_file}"; then
+    echo
+    echo "### Failed tasks"
+    grep -E '> Task .+ FAILED' "${log_file}" | while IFS= read -r line; do
+      task="${line#*> Task }"
+      task="${task% FAILED}"
+      [[ -n "${task}" ]] || continue
+      echo "- \`${task}\`"
+    done
+  fi
+} >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -123,8 +123,10 @@ jobs:
           INPUT_MODULE: ${{ github.event.inputs.module || '' }}
         run: |
           set -euo pipefail
-          tasks="$(echo -n "${INPUT_TASKS}" | xargs || true)"
-          module="$(echo -n "${INPUT_MODULE}" | xargs || true)"
+          tasks="${INPUT_TASKS#"${INPUT_TASKS%%[![:space:]]*}"}"
+          tasks="${tasks%"${tasks##*[![:space:]]}"}"
+          module="${INPUT_MODULE#"${INPUT_MODULE%%[![:space:]]*}"}"
+          module="${module%"${module##*[![:space:]]}"}"
 
           if [[ -n "$module" && ! "$module" =~ ^[A-Za-z0-9_-]+$ ]]; then
             echo "Invalid module name: $module" >&2
@@ -133,7 +135,7 @@ jobs:
 
           if [[ -z "$tasks" ]]; then
             if [[ -n "$module" ]]; then
-              tasks=":${module}:build :${module}:test"
+              tasks=":${module}:build"
             else
               tasks="build dokkaGenerate koverXmlReport koverHtmlReport"
             fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,18 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      tasks:
+        description: Gradle tasks (space-separated). Empty uses the default CI task set, or :module:build when module is set.
+        required: false
+        default: ''
+        type: string
+      module:
+        description: Optional Gradle project name (e.g. core, minimessage). Empty runs the full multi-project default.
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -31,18 +43,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      code: ${{ steps.resolve.outputs.code }}
     steps:
       - name: Checkout
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Path filter
         id: filter
+        if: github.event_name != 'workflow_dispatch'
         uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           filters: .github/code-paths-filter.yml
+
+      - name: Resolve code-change flag
+        id: resolve
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+          fi
 
   lint:
     name: Format and lint
@@ -62,7 +86,15 @@ jobs:
         uses: ./.github/actions/setup-jdk-gradle
 
       - name: Run Spotless and ktlint
-        run: ./gradlew spotlessCheck ktlintCheck
+        run: |
+          set -euo pipefail
+          ./gradlew spotlessCheck ktlintCheck 2>&1 | tee lint.log
+
+      - name: Write job summary
+        if: always()
+        env:
+          GRADLE_TASKS: spotlessCheck ktlintCheck
+        run: bash .github/scripts/write-gradle-job-summary.sh lint.log
 
   gradle:
     name: Gradle build
@@ -84,8 +116,45 @@ jobs:
       - name: Set up JDK and Gradle
         uses: ./.github/actions/setup-jdk-gradle
 
+      - name: Resolve Gradle tasks
+        id: tasks
+        env:
+          INPUT_TASKS: ${{ github.event.inputs.tasks || '' }}
+          INPUT_MODULE: ${{ github.event.inputs.module || '' }}
+        run: |
+          set -euo pipefail
+          tasks="$(echo -n "${INPUT_TASKS}" | xargs || true)"
+          module="$(echo -n "${INPUT_MODULE}" | xargs || true)"
+
+          if [[ -n "$module" && ! "$module" =~ ^[A-Za-z0-9_-]+$ ]]; then
+            echo "Invalid module name: $module" >&2
+            exit 1
+          fi
+
+          if [[ -z "$tasks" ]]; then
+            if [[ -n "$module" ]]; then
+              tasks=":${module}:build :${module}:test"
+            else
+              tasks="build dokkaGenerate koverXmlReport koverHtmlReport"
+            fi
+          fi
+
+          echo "tasks=$tasks" >> "$GITHUB_OUTPUT"
+          echo "Resolved Gradle tasks: $tasks"
+
       - name: Run build, tests, and coverage
-        run: ./gradlew build dokkaGenerate koverXmlReport koverHtmlReport
+        env:
+          GRADLE_TASKS: ${{ steps.tasks.outputs.tasks }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2086
+          ./gradlew ${GRADLE_TASKS} 2>&1 | tee gradle.log
+
+      - name: Write job summary
+        if: always()
+        env:
+          GRADLE_TASKS: ${{ steps.tasks.outputs.tasks }}
+        run: bash .github/scripts/write-gradle-job-summary.sh gradle.log
 
       - name: Publish JUnit test report
         if: always()

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -67,10 +67,10 @@ Actions → **Build** → **Run workflow**. Always runs Format and lint + Gradle
 
 | Input | Default | Behaviour |
 |-------|---------|-----------|
-| `tasks` | empty | Default full set: `build dokkaGenerate koverXmlReport koverHtmlReport`. If only `module` is set: `:<module>:build :<module>:test`. |
-| `module` | empty | Optional project name (`core`, `minimessage`, …). Ignored when `tasks` is non-empty (tasks run as typed). |
+| `tasks` | empty | Default full set: `build dokkaGenerate koverXmlReport koverHtmlReport`. If only `module` is set: `:<module>:build` (includes tests when the project has them). |
+| `module` | empty | Optional project name (`core`, `minimessage`, `bom`, …). Ignored when `tasks` is non-empty (tasks run as typed). |
 
-Module names must match `[A-Za-z0-9_-]+`.
+Module names must match `[A-Za-z0-9_-]+`. Manual runs use a separate concurrency group from push/PR so they do not cancel each other.
 
 ### Heavy CI gate (release-please)
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -10,7 +10,7 @@ For local development commands, see [CONTRIBUTING.md](../.github/CONTRIBUTING.md
 
 | Workflow | Triggers | Purpose |
 |----------|----------|---------|
-| **Build** | PR → `master`, push → `master` | Parallel format/lint + Gradle verify when code paths change; required check always reports |
+| **Build** | PR → `master`, push → `master`, `workflow_dispatch` | Parallel format/lint + Gradle verify when code paths change; required check always reports |
 | **Qodana** | PR → `master` (path-filtered), weekly schedule, `workflow_dispatch` | Static analysis + SARIF to code scanning |
 | **CodeQL** | PR/push → `master` (path-filtered), weekly schedule, `workflow_dispatch` | Code scanning for Actions and Java/Kotlin |
 | **Vanilla Conformance** | Path-filtered PRs, weekly schedule, `workflow_dispatch` | MC-backed selector tests |
@@ -59,7 +59,18 @@ Gradle does not run for docs-only / template-only changes. Markdown under `modul
 | Push to `master` (code paths) | ✓ | ✓ | — | ✓ |
 | Push to `master` (docs only) | ✓ | — | — | — |
 | Weekly schedule | — | — | ✓ | ✓ |
-| `workflow_dispatch` | — | — | ✓ | ✓ |
+| `workflow_dispatch` | ✓ | ✓ | ✓ | ✓ |
+
+### Manual Build (`workflow_dispatch`)
+
+Actions → **Build** → **Run workflow**. Always runs Format and lint + Gradle build (path filter skipped).
+
+| Input | Default | Behaviour |
+|-------|---------|-----------|
+| `tasks` | empty | Default full set: `build dokkaGenerate koverXmlReport koverHtmlReport`. If only `module` is set: `:<module>:build :<module>:test`. |
+| `module` | empty | Optional project name (`core`, `minimessage`, …). Ignored when `tasks` is non-empty (tasks run as typed). |
+
+Module names must match `[A-Za-z0-9_-]+`.
 
 ### Heavy CI gate (release-please)
 
@@ -105,6 +116,9 @@ Checkout stays per-workflow (Qodana custom `ref` / history; Build uses full hist
 |--------|------|
 | [`.github/scripts/validate-conventional-title.sh`](../.github/scripts/validate-conventional-title.sh) | Title/commit subject format |
 | [`.github/scripts/normalize-qodana-sarif.sh`](../.github/scripts/normalize-qodana-sarif.sh) | Fix 0-based SARIF regions for GitHub code scanning |
+| [`.github/scripts/write-gradle-job-summary.sh`](../.github/scripts/write-gradle-job-summary.sh) | Job summary: Java/Gradle/Kotlin versions + failed tasks |
+
+Format and lint and Gradle build always write a job summary (toolchain + event; failed Gradle task names when the log contains `> Task … FAILED`).
 
 ## Action pins and Dependabot
 
@@ -117,22 +131,42 @@ Third-party actions are SHA-pinned with a version comment. Dependabot updates (`
 
 New composites that pin third-party actions need a matching Dependabot directory.
 
+| Ecosystem | Grouping | Open PR limit |
+|-----------|----------|---------------|
+| Gradle (`/`) | Minor + patch grouped (`gradle-minor-patch`); **majors ungrouped** (one PR each for review — Kotlin, Adventure, etc.) | 10 |
+| GitHub Actions (root + composites) | Minor + patch grouped; majors ungrouped | 10 (root), 5 (composites) |
+
 ## Branch protection (`master`)
 
 Repository ruleset **Master** (default branch):
 
 - Block force-push, branch deletion, and direct pushes (updates only via PR).
 - Pull requests: one approving review, code-owner review, dismiss stale reviews, resolve conversations, squash only.
-- Required status checks (must pass before merge):
-  - `Build, Test, and Lint`
-  - `Validate Pull Request Title`
-  - `Validate Commit Subjects`
-  - `Review Dependency Changes`
+- Required status checks (must pass before merge) — see [Required vs optional checks](#required-vs-optional-checks).
 - Code scanning gate for Qodana (`QDJVM`) alerts at medium-or-higher security / errors severity.
 - Maintainer bypass remains configured for emergency overrides.
 
 [CODEOWNERS](../.github/CODEOWNERS) assigns `@LMLiam` as default owner and explicitly for `.github/workflows/`,
 `.github/actions/`, `.github/scripts/`, and related CI config so code-owner review covers automation changes.
+
+## Required vs optional checks
+
+PRs show many checks; only a subset is merge-blocking via the **Master** ruleset.
+
+| Check | Merge gate | Notes |
+|-------|:----------:|-------|
+| **Build, Test, and Lint** | **Required** | Always reports; green when lint/Gradle are skipped (docs-only / pure release-please allow-list) |
+| **Validate Pull Request Title** | **Required** | Conventional PR title |
+| **Validate Commit Subjects** | **Required** | Conventional commit subjects on the PR |
+| **Review Dependency Changes** | **Required** | Dependency review; not heavy-CI-gated |
+| Format and lint / Gradle build | No | Nested under the Build aggregator |
+| Qodana / QDJVM | No* | Workflow is informational as a status check; **QDJVM** code-scanning alerts are ruleset-gated (medium-or-higher security / errors) |
+| CodeQL (`Analyze (…)` ) | No | SARIF to code scanning |
+| Vanilla conformance | No | Path-filtered |
+| Labeler / Apply area labels | No | Labelling only |
+| Scorecard | No | Schedule / dispatch |
+
+\*Qodana is **not** a required status check and is not marked `continue-on-error`. Failures remain visible on the PR without blocking merge by themselves; serious findings still surface through the QDJVM code-scanning ruleset rule.
 
 ## Dependency review
 
@@ -159,7 +193,8 @@ Workflow: [`.github/workflows/dependency-review.yml`](../.github/workflows/depen
 ## Re-running CI
 
 - **Re-run failed jobs** / **Re-run all jobs** on an Actions run.
-- Qodana, CodeQL, Vanilla Conformance, and Scorecard also support `workflow_dispatch`.
+- **Build**, Qodana, CodeQL, Vanilla Conformance, and Scorecard support `workflow_dispatch` (Build accepts optional `tasks` / `module` inputs).
+- Open the failed **Format and lint** or **Gradle build** job for the job summary (toolchain + failed tasks).
 
 ## Related docs
 


### PR DESCRIPTION
## Summary

DX / maintainer ergonomics slice:

- **Build `workflow_dispatch`** with optional `tasks` and `module` inputs (path filter skipped; always runs lint + Gradle)
- **Job summaries** on Format and lint + Gradle build (Java / Gradle / Kotlin + failed task names from the log)
- **Required vs optional checks** table in `docs/CI.md` (matches Master ruleset; Qodana stays non-required as a status check, QDJVM code-scanning gate unchanged)
- **Dependabot**: document majors stay ungrouped for review; keep open-PR limits and minor/patch groups as-is

## Defaults chosen

| Item | Choice |
|------|--------|
| Manual `module` only | `:<module>:build :<module>:test` |
| Manual empty inputs | Full default CI task set |
| Qodana | Document as optional status check — **not** `continue-on-error` |
| Dependabot majors | Leave ungrouped (safer review) |

## Test plan

- [ ] PR CI green; required checks still report
- [ ] Job summary appears on Format and lint / Gradle build with toolchain versions
- [ ] (optional) Manual **Run workflow** with empty inputs runs full build
- [ ] (optional) `module=core` resolves to `:core:build :core:test`
- [ ] Docs-only changes still always-green aggregator