### PR TITLE
feat(audience): add the tab list header/footer dsl

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -206,6 +206,10 @@ player.sound(key("minecraft:entity.pig.ambient")) {    // build + play one-shot
 }
 player.stopSound { source(music) }
 player.stopSound { all() }
+player.tabList {
+    header { text("Welcome") }
+    footer { text("play.example.org") }
+}
 
 // Managed (timed) boss bars — context(ticker) once; `over` opts into lifecycle management
 // val ticker = paperTicker(plugin)   // platform-provided; ManualTicker in tests

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TabList.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TabList.kt
@@ -1,0 +1,23 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.component.emptyComponent
+import net.kyori.adventure.audience.Audience
+
+/**
+ * Builds a player list (tab list) header and footer from a [TabListScope] block and sends them to
+ * this [Audience] via [Audience.sendPlayerListHeaderAndFooter].
+ *
+ * Adventure has a single primitive that always sets **both** sides. An unset slot in this block
+ * is sent as empty and therefore **clears** any previous value on that side. Set at least one of
+ * `header` or `footer` (either alone is fine — the other is sent empty). To clear both sides
+ * explicitly, set both to [emptyComponent].
+ *
+ * Works for any audience — a player, the console, or a forwarding audience over many members;
+ * audiences without a player-list surface ignore it.
+ *
+ * @throws IllegalStateException when the block sets neither slot, or sets any slot twice.
+ * @sample io.github.lmliam.kotventure.core.audience.tabListSample
+ */
+public fun Audience.tabList(init: TabListScope.() -> Unit) {
+    TabListBuilder().apply(init).sendTo(this)
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TabListBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TabListBuilder.kt
@@ -1,0 +1,33 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.component.emptyComponent
+import io.github.lmliam.kotventure.core.dsl.once
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+
+internal class TabListBuilder : TabListScope {
+    private var header: Component? by once()
+    private var footer: Component? by once()
+
+    override fun header(init: ComponentScope.() -> Unit) = header(component(init))
+
+    override fun <T : ComponentLike> header(component: T) {
+        header = component.asComponent()
+    }
+
+    override fun footer(init: ComponentScope.() -> Unit) = footer(component(init))
+
+    override fun <T : ComponentLike> footer(component: T) {
+        footer = component.asComponent()
+    }
+
+    internal fun sendTo(audience: Audience) {
+        check(header != null || footer != null) {
+            "At least one of 'header' or 'footer' must be set."
+        }
+        audience.sendPlayerListHeaderAndFooter(header ?: emptyComponent(), footer ?: emptyComponent())
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TabListScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/TabListScope.kt
@@ -1,0 +1,43 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Scope for configuring the player list (tab list) header and footer shown via
+ * [Audience.tabList].
+ *
+ * At least one of [header] or [footer] must be set before the block ends.
+ */
+@KotventureDslMarker
+public interface TabListScope {
+    /**
+     * Builds the tab list header from a component DSL block.
+     *
+     * @throws IllegalStateException when the header is already set in this block.
+     */
+    public fun header(init: ComponentScope.() -> Unit)
+
+    /**
+     * Sets the tab list header.
+     *
+     * @throws IllegalStateException when the header is already set in this block.
+     */
+    public fun <T : ComponentLike> header(component: T)
+
+    /**
+     * Builds the tab list footer from a component DSL block.
+     *
+     * @throws IllegalStateException when the footer is already set in this block.
+     */
+    public fun footer(init: ComponentScope.() -> Unit)
+
+    /**
+     * Sets the tab list footer.
+     *
+     * @throws IllegalStateException when the footer is already set in this block.
+     */
+    public fun <T : ComponentLike> footer(component: T)
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/TabListSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/audience/TabListSamples.kt
@@ -1,0 +1,15 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.text.text
+
+internal fun tabListSample() {
+    val audience = emptyAudience()
+
+    audience.tabList {
+        header {
+            text("Welcome") { color(gold) }
+        }
+        footer { text("play.example.org") }
+    }
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TabListDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/audience/TabListDslTest.kt
@@ -1,0 +1,119 @@
+package io.github.lmliam.kotventure.core.audience
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.Component
+
+/**
+ * Captures tab list header/footer pairs via [sendPlayerListHeaderAndFooter].
+ * Kept local to the test for isolation and readability.
+ */
+private class TabListRecordingAudience : Audience {
+    data class HeaderFooter(
+        val header: Component,
+        val footer: Component,
+    )
+
+    val sent = mutableListOf<HeaderFooter>()
+
+    override fun sendPlayerListHeaderAndFooter(
+        header: Component,
+        footer: Component,
+    ) {
+        sent += HeaderFooter(header, footer)
+    }
+}
+
+class TabListDslTest :
+    StringSpec(
+        {
+            fun record(block: TabListScope.() -> Unit): TabListRecordingAudience.HeaderFooter =
+                TabListRecordingAudience().also { it.tabList(block) }.sent.single()
+
+            "builds and sends header and footer via block form" {
+                val pair =
+                    record {
+                        header {
+                            text("Welcome") { color(gold) }
+                        }
+                        footer { text("play.example.org") }
+                    }
+
+                pair.header.childAt(0) shouldContainText "Welcome"
+                pair.header.childAt(0) shouldHaveColor gold
+                pair.footer.childAt(0) shouldContainText "play.example.org"
+            }
+
+            "accepts existing components for header and footer" {
+                val header = Component.text("Header")
+                val footer = Component.text("Footer")
+
+                val pair =
+                    record {
+                        header(header)
+                        footer(footer)
+                    }
+
+                pair.header shouldBe header
+                pair.footer shouldBe footer
+            }
+
+            "sends empty footer when only header is set" {
+                val pair = record { header { text("Header only") } }
+
+                pair.header.childAt(0) shouldContainText "Header only"
+                pair.footer shouldBe Component.empty()
+            }
+
+            "sends empty header when only footer is set" {
+                val pair = record { footer { text("Footer only") } }
+
+                pair.header shouldBe Component.empty()
+                pair.footer.childAt(0) shouldContainText "Footer only"
+            }
+
+            "sends the same header and footer to every member of a forwarding audience" {
+                val first = TabListRecordingAudience()
+                val second = TabListRecordingAudience()
+
+                audienceOf(first, second).tabList {
+                    header { text("Broadcast") }
+                    footer { text("Footer") }
+                }
+
+                first.sent shouldHaveSize 1
+                second.sent shouldHaveSize 1
+                first.sent.single() shouldBe second.sent.single()
+            }
+
+            listOf(
+                "rejects a block with neither header nor footer" to {
+                    TabListRecordingAudience().tabList {}
+                },
+                "rejects a duplicate header" to {
+                    TabListRecordingAudience().tabList {
+                        header { text("a") }
+                        header(Component.text("b"))
+                    }
+                },
+                "rejects a duplicate footer" to {
+                    TabListRecordingAudience().tabList {
+                        footer { text("a") }
+                        footer { text("b") }
+                    }
+                },
+            ).forEach { (name, action) ->
+                name {
+                    shouldThrow<IllegalStateException> { action() }
+                }
+            }
+        },
+    )


### PR DESCRIPTION
## Summary

Adds the tab list DSL: set the player-list header and footer on any `Audience` with
`tabList { header { }; footer { } }`, wrapping `Audience.sendPlayerListHeaderAndFooter`.

## Related Issues

Closes #40

## DSL Impact

```kotlin
player.tabList {
    header { text("Welcome") { color(gold) } }
    footer { text("play.example.org") }
}
player.tabList { header { text("Header only") } }   // footer side is sent empty (cleared)
```

Both slots take the title-style pair of forms: a component DSL block or any `ComponentLike`.
Adventure's pair send is the only primitive — a send always sets **both** sides, so an unset slot
goes out empty and clears that side; the KDoc states this contract plainly, and clearing both is
the explicit `header(emptyComponent()); footer(emptyComponent())`, never a silent default: the
empty block is rejected with `IllegalStateException`, as are duplicate slots.

## Rationale

Completes another Phase 2 audience send-surface slice: idiomatic, compile-checked tab list
updates matching the title DSL's shape (same scope/builder split, same `once()` rejection policy),
so the audience surface stays uniform for downstream plugin authors.

## Testing

`core/audience/TabListDslTest` — recording audience on the `sendPlayerListHeaderAndFooter`
primitive: block and `ComponentLike` forms (asserted with the project's component matchers),
header-only/footer-only proving the empty-side clearing contract against raw `Component.empty()`,
forwarding via `audienceOf`, and a rejection table (empty block, duplicate header across mixed
forms, duplicate footer).

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages (`docs/DESIGN.md` §5 canonical surface)
- [x] Verified examples build and run (`src/samples` compile; `./gradlew build` green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLUKXPAvRHZZJDyh42yUFZ
