### PR TITLE
refactor(core): DSL fail-fast, selector parity, and package hygiene

### DIFF
--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/BoundChatBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/BoundChatBuilder.kt
@@ -7,7 +7,7 @@ import net.kyori.adventure.chat.ChatType
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentLike
 
-internal sealed class BoundChatBuilder : BoundChatScope {
+internal open class BoundChatBuilder : BoundChatScope {
     private var type: ChatType? by once()
     private var name: Component? by once()
     private var target: Component? by once()
@@ -32,7 +32,4 @@ internal sealed class BoundChatBuilder : BoundChatScope {
         val name = checkNotNull(name) { "'name' is not set." }
         return (type ?: ChatType.CHAT).bind(name, target)
     }
-
-    /** Concrete builder for signed-message [BoundChatScope] blocks (no message content slot). */
-    internal class Bound : BoundChatBuilder()
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/BoundChatBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/BoundChatBuilder.kt
@@ -7,7 +7,7 @@ import net.kyori.adventure.chat.ChatType
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentLike
 
-internal open class BoundChatBuilder : BoundChatScope {
+internal sealed class BoundChatBuilder : BoundChatScope {
     private var type: ChatType? by once()
     private var name: Component? by once()
     private var target: Component? by once()
@@ -32,4 +32,7 @@ internal open class BoundChatBuilder : BoundChatScope {
         val name = checkNotNull(name) { "'name' is not set." }
         return (type ?: ChatType.CHAT).bind(name, target)
     }
+
+    /** Concrete builder for signed-message [BoundChatScope] blocks (no message content slot). */
+    internal class Bound : BoundChatBuilder()
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Chat.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Chat.kt
@@ -36,4 +36,4 @@ public fun Audience.chat(init: ChatScope.() -> Unit) {
 public fun Audience.chat(
     signed: SignedMessage,
     init: BoundChatScope.() -> Unit,
-): Unit = sendMessage(signed, BoundChatBuilder().apply(init).buildBound())
+): Unit = sendMessage(signed, BoundChatBuilder.Bound().apply(init).buildBound())

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Chat.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/Chat.kt
@@ -36,4 +36,4 @@ public fun Audience.chat(init: ChatScope.() -> Unit) {
 public fun Audience.chat(
     signed: SignedMessage,
     init: BoundChatScope.() -> Unit,
-): Unit = sendMessage(signed, BoundChatBuilder.Bound().apply(init).buildBound())
+): Unit = sendMessage(signed, BoundChatBuilder().apply(init).buildBound())

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarBuilder.kt
@@ -23,7 +23,10 @@ internal class BossBarBuilder(
     }
 
     override fun progress(progress: Float) {
-        progressValue = progress.requireBossBarProgress()
+        // Claim the once-slot before range validation so a second call always throws
+        // IllegalStateException, even when the new value is out of range (e.g. NaN, 1.5f).
+        progressValue = progress
+        progress.requireBossBarProgress()
     }
 
     internal fun build(): BossBar {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarBuilder.kt
@@ -24,7 +24,7 @@ internal class BossBarBuilder(
 
     override fun progress(progress: Float) {
         // Claim the once-slot before range validation so a second call always throws
-        // IllegalStateException, even when the new value is out of range (e.g. NaN, 1.5f).
+        // IllegalStateException
         progressValue = progress
         progress.requireBossBarProgress()
     }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarBuilder.kt
@@ -23,7 +23,7 @@ internal class BossBarBuilder(
     }
 
     override fun progress(progress: Float) {
-        progressValue = progress
+        progressValue = progress.requireBossBarProgress()
     }
 
     internal fun build(): BossBar {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarProgress.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarProgress.kt
@@ -7,9 +7,9 @@ import net.kyori.adventure.bossbar.BossBar
  *
  * @throws IllegalArgumentException when outside [[BossBar.MIN_PROGRESS], [BossBar.MAX_PROGRESS]]
  */
-internal fun Float.requireBossBarProgress(label: String = "value"): Float =
+internal fun Float.requireBossBarProgress(label: String = "progress"): Float =
     also {
         require(this in BossBar.MIN_PROGRESS..BossBar.MAX_PROGRESS) {
-            "'progress' $label must be in ${BossBar.MIN_PROGRESS}..${BossBar.MAX_PROGRESS}, got $this."
+            "'$label' must be in ${BossBar.MIN_PROGRESS}..${BossBar.MAX_PROGRESS}, got $this."
         }
     }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarProgress.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarProgress.kt
@@ -1,0 +1,15 @@
+package io.github.lmliam.kotventure.core.bossbar
+
+import net.kyori.adventure.bossbar.BossBar
+
+/**
+ * Requires this float to lie in Adventure's inclusive boss-bar progress range.
+ *
+ * @throws IllegalArgumentException when outside [[BossBar.MIN_PROGRESS], [BossBar.MAX_PROGRESS]]
+ */
+internal fun Float.requireBossBarProgress(label: String = "value"): Float =
+    also {
+        require(this in BossBar.MIN_PROGRESS..BossBar.MAX_PROGRESS) {
+            "'progress' $label must be in ${BossBar.MIN_PROGRESS}..${BossBar.MAX_PROGRESS}, got $this."
+        }
+    }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBar.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBar.kt
@@ -1,11 +1,8 @@
 package io.github.lmliam.kotventure.core.bossbar.timed
 
 import io.github.lmliam.kotventure.core.time.Ticker
-import io.github.lmliam.kotventure.core.time.TickerTask
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.bossbar.BossBar
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 import kotlin.time.Duration
 
 /**
@@ -17,7 +14,7 @@ import kotlin.time.Duration
  * [show] are tracked so completion and [cancel] hide the bar from every tracked audience.
  */
 public class TimedBossBar internal constructor(
-    private val ticker: Ticker,
+    ticker: Ticker,
     private val config: TimedBossBarConfig,
     initialViewer: Audience,
 ) {
@@ -31,31 +28,25 @@ public class TimedBossBar internal constructor(
             config.appearance.flags,
         )
 
-    private val lock = ReentrantLock()
-    private val viewers = TimedBossBarViewers()
-    private var task: TickerTask? = null
-    private var remainingTime = config.over
-    private var running = true
-    private var paused = false
+    private val runtime = TimedBossBarRuntime(ticker, config, bar, this)
 
     /**
      * Time remaining until natural completion; frozen while [isPaused] and at the value it had
      * when [cancel] ended the bar early. [Duration.ZERO] after natural completion.
      */
     public val remaining: Duration
-        get() = lock.withLock { remainingTime }
+        get() = runtime.remaining
 
     /** `true` until the bar finishes naturally or is [cancel]led. */
     public val isRunning: Boolean
-        get() = lock.withLock { running }
+        get() = runtime.isRunning
 
     /** `true` after [pause] and before [resume], while still [isRunning]. */
     public val isPaused: Boolean
-        get() = lock.withLock { paused }
+        get() = runtime.isPaused
 
     init {
-        show(initialViewer)
-        startTicking()
+        runtime.start(initialViewer)
     }
 
     /**
@@ -64,14 +55,7 @@ public class TimedBossBar internal constructor(
      * @throws IllegalStateException when the bar is finished, cancelled, or already paused.
      */
     public fun pause() {
-        val toCancel =
-            lock.withLock {
-                check(running) { "Cannot pause a finished or cancelled TimedBossBar." }
-                check(!paused) { "TimedBossBar is already paused." }
-                paused = true
-                detachTask()
-            }
-        toCancel?.cancel()
+        runtime.pause()
     }
 
     /**
@@ -80,13 +64,7 @@ public class TimedBossBar internal constructor(
      * @throws IllegalStateException when the bar is finished, cancelled, or not paused.
      */
     public fun resume() {
-        // Schedule under the lock so cancel cannot race a new task into existence after stop.
-        lock.withLock {
-            check(running) { "Cannot resume a finished or cancelled TimedBossBar." }
-            check(paused) { "TimedBossBar is not paused." }
-            paused = false
-            startTicking()
-        }
+        runtime.resume()
     }
 
     /**
@@ -94,12 +72,8 @@ public class TimedBossBar internal constructor(
      * ends a still-running bar. Idempotent after finish or a prior cancel.
      */
     public fun cancel() {
-        val shutdown =
-            lock.withLock {
-                if (!running) return
-                markStopped()
-            }
-        finaliseShutdown(shutdown, config.onCancel)
+        val shutdown = runtime.cancel() ?: return
+        runtime.finaliseShutdown(shutdown, config.onCancel)
     }
 
     /**
@@ -110,103 +84,13 @@ public class TimedBossBar internal constructor(
      * entry.
      */
     public fun show(audience: Audience) {
-        val accepted =
-            lock.withLock {
-                if (!running) {
-                    false
-                } else {
-                    viewers.add(audience)
-                    true
-                }
-            }
-        if (!accepted) return
-
-        audience.showBossBar(bar)
-
-        // If cancel/finish raced between track and show, undo the visible bar.
-        val stillTracked = lock.withLock { running && audience in viewers }
-        if (!stillTracked) {
-            audience.hideBossBar(bar)
-        }
+        runtime.show(audience)
     }
 
     /**
      * Hides [bar] from [audience] and stops tracking it for auto-hide.
      */
     public fun hide(audience: Audience) {
-        lock.withLock { viewers.remove(audience) }
-        audience.hideBossBar(bar)
-    }
-
-    private fun startTicking() {
-        task = ticker.repeating(config.every) { onTick() }
-    }
-
-    private fun detachTask(): TickerTask? {
-        val current = task
-        task = null
-        return current
-    }
-
-    private fun onTick() {
-        val remainingNow = lock.withLock { advanceOrNull() } ?: return
-        config.onTick?.invoke(this, remainingNow)
-        if (remainingNow == Duration.ZERO) completeNaturally()
-    }
-
-    /**
-     * Advances one interval and updates the bar, returning the new [remaining]; `null` when the
-     * bar is no longer advancing. The re-rendered name is pushed only when it differs from the
-     * current one, so fixed names and unchanged dynamic frames stay silent.
-     */
-    private fun advanceOrNull(): Duration? {
-        if (!running || paused) return null
-        remainingTime = (remainingTime - config.every).coerceAtLeast(Duration.ZERO)
-        bar.progress(config.progress.at(remaining = remainingTime, over = config.over))
-        updateNameIfChanged(remainingTime)
-        return remainingTime
-    }
-
-    private fun updateNameIfChanged(remaining: Duration) {
-        val name = config.name(remaining)
-        if (name != bar.name()) bar.name(name)
-    }
-
-    private fun completeNaturally() {
-        val shutdown =
-            lock.withLock {
-                if (!running) return
-                markStopped()
-            }
-        finaliseShutdown(shutdown, config.onFinish)
-    }
-
-    /**
-     * Ends the bar under [lock]: clears running state, detaches the ticker task, and snapshots
-     * viewers. Adventure hide and task cancel happen outside the lock via [finaliseShutdown].
-     */
-    private fun markStopped(): TimedBossBarShutdown {
-        running = false
-        paused = false
-        return TimedBossBarShutdown(
-            task = detachTask(),
-            viewers = viewers.snapshotAndClear(),
-        )
-    }
-
-    /**
-     * Cancels the detached ticker task, hides every snapshotted viewer (isolating per-viewer
-     * failures), then always runs the terminal [hook] once.
-     */
-    private fun finaliseShutdown(
-        shutdown: TimedBossBarShutdown,
-        hook: (TimedBossBar.() -> Unit)?,
-    ) {
-        shutdown.task?.cancel()
-        try {
-            viewers.hideAll(bar, shutdown.viewers)
-        } finally {
-            hook?.invoke(this)
-        }
+        runtime.hide(audience)
     }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBar.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBar.kt
@@ -15,18 +15,11 @@ import kotlin.time.Duration
  */
 public class TimedBossBar internal constructor(
     ticker: Ticker,
-    private val config: TimedBossBarConfig,
+    config: TimedBossBarConfig,
     initialViewer: Audience,
 ) {
-    /** The underlying Adventure boss bar; progress and name are updated each tick. */
-    public val bar: BossBar =
-        BossBar.bossBar(
-            config.name(config.over),
-            config.progress.from,
-            config.appearance.color,
-            config.appearance.overlay,
-            config.appearance.flags,
-        )
+    /** The underlying Adventure bsos bar; progress and name are updated each tick. */
+    public val bar: BossBar = config.buildInitialBar()
 
     private val runtime = TimedBossBarRuntime(ticker, config, bar, this)
 
@@ -34,16 +27,13 @@ public class TimedBossBar internal constructor(
      * Time remaining until natural completion; frozen while [isPaused] and at the value it had
      * when [cancel] ended the bar early. [Duration.ZERO] after natural completion.
      */
-    public val remaining: Duration
-        get() = runtime.remaining
+    public val remaining: Duration by runtime::remaining
 
     /** `true` until the bar finishes naturally or is [cancel]led. */
-    public val isRunning: Boolean
-        get() = runtime.isRunning
+    public val isRunning: Boolean by runtime::isRunning
 
     /** `true` after [pause] and before [resume], while still [isRunning]. */
-    public val isPaused: Boolean
-        get() = runtime.isPaused
+    public val isPaused: Boolean by runtime::isPaused
 
     init {
         runtime.start(initialViewer)
@@ -54,42 +44,34 @@ public class TimedBossBar internal constructor(
      *
      * @throws IllegalStateException when the bar is finished, cancelled, or already paused.
      */
-    public fun pause() {
-        runtime.pause()
-    }
+    public fun pause(): Unit = runtime.pause()
 
     /**
      * Continues from the frozen [remaining] after [pause].
      *
      * @throws IllegalStateException when the bar is finished, cancelled, or not paused.
      */
-    public fun resume() {
-        runtime.resume()
-    }
+    public fun resume(): Unit = runtime.resume()
 
     /**
      * Stops the bar, hides it from all tracked viewers, and fires `onCancel` once when this call
      * ends a still-running bar. Idempotent after finish or a prior cancel.
      */
-    public fun cancel() {
-        runtime.cancel()
-    }
+    public fun cancel(): Unit = runtime.cancel()
 
     /**
      * Shows [bar] to [audience] and tracks it for auto-hide on completion or [cancel].
      *
-     * No-op when the bar is already finished or cancelled (not tracked, not shown). Showing the
-     * same audience again while running re-invokes Adventure show and keeps a single tracking
-     * entry.
+     * No-op when the bar is already finished or cancelled (not tracked, not shown).
+     * Showing the same audience again while running re-invokes Adventure show and keeps a single tracking entry.
      */
-    public fun show(audience: Audience) {
-        runtime.show(audience)
-    }
+    public fun show(audience: Audience): Unit = runtime.show(audience)
 
     /**
      * Hides [bar] from [audience] and stops tracking it for auto-hide.
      */
-    public fun hide(audience: Audience) {
-        runtime.hide(audience)
-    }
+    public fun hide(audience: Audience): Unit = runtime.hide(audience)
 }
+
+private fun TimedBossBarConfig.buildInitialBar(): BossBar =
+    BossBar.bossBar(name(over), progress.from, appearance.color, appearance.overlay, appearance.flags)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBar.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBar.kt
@@ -18,7 +18,7 @@ public class TimedBossBar internal constructor(
     config: TimedBossBarConfig,
     initialViewer: Audience,
 ) {
-    /** The underlying Adventure bsos bar; progress and name are updated each tick. */
+    /** The underlying Adventure boss bar; progress and name are updated each tick. */
     public val bar: BossBar = config.buildInitialBar()
 
     private val runtime = TimedBossBarRuntime(ticker, config, bar, this)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBar.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBar.kt
@@ -72,8 +72,7 @@ public class TimedBossBar internal constructor(
      * ends a still-running bar. Idempotent after finish or a prior cancel.
      */
     public fun cancel() {
-        val shutdown = runtime.cancel() ?: return
-        runtime.finaliseShutdown(shutdown, config.onCancel)
+        runtime.cancel()
     }
 
     /**

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarProgress.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarProgress.kt
@@ -1,5 +1,6 @@
 package io.github.lmliam.kotventure.core.bossbar.timed
 
+import io.github.lmliam.kotventure.core.bossbar.requireBossBarProgress
 import net.kyori.adventure.bossbar.BossBar
 import kotlin.time.Duration
 
@@ -30,10 +31,3 @@ internal data class TimedBossBarProgress(
         return from + ((to - from) * elapsedFraction).toFloat()
     }
 }
-
-private fun Float.requireBossBarProgress(label: String): Float =
-    also {
-        require(this in BossBar.MIN_PROGRESS..BossBar.MAX_PROGRESS) {
-            "'progress' $label must be in ${BossBar.MIN_PROGRESS}..${BossBar.MAX_PROGRESS}, got $this."
-        }
-    }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarProgress.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarProgress.kt
@@ -13,8 +13,8 @@ internal data class TimedBossBarProgress(
     val to: Float,
 ) {
     init {
-        from.requireBossBarProgress(label = "from")
-        to.requireBossBarProgress(label = "to")
+        from.requireBossBarProgress(label = "progress from")
+        to.requireBossBarProgress(label = "progress to")
     }
 
     /**

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
@@ -1,0 +1,153 @@
+package io.github.lmliam.kotventure.core.bossbar.timed
+
+import io.github.lmliam.kotventure.core.time.Ticker
+import io.github.lmliam.kotventure.core.time.TickerTask
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.bossbar.BossBar
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.time.Duration
+
+/**
+ * Lock-guarded lifecycle and tick progression for a [TimedBossBar].
+ *
+ * Owns running/paused state, remaining time, viewer tracking, and the ticker task. Adventure
+ * show/hide and terminal hooks run outside the lock where noted by the public facade.
+ */
+internal class TimedBossBarRuntime(
+    private val ticker: Ticker,
+    private val config: TimedBossBarConfig,
+    private val bar: BossBar,
+    private val owner: TimedBossBar,
+) {
+    private val lock = ReentrantLock()
+    private val viewers = TimedBossBarViewers()
+    private var task: TickerTask? = null
+    private var remainingTime = config.over
+    private var running = true
+    private var paused = false
+
+    val remaining: Duration
+        get() = lock.withLock { remainingTime }
+
+    val isRunning: Boolean
+        get() = lock.withLock { running }
+
+    val isPaused: Boolean
+        get() = lock.withLock { paused }
+
+    fun start(initialViewer: Audience) {
+        show(initialViewer)
+        startTicking()
+    }
+
+    fun pause() {
+        val toCancel =
+            lock.withLock {
+                check(running) { "Cannot pause a finished or cancelled TimedBossBar." }
+                check(!paused) { "TimedBossBar is already paused." }
+                paused = true
+                detachTask()
+            }
+        toCancel?.cancel()
+    }
+
+    fun resume() {
+        lock.withLock {
+            check(running) { "Cannot resume a finished or cancelled TimedBossBar." }
+            check(paused) { "TimedBossBar is not paused." }
+            paused = false
+            startTicking()
+        }
+    }
+
+    fun cancel(): TimedBossBarShutdown? =
+        lock.withLock {
+            if (!running) return null
+            markStopped()
+        }
+
+    fun show(audience: Audience) {
+        val accepted =
+            lock.withLock {
+                if (!running) {
+                    false
+                } else {
+                    viewers.add(audience)
+                    true
+                }
+            }
+        if (!accepted) return
+
+        audience.showBossBar(bar)
+
+        val stillTracked = lock.withLock { running && audience in viewers }
+        if (!stillTracked) {
+            audience.hideBossBar(bar)
+        }
+    }
+
+    fun hide(audience: Audience) {
+        lock.withLock { viewers.remove(audience) }
+        audience.hideBossBar(bar)
+    }
+
+    fun finaliseShutdown(
+        shutdown: TimedBossBarShutdown,
+        hook: (TimedBossBar.() -> Unit)?,
+    ) {
+        shutdown.task?.cancel()
+        try {
+            viewers.hideAll(bar, shutdown.viewers)
+        } finally {
+            hook?.invoke(owner)
+        }
+    }
+
+    private fun startTicking() {
+        task = ticker.repeating(config.every) { onTick() }
+    }
+
+    private fun detachTask(): TickerTask? {
+        val current = task
+        task = null
+        return current
+    }
+
+    private fun onTick() {
+        val remainingNow = lock.withLock { advanceOrNull() } ?: return
+        config.onTick?.invoke(owner, remainingNow)
+        if (remainingNow == Duration.ZERO) completeNaturally()
+    }
+
+    private fun advanceOrNull(): Duration? {
+        if (!running || paused) return null
+        remainingTime = (remainingTime - config.every).coerceAtLeast(Duration.ZERO)
+        bar.progress(config.progress.at(remaining = remainingTime, over = config.over))
+        updateNameIfChanged(remainingTime)
+        return remainingTime
+    }
+
+    private fun updateNameIfChanged(remaining: Duration) {
+        val name = config.name(remaining)
+        if (name != bar.name()) bar.name(name)
+    }
+
+    private fun completeNaturally() {
+        val shutdown =
+            lock.withLock {
+                if (!running) return
+                markStopped()
+            }
+        finaliseShutdown(shutdown, config.onFinish)
+    }
+
+    private fun markStopped(): TimedBossBarShutdown {
+        running = false
+        paused = false
+        return TimedBossBarShutdown(
+            task = detachTask(),
+            viewers = viewers.snapshotAndClear(),
+        )
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
@@ -57,7 +57,6 @@ internal class TimedBossBarRuntime(
             lock.withLock {
                 check(running) { "Cannot pause a finished or cancelled TimedBossBar." }
                 check(!paused) { "TimedBossBar is already paused." }
-                // Invalidate before exposing paused so a concurrent resume cannot share this task.
                 val detached = detachTask()
                 paused = true
                 detached
@@ -139,31 +138,49 @@ internal class TimedBossBarRuntime(
     }
 
     private fun onTick(generation: Int) {
-        val remainingNow = lock.withLock { advanceOrNull(generation) } ?: return
-        config.onTick?.invoke(owner, remainingNow)
-        if (remainingNow == Duration.ZERO) completeNaturally()
+        // At ZERO, mark natural stop under the same lock as the tick so cancel() from onTick
+        // cannot steal completion (onFinish must win) and a thrown onTick still finalises hide.
+        val outcome = lock.withLock { advanceOrNull(generation) } ?: return
+        var tickError: Throwable? = null
+        try {
+            config.onTick?.invoke(owner, outcome.remaining)
+        } catch (error: Throwable) {
+            tickError = error
+        }
+        if (outcome.shutdown != null) {
+            try {
+                finaliseShutdown(outcome.shutdown, config.onFinish)
+            } catch (error: Throwable) {
+                if (tickError != null) {
+                    tickError.addSuppressed(error)
+                    throw tickError
+                }
+                throw error
+            }
+        }
+        if (tickError != null) {
+            throw tickError
+        }
     }
 
-    private fun advanceOrNull(generation: Int): Duration? {
+    /**
+     * Advances remaining time under [lock]. When the tick lands on [Duration.ZERO], atomically
+     * marks the bar stopped and returns the [TimedBossBarShutdown] for outside-lock finalisation.
+     * Stale generations (detached tasks) are ignored.
+     */
+    private fun advanceOrNull(generation: Int): TickOutcome? {
         if (!running || paused || generation != tickGeneration) return null
         remainingTime = (remainingTime - config.every).coerceAtLeast(Duration.ZERO)
         bar.progress(config.progress.at(remaining = remainingTime, over = config.over))
         updateNameIfChanged(remainingTime)
-        return remainingTime
+        val remaining = remainingTime
+        val shutdown = if (remaining == Duration.ZERO) markStopped() else null
+        return TickOutcome(remaining = remaining, shutdown = shutdown)
     }
 
     private fun updateNameIfChanged(remaining: Duration) {
         val name = config.name(remaining)
         if (name != bar.name()) bar.name(name)
-    }
-
-    private fun completeNaturally() {
-        val shutdown =
-            lock.withLock {
-                if (!running) return
-                markStopped()
-            }
-        finaliseShutdown(shutdown, config.onFinish)
     }
 
     /**
@@ -178,4 +195,10 @@ internal class TimedBossBarRuntime(
             viewers = viewers.snapshotAndClear(),
         )
     }
+
+    /** Result of one locked tick advance; [shutdown] is non-null only on natural completion. */
+    private data class TickOutcome(
+        val remaining: Duration,
+        val shutdown: TimedBossBarShutdown?,
+    )
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
@@ -12,7 +12,12 @@ import kotlin.time.Duration
  * Lock-guarded lifecycle and tick progression for a [TimedBossBar].
  *
  * Owns running/paused state, remaining time, viewer tracking, and the ticker task. Adventure
- * show/hide and terminal hooks run outside the lock where noted by the public facade.
+ * show/hide and terminal hooks run outside the lock.
+ *
+ * **This-escape:** [owner] is the constructing [TimedBossBar]. [start] may schedule ticks before
+ * that constructor returns, so [TimedBossBarConfig.onTick] can observe [owner] mid-construction
+ * on a real scheduler thread. Callers must not assume the facade is fully initialised inside
+ * early hooks.
  */
 internal class TimedBossBarRuntime(
     private val ticker: Ticker,
@@ -62,11 +67,14 @@ internal class TimedBossBarRuntime(
         }
     }
 
-    fun cancel(): TimedBossBarShutdown? =
-        lock.withLock {
-            if (!running) return null
-            markStopped()
-        }
+    fun cancel() {
+        val shutdown =
+            lock.withLock {
+                if (!running) return
+                markStopped()
+            }
+        finaliseShutdown(shutdown, config.onCancel)
+    }
 
     fun show(audience: Audience) {
         val accepted =
@@ -98,7 +106,7 @@ internal class TimedBossBarRuntime(
      * Cancels the detached ticker task, hides every snapshotted viewer (isolating per-viewer
      * failures), then always runs the terminal [hook] once.
      */
-    fun finaliseShutdown(
+    private fun finaliseShutdown(
         shutdown: TimedBossBarShutdown,
         hook: (TimedBossBar.() -> Unit)?,
     ) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
@@ -141,25 +141,10 @@ internal class TimedBossBarRuntime(
         // At ZERO, mark natural stop under the same lock as the tick so cancel() from onTick
         // cannot steal completion (onFinish must win) and a thrown onTick still finalises hide.
         val outcome = lock.withLock { advanceOrNull(generation) } ?: return
-        var tickError: Throwable? = null
         try {
             config.onTick?.invoke(owner, outcome.remaining)
-        } catch (error: Throwable) {
-            tickError = error
-        }
-        if (outcome.shutdown != null) {
-            try {
-                finaliseShutdown(outcome.shutdown, config.onFinish)
-            } catch (error: Throwable) {
-                if (tickError != null) {
-                    tickError.addSuppressed(error)
-                    throw tickError
-                }
-                throw error
-            }
-        }
-        if (tickError != null) {
-            throw tickError
+        } finally {
+            outcome.shutdown?.let { finaliseShutdown(it, config.onFinish) }
         }
     }
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
@@ -53,6 +53,7 @@ internal class TimedBossBarRuntime(
     }
 
     fun resume() {
+        // Schedule under the lock so cancel cannot race a new task into existence after stop.
         lock.withLock {
             check(running) { "Cannot resume a finished or cancelled TimedBossBar." }
             check(paused) { "TimedBossBar is not paused." }
@@ -81,6 +82,7 @@ internal class TimedBossBarRuntime(
 
         audience.showBossBar(bar)
 
+        // If cancel/finish raced between track and show, undo the visible bar.
         val stillTracked = lock.withLock { running && audience in viewers }
         if (!stillTracked) {
             audience.hideBossBar(bar)
@@ -92,6 +94,10 @@ internal class TimedBossBarRuntime(
         audience.hideBossBar(bar)
     }
 
+    /**
+     * Cancels the detached ticker task, hides every snapshotted viewer (isolating per-viewer
+     * failures), then always runs the terminal [hook] once.
+     */
     fun finaliseShutdown(
         shutdown: TimedBossBarShutdown,
         hook: (TimedBossBar.() -> Unit)?,
@@ -142,6 +148,10 @@ internal class TimedBossBarRuntime(
         finaliseShutdown(shutdown, config.onFinish)
     }
 
+    /**
+     * Ends the bar under [lock]: clears running state, detaches the ticker task, and snapshots
+     * viewers. Adventure hide and task cancel happen outside the lock via [finaliseShutdown].
+     */
     private fun markStopped(): TimedBossBarShutdown {
         running = false
         paused = false

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
@@ -32,6 +32,12 @@ internal class TimedBossBarRuntime(
     private var running = true
     private var paused = false
 
+    /**
+     * Invalidated on every [detachTask] so a cancelled/stale ticker callback cannot advance after
+     * pause/resume schedules a replacement (cancel alone does not abort an in-flight action).
+     */
+    private var tickGeneration: Int = 0
+
     val remaining: Duration
         get() = lock.withLock { remainingTime }
 
@@ -51,8 +57,10 @@ internal class TimedBossBarRuntime(
             lock.withLock {
                 check(running) { "Cannot pause a finished or cancelled TimedBossBar." }
                 check(!paused) { "TimedBossBar is already paused." }
+                // Invalidate before exposing paused so a concurrent resume cannot share this task.
+                val detached = detachTask()
                 paused = true
-                detachTask()
+                detached
             }
         toCancel?.cancel()
     }
@@ -119,23 +127,25 @@ internal class TimedBossBarRuntime(
     }
 
     private fun startTicking() {
-        task = ticker.repeating(config.every) { onTick() }
+        val generation = tickGeneration
+        task = ticker.repeating(config.every) { onTick(generation) }
     }
 
     private fun detachTask(): TickerTask? {
+        tickGeneration++
         val current = task
         task = null
         return current
     }
 
-    private fun onTick() {
-        val remainingNow = lock.withLock { advanceOrNull() } ?: return
+    private fun onTick(generation: Int) {
+        val remainingNow = lock.withLock { advanceOrNull(generation) } ?: return
         config.onTick?.invoke(owner, remainingNow)
         if (remainingNow == Duration.ZERO) completeNaturally()
     }
 
-    private fun advanceOrNull(): Duration? {
-        if (!running || paused) return null
+    private fun advanceOrNull(generation: Int): Duration? {
+        if (!running || paused || generation != tickGeneration) return null
         remainingTime = (remainingTime - config.every).coerceAtLeast(Duration.ZERO)
         bar.progress(config.progress.at(remaining = remainingTime, over = config.over))
         updateNameIfChanged(remainingTime)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
@@ -11,12 +11,16 @@ import kotlin.time.Duration
 /**
  * Lock-guarded lifecycle and tick progression for a [TimedBossBar].
  *
- * Owns running/paused state, remaining time, viewer tracking, and the ticker task. Adventure
+ * Owns running/paused state, remaining time, viewer tracking, and the ticker task.
+Adventure
  * show/hide and terminal hooks run outside the lock.
  *
- * **This-escape:** [owner] is the constructing [TimedBossBar]. [start] may schedule ticks before
- * that constructor returns, so [TimedBossBarConfig.onTick] can observe [owner] mid-construction
- * on a real scheduler thread. Callers must not assume the facade is fully initialised inside
+ * **This-escape:** [owner] is the constructing [TimedBossBar]. [start] may schedule
+ticks before
+ * that constructor returns, so [TimedBossBarConfig.onTick] can observe [owner]
+mid-construction
+ * on a real scheduler thread. Callers must not assume the facade is fully initialised
+inside
  * early hooks.
  */
 internal class TimedBossBarRuntime(
@@ -57,9 +61,7 @@ internal class TimedBossBarRuntime(
             lock.withLock {
                 check(running) { "Cannot pause a finished or cancelled TimedBossBar." }
                 check(!paused) { "TimedBossBar is already paused." }
-                val detached = detachTask()
-                paused = true
-                detached
+                detachTask().also { paused = true }
             }
         toCancel?.cancel()
     }
@@ -75,11 +77,7 @@ internal class TimedBossBarRuntime(
     }
 
     fun cancel() {
-        val shutdown =
-            lock.withLock {
-                if (!running) return
-                markStopped()
-            }
+        val shutdown = lock.withLock { if (running) markStopped() else null } ?: return
         finaliseShutdown(shutdown, config.onCancel)
     }
 
@@ -97,7 +95,7 @@ internal class TimedBossBarRuntime(
 
         audience.showBossBar(bar)
 
-        // If cancel/finish raced between track and show, undo the visible bar.
+        // If cancel/finish raced between track and show, undo the visible bar
         val stillTracked = lock.withLock { running && audience in viewers }
         if (!stillTracked) {
             audience.hideBossBar(bar)
@@ -132,9 +130,7 @@ internal class TimedBossBarRuntime(
 
     private fun detachTask(): TickerTask? {
         tickGeneration++
-        val current = task
-        task = null
-        return current
+        return task.also { task = null }
     }
 
     private fun onTick(generation: Int) {
@@ -151,16 +147,15 @@ internal class TimedBossBarRuntime(
     /**
      * Advances remaining time under [lock]. When the tick lands on [Duration.ZERO], atomically
      * marks the bar stopped and returns the [TimedBossBarShutdown] for outside-lock finalisation.
-     * Stale generations (detached tasks) are ignored.
+     * Stale generation (detached tasks) are ignored.
      */
     private fun advanceOrNull(generation: Int): TickOutcome? {
         if (!running || paused || generation != tickGeneration) return null
         remainingTime = (remainingTime - config.every).coerceAtLeast(Duration.ZERO)
         bar.progress(config.progress.at(remaining = remainingTime, over = config.over))
         updateNameIfChanged(remainingTime)
-        val remaining = remainingTime
-        val shutdown = if (remaining == Duration.ZERO) markStopped() else null
-        return TickOutcome(remaining = remaining, shutdown = shutdown)
+        val shutdown = if (remainingTime == Duration.ZERO) markStopped() else null
+        return TickOutcome(remaining = remainingTime, shutdown = shutdown)
     }
 
     private fun updateNameIfChanged(remaining: Duration) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/keybind/Keybind.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/keybind/Keybind.kt
@@ -3,7 +3,6 @@ package io.github.lmliam.kotventure.core.keybind
 import io.github.lmliam.kotventure.core.component.ComponentBuilder
 import io.github.lmliam.kotventure.core.component.ComponentScope
 import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.KeybindComponent
 
 /**
  * Builds a keybind [Component] — text the client renders as the player's current binding for a game action.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/Nbt.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/nbt/Nbt.kt
@@ -5,6 +5,10 @@ import net.kyori.adventure.nbt.api.BinaryTagHolder
 /**
  * Builds a [BinaryTagHolder] from compound DSL calls, rendering the compound to SNBT.
  *
+ * This package models **SNBT text** for selector arguments and NBT components — not a full binary
+ * NBT library or reimplementation of Adventure NBT types. Build compounds here, render to SNBT, and
+ * hand off at the [BinaryTagHolder] / selector edge.
+ *
  * @sample io.github.lmliam.kotventure.core.nbt.nbtSample
  */
 public fun nbt(init: NbtCompoundScope.() -> Unit): BinaryTagHolder {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectFallbackRenderer.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectFallbackRenderer.kt
@@ -4,12 +4,7 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ObjectComponent
 import net.kyori.adventure.text.renderer.TranslatableComponentRenderer
 
-/**
- * Renders object components to their fallback components where a fallback is configured.
- */
-public fun Component.renderObjectFallbacks(): Component = ObjectFallbackRenderer.render(this, Unit)
-
-private object ObjectFallbackRenderer : TranslatableComponentRenderer<Unit>() {
+internal object ObjectFallbackRenderer : TranslatableComponentRenderer<Unit>() {
     override fun renderObject(
         component: ObjectComponent,
         context: Unit,

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectFallbacks.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/objectcomponent/ObjectFallbacks.kt
@@ -1,0 +1,8 @@
+package io.github.lmliam.kotventure.core.objectcomponent
+
+import net.kyori.adventure.text.Component
+
+/**
+ * Renders object components to their fallback components where a fallback is configured.
+ */
+public fun Component.renderObjectFallbacks(): Component = ObjectFallbackRenderer.render(this, Unit)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/score/Score.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/score/Score.kt
@@ -3,7 +3,6 @@ package io.github.lmliam.kotventure.core.score
 import io.github.lmliam.kotventure.core.component.ComponentBuilder
 import io.github.lmliam.kotventure.core.component.ComponentScope
 import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.ScoreComponent
 
 /**
  * Builds a score [Component] — text the client resolves to a scoreboard value at display time.

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/CommonEntitySelectorScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/CommonEntitySelectorScope.kt
@@ -32,8 +32,7 @@ public sealed interface CommonEntitySelectorScope {
     /**
      * Sets selector origin coordinates (vanilla `x`, `y`, `z`): `origin(12.5.x, 64.y)`.
      *
-     * Each coordinate binds once across the whole selector. Additional coordinates override
-     * previous ones.
+     * Each coordinate binds at most once across the whole selector (fail fast; not last-write-wins).
      *
      * @throws IllegalStateException if a supplied coordinate is already set
      * @sample io.github.lmliam.kotventure.core.selector.selectorPositionVolumeSample
@@ -46,7 +45,7 @@ public sealed interface CommonEntitySelectorScope {
     /**
      * Sets selector bounding-volume deltas (vanilla `dx`, `dy`, `dz`): `volume(16.dx, 8.dy)`.
      *
-     * Each delta binds once across the whole selector. Additional deltas override previous ones.
+     * Each delta binds at most once across the whole selector (fail fast; not last-write-wins).
      *
      * @throws IllegalStateException if a supplied delta is already set
      * @sample io.github.lmliam.kotventure.core.selector.selectorPositionVolumeSample

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelector.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelector.kt
@@ -36,17 +36,10 @@ public data class EntitySelector private constructor(
 
     init {
         arguments.forEach(head::requireSupportFor)
-        val seenSingletons = mutableSetOf<String>()
-        val filterPolarity = mutableMapOf<String, FilterPolarityState>()
+        val occurrences = SelectorArgumentOccurrences()
         for (argument in arguments) {
-            val singletonKey = argument.singletonKey
-            if (singletonKey != null) {
-                require(seenSingletons.add(singletonKey)) {
-                    "Selector argument '$singletonKey' may only appear once (vanilla syntax allows a single occurrence)."
-                }
-                continue
-            }
-            requireValidFilterGroupEntry(argument, filterPolarity)
+            val violation = occurrences.recordName(argument.argumentName) ?: occurrences.recordFilter(argument)
+            if (violation != null) throw IllegalArgumentException(violation)
         }
     }
 
@@ -63,31 +56,4 @@ public data class EntitySelector private constructor(
         }
 
     public override fun toString(): String = asString()
-}
-
-/**
- * Running positive/negative flags for one filter-group argument name while validating a list.
- */
-private class FilterPolarityState {
-    var hasPositive: Boolean = false
-    var hasNegative: Boolean = false
-}
-
-/**
- * Applies shared exclusive/repeatable policy for one filter-group argument, updating [states].
- *
- * @throws IllegalArgumentException when exclusive policy is violated
- */
-private fun requireValidFilterGroupEntry(
-    argument: EntitySelectorArgument,
-    states: MutableMap<String, FilterPolarityState>,
-) {
-    val keyword = argument.keyword ?: return
-    val policy = keyword.filterPolicy ?: return
-    val name = keyword.sourceName
-    val state = states.getOrPut(name) { FilterPolarityState() }
-    val isExclusion = (argument as EntitySelectorArgument.Negatable).isFilterExclusion
-    val violation = policy.violationFor(name, state.hasPositive, state.hasNegative, isExclusion)
-    require(violation == null) { violation!! }
-    if (isExclusion) state.hasNegative = true else state.hasPositive = true
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelector.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelector.kt
@@ -42,7 +42,7 @@ public data class EntitySelector private constructor(
             val singletonKey = argument.singletonKey
             if (singletonKey != null) {
                 require(seenSingletons.add(singletonKey)) {
-                    selectorSingletonAlreadySetMessage(singletonKey)
+                    "Selector argument '$singletonKey' may only appear once (vanilla syntax allows a single occurrence)."
                 }
                 continue
             }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelector.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelector.kt
@@ -7,9 +7,16 @@ package io.github.lmliam.kotventure.core.selector
  * Construct through a typed target factory such as [entities], or validate selector source with
  * [parseSelector].
  *
+ * Package orientation: **heads** ([EntitySelectorHead] + factories) narrow a capability **scope**;
+ * [EntitySelectorBuilder] is the single mutable backend (singleton slots fail fast; filter groups
+ * enforce exclusive/repeatable policy); this type plus sealed [EntitySelectorArgument] form the
+ * immutable **model**; [parseSelector] and `parsing/` produce the same model from vanilla source;
+ * [asString] is the single **render** path for DSL and parse.
+ *
  * @property head selector head (determines which arguments are valid)
  * @property arguments arguments in source or DSL rendering order (immutable list)
- * @throws IllegalArgumentException if any argument is incompatible with [head]
+ * @throws IllegalArgumentException if any argument is incompatible with [head], or a singleton
+ *   argument name appears more than once
  */
 @ConsistentCopyVisibility
 public data class EntitySelector private constructor(
@@ -29,6 +36,13 @@ public data class EntitySelector private constructor(
     init {
         // Validate that each argument is supported by this selector head
         arguments.forEach(head::requireSupportFor)
+        val seenSingletons = mutableSetOf<String>()
+        for (argument in arguments) {
+            val key = argument.singletonKey ?: continue
+            require(seenSingletons.add(key)) {
+                "Selector argument '$key' is already set; vanilla syntax allows it only once."
+            }
+        }
     }
 
     /**

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelector.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelector.kt
@@ -15,8 +15,9 @@ package io.github.lmliam.kotventure.core.selector
  *
  * @property head selector head (determines which arguments are valid)
  * @property arguments arguments in source or DSL rendering order (immutable list)
- * @throws IllegalArgumentException if any argument is incompatible with [head], or a singleton
- *   argument name appears more than once
+ * @throws IllegalArgumentException if any argument is incompatible with [head], a singleton
+ *   argument name appears more than once, or an exclusive filter group
+ *   (`name`/`type`/`gamemode`/`team`) has two positives or mixes a positive with exclusions
  */
 @ConsistentCopyVisibility
 public data class EntitySelector private constructor(
@@ -34,14 +35,18 @@ public data class EntitySelector private constructor(
     ) : this(head, arguments.toList())
 
     init {
-        // Validate that each argument is supported by this selector head
         arguments.forEach(head::requireSupportFor)
         val seenSingletons = mutableSetOf<String>()
+        val filterPolarity = mutableMapOf<String, FilterPolarityState>()
         for (argument in arguments) {
-            val key = argument.singletonKey ?: continue
-            require(seenSingletons.add(key)) {
-                "Selector argument '$key' is already set; vanilla syntax allows it only once."
+            val singletonKey = argument.singletonKey
+            if (singletonKey != null) {
+                require(seenSingletons.add(singletonKey)) {
+                    selectorSingletonAlreadySetMessage(singletonKey)
+                }
+                continue
             }
+            requireValidFilterGroupEntry(argument, filterPolarity)
         }
     }
 
@@ -58,4 +63,31 @@ public data class EntitySelector private constructor(
         }
 
     public override fun toString(): String = asString()
+}
+
+/**
+ * Running positive/negative flags for one filter-group argument name while validating a list.
+ */
+private class FilterPolarityState {
+    var hasPositive: Boolean = false
+    var hasNegative: Boolean = false
+}
+
+/**
+ * Applies shared exclusive/repeatable policy for one filter-group argument, updating [states].
+ *
+ * @throws IllegalArgumentException when exclusive policy is violated
+ */
+private fun requireValidFilterGroupEntry(
+    argument: EntitySelectorArgument,
+    states: MutableMap<String, FilterPolarityState>,
+) {
+    val keyword = argument.keyword ?: return
+    val policy = keyword.filterPolicy ?: return
+    val name = keyword.sourceName
+    val state = states.getOrPut(name) { FilterPolarityState() }
+    val isExclusion = (argument as EntitySelectorArgument.Negatable).isFilterExclusion
+    val violation = policy.violationFor(name, state.hasPositive, state.hasNegative, isExclusion)
+    require(violation == null) { violation!! }
+    if (isExclusion) state.hasNegative = true else state.hasPositive = true
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelector.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelector.kt
@@ -4,20 +4,27 @@ package io.github.lmliam.kotventure.core.selector
  * An immutable, structured entity selector such as `@s`, `@p`, or
  * `@e[type=minecraft:armor_stand,limit=1]`.
  *
- * Construct through a typed target factory such as [entities], or validate selector source with
+ * Construct through a typed target factory such as [entities], or validate selector
+source with
  * [parseSelector].
  *
- * Package orientation: **heads** ([EntitySelectorHead] + factories) narrow a capability **scope**;
- * [EntitySelectorBuilder] is the single mutable backend (singleton slots fail fast; filter groups
- * enforce exclusive/repeatable policy); this type plus sealed [EntitySelectorArgument] form the
- * immutable **model**; [parseSelector] and `parsing/` produce the same model from vanilla source;
+ * Package orientation: **heads** ([EntitySelectorHead] + factories) narrow a capability
+ **scope**;
+ * [EntitySelectorBuilder] is the single mutable backend (singleton slots fail fast;
+filter groups
+ * enforce exclusive/repeatable policy); this type plus sealed [EntitySelectorArgument]
+form the
+ * immutable **model**; [parseSelector] and `parsing/` produce the same model from
+vanilla source;
  * [asString] is the single **render** path for DSL and parse.
  *
  * @property head selector head (determines which arguments are valid)
  * @property arguments arguments in source or DSL rendering order (immutable list)
- * @throws IllegalArgumentException if any argument is incompatible with [head], a singleton
+ * @throws IllegalArgumentException if any argument is incompatible with [head], a
+singleton
  *   argument name appears more than once, or an exclusive filter group
- *   (`name`/`type`/`gamemode`/`team`) has two positives or mixes a positive with exclusions
+ *   (`name`/`type`/`gamemode`/`team`) has two positives or mixes a positive with
+exclusions
  */
 @ConsistentCopyVisibility
 public data class EntitySelector private constructor(
@@ -37,16 +44,16 @@ public data class EntitySelector private constructor(
     init {
         arguments.forEach(head::requireSupportFor)
         val occurrences = SelectorArgumentOccurrences()
-        for (argument in arguments) {
-            val violation = occurrences.recordName(argument.argumentName) ?: occurrences.recordFilter(argument)
-            if (violation != null) throw IllegalArgumentException(violation)
-        }
+        arguments
+            .firstNotNullOfOrNull { occurrences.recordName(it.argumentName) ?: occurrences.recordFilter(it) }
+            ?.let { throw IllegalArgumentException(it) }
     }
 
     /**
      * Renders this selector as canonical entity-selector source text.
      *
-     * Produces `@<head>` for empty arguments, or `@<head>[arg1,arg2,...]` for non-empty.
+     * Produces `@<head>` for empty arguments, or `@<head>[arg1,arg2,...]` for
+    non-empty.
      */
     public fun asString(): String =
         if (arguments.isEmpty()) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentNames.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentNames.kt
@@ -38,3 +38,27 @@ internal val EntitySelectorArgument.argumentName: String
             is EntitySelectorArgument.Range -> argument.argumentName
             else -> checkNotNull(keyword) { "Keyword arguments always declare a keyword" }.sourceName
         }
+
+/**
+ * Key used for singleton uniqueness (DSL and parse). Filter-group arguments are multi-valued under
+ * [SelectorFilterPolicy] and return `null`.
+ */
+internal val EntitySelectorArgument.singletonKey: String?
+    get() =
+        when (this) {
+            is EntitySelectorArgument.Coordinate -> coordinate.argumentName
+            is EntitySelectorArgument.Range -> argument.argumentName
+            is EntitySelectorArgument.Level -> SelectorArgumentKeyword.LEVEL.sourceName
+            is EntitySelectorArgument.Limit -> SelectorArgumentKeyword.LIMIT.sourceName
+            is EntitySelectorArgument.Sort -> SelectorArgumentKeyword.SORT.sourceName
+            is EntitySelectorArgument.Scores -> SelectorArgumentKeyword.SCORES.sourceName
+            is EntitySelectorArgument.Advancements -> SelectorArgumentKeyword.ADVANCEMENTS.sourceName
+            is EntitySelectorArgument.GameMode,
+            is EntitySelectorArgument.Name,
+            is EntitySelectorArgument.Type,
+            is EntitySelectorArgument.Tag,
+            is EntitySelectorArgument.Team,
+            is EntitySelectorArgument.Nbt,
+            is EntitySelectorArgument.Predicate,
+            -> null
+        }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentNames.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentNames.kt
@@ -40,25 +40,28 @@ internal val EntitySelectorArgument.argumentName: String
         }
 
 /**
+ * Vanilla argument names that may appear at most once in a selector (coordinates, ranges, and
+ * non-filter-group keywords).
+ *
+ * Single source of truth for singleton policy: [EntitySelectorArgument.singletonKey] and the
+ * parser both consult this set so model validation and parse-time rejection cannot diverge.
+ */
+internal val singletonSelectorArgumentNames: Set<String> =
+    buildSet {
+        addAll(SelectorCoordinate.entries.map { it.argumentName })
+        addAll(SelectorRangeArgument.entries.map { it.argumentName })
+        add(SelectorArgumentKeyword.LIMIT.sourceName)
+        add(SelectorArgumentKeyword.SORT.sourceName)
+        add(SelectorArgumentKeyword.LEVEL.sourceName)
+        add(SelectorArgumentKeyword.SCORES.sourceName)
+        add(SelectorArgumentKeyword.ADVANCEMENTS.sourceName)
+    }
+
+/**
  * Key used for singleton uniqueness (DSL and parse). Filter-group arguments are multi-valued under
  * [SelectorFilterPolicy] and return `null`.
+ *
+ * Derived from [singletonSelectorArgumentNames] via [argumentName] — do not re-list singletons here.
  */
 internal val EntitySelectorArgument.singletonKey: String?
-    get() =
-        when (this) {
-            is EntitySelectorArgument.Coordinate -> coordinate.argumentName
-            is EntitySelectorArgument.Range -> argument.argumentName
-            is EntitySelectorArgument.Level -> SelectorArgumentKeyword.LEVEL.sourceName
-            is EntitySelectorArgument.Limit -> SelectorArgumentKeyword.LIMIT.sourceName
-            is EntitySelectorArgument.Sort -> SelectorArgumentKeyword.SORT.sourceName
-            is EntitySelectorArgument.Scores -> SelectorArgumentKeyword.SCORES.sourceName
-            is EntitySelectorArgument.Advancements -> SelectorArgumentKeyword.ADVANCEMENTS.sourceName
-            is EntitySelectorArgument.GameMode,
-            is EntitySelectorArgument.Name,
-            is EntitySelectorArgument.Type,
-            is EntitySelectorArgument.Tag,
-            is EntitySelectorArgument.Team,
-            is EntitySelectorArgument.Nbt,
-            is EntitySelectorArgument.Predicate,
-            -> null
-        }
+    get() = argumentName.takeIf { it in singletonSelectorArgumentNames }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentNames.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentNames.kt
@@ -65,11 +65,3 @@ internal val singletonSelectorArgumentNames: Set<String> =
  */
 internal val EntitySelectorArgument.singletonKey: String?
     get() = argumentName.takeIf { it in singletonSelectorArgumentNames }
-
-/**
- * Fail-fast message when a singleton selector argument appears more than once.
- *
- * Shared by the DSL builder, model constructor, and parser so wording stays identical.
- */
-internal fun selectorSingletonAlreadySetMessage(argument: String): String =
-    "Selector argument '$argument' may only appear once (vanilla syntax allows a single occurrence)."

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentNames.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentNames.kt
@@ -43,8 +43,8 @@ internal val EntitySelectorArgument.argumentName: String
  * Vanilla argument names that may appear at most once in a selector (coordinates, ranges, and
  * non-filter-group keywords).
  *
- * Single source of truth for singleton policy: [EntitySelectorArgument.singletonKey] and the
- * parser both consult this set so model validation and parse-time rejection cannot diverge.
+ * Single source of truth for singleton policy: [SelectorArgumentOccurrences] consults this set for
+ * both model validation and parse-time rejection, so the two cannot diverge.
  */
 internal val singletonSelectorArgumentNames: Set<String> =
     buildSet {
@@ -56,12 +56,3 @@ internal val singletonSelectorArgumentNames: Set<String> =
         add(SelectorArgumentKeyword.SCORES.sourceName)
         add(SelectorArgumentKeyword.ADVANCEMENTS.sourceName)
     }
-
-/**
- * Key used for singleton uniqueness (DSL and parse). Filter-group arguments are multi-valued under
- * [SelectorFilterPolicy] and return `null`.
- *
- * Derived from [singletonSelectorArgumentNames] via [argumentName] — do not re-list singletons here.
- */
-internal val EntitySelectorArgument.singletonKey: String?
-    get() = argumentName.takeIf { it in singletonSelectorArgumentNames }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentNames.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentNames.kt
@@ -65,3 +65,11 @@ internal val singletonSelectorArgumentNames: Set<String> =
  */
 internal val EntitySelectorArgument.singletonKey: String?
     get() = argumentName.takeIf { it in singletonSelectorArgumentNames }
+
+/**
+ * Fail-fast message when a singleton selector argument appears more than once.
+ *
+ * Shared by the DSL builder, model constructor, and parser so wording stays identical.
+ */
+internal fun selectorSingletonAlreadySetMessage(argument: String): String =
+    "Selector argument '$argument' may only appear once (vanilla syntax allows a single occurrence)."

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
@@ -1,5 +1,6 @@
 package io.github.lmliam.kotventure.core.selector
 
+import io.github.lmliam.kotventure.core.dsl.once
 import io.github.lmliam.kotventure.core.nbt.NbtCompound
 import io.github.lmliam.kotventure.core.nbt.NbtCompoundBuilder
 import io.github.lmliam.kotventure.core.nbt.NbtCompoundScope
@@ -10,17 +11,17 @@ import net.kyori.adventure.key.Key
  * compile-time: each factory narrows its lambda receiver to a capability scope.
  */
 internal class EntitySelectorBuilder : EntitySelectorScope {
-    var limit: Int? = null
+    var limit: Int? by once { alreadySet("limit") }
         private set
-    var distance: SelectorRange? = null
+    var distance: SelectorRange? by once { alreadySet("distance") }
         private set
-    var pitch: SelectorRange? = null
+    var pitch: SelectorRange? by once { alreadySet("pitch") }
         private set
-    var yaw: SelectorRange? = null
+    var yaw: SelectorRange? by once { alreadySet("yaw") }
         private set
-    var sort: SelectorSort? = null
+    var sort: SelectorSort? by once { alreadySet("sort") }
         private set
-    var level: SelectorIntRange? = null
+    var level: SelectorIntRange? by once { alreadySet("level") }
         private set
 
     val typeFilters = SelectorFilterGroup<String>("type", SelectorFilterPolicy.EXCLUSIVE)
@@ -34,10 +35,10 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     val coordinates: Map<SelectorCoordinate, Double>
         field = mutableMapOf()
 
-    var scores: Map<String, SelectorIntRange>? = null
+    var scores: Map<String, SelectorIntRange>? by once { alreadySet("scores") }
         private set
 
-    var advancements: Map<Key, AdvancementCondition>? = null
+    var advancements: Map<Key, AdvancementCondition>? by once { alreadySet("advancements") }
         private set
 
     private var isConfiguring = false
@@ -81,7 +82,6 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     }
 
     override fun distance(range: SelectorRange) {
-        checkUnset("distance", distance)
         distance = range.requireAscending("distance").requireNonNegative("distance")
     }
 
@@ -90,7 +90,6 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     }
 
     override fun pitch(range: SelectorRange) {
-        checkUnset("pitch", pitch)
         pitch = range
     }
 
@@ -99,7 +98,6 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     }
 
     override fun yaw(range: SelectorRange) {
-        checkUnset("yaw", yaw)
         yaw = range
     }
 
@@ -124,7 +122,6 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     override fun name(name: String): SelectorFilterExpression = nameFilters.add(this, name)
 
     override fun level(range: SelectorIntRange) {
-        checkUnset("level", level)
         level = range.requireNonNegative("level")
     }
 
@@ -133,12 +130,10 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     }
 
     override fun scores(init: SelectorScoresScope.() -> Unit) {
-        checkUnset("scores", scores)
         scores = SelectorScoresBuilder().apply(init).scores
     }
 
     override fun advancements(init: SelectorAdvancementsScope.() -> Unit) {
-        checkUnset("advancements", advancements)
         advancements = SelectorAdvancementsBuilder().apply(init).advancements
     }
 
@@ -152,12 +147,10 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
 
     override fun limit(n: Int) {
         require(n > 0) { "Selector limit must be positive, got: $n" }
-        checkUnset("limit", limit)
         limit = n
     }
 
     override fun sort(sort: SelectorSort) {
-        checkUnset("sort", this.sort)
         this.sort = sort
     }
 
@@ -199,7 +192,7 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
         argument: String,
         current: Any?,
     ) {
-        check(current == null) { "Selector argument '$argument' is already set; vanilla syntax allows it only once." }
+        check(current == null) { alreadySet(argument) }
     }
 
     private fun validTeamName(team: String): String {
@@ -212,6 +205,9 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
         return team
     }
 }
+
+private fun alreadySet(argument: String): String =
+    "Selector argument '$argument' is already set; vanilla syntax allows it only once."
 
 private val SelectorPresence.polarity: SelectorFilterPolarity
     get() =

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
@@ -182,19 +182,12 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     private fun bindCoordinates(bindings: List<Pair<SelectorCoordinate, Double>>) {
         val staged = mutableMapOf<SelectorCoordinate, Double>()
         bindings.forEach { (coordinate, value) ->
-            checkUnset(coordinate.argumentName, coordinates[coordinate] ?: staged[coordinate])
+            check(coordinate !in coordinates && coordinate !in staged) {
+                "Selector argument '${coordinate.argumentName}' may only appear once (vanilla syntax allows a single occurrence)."
+            }
             staged[coordinate] = value
         }
         coordinates += staged
-    }
-
-    private fun checkUnset(
-        argument: String,
-        current: Any?,
-    ) {
-        check(current == null) {
-            "Selector argument '$argument' may only appear once (vanilla syntax allows a single occurrence)."
-        }
     }
 
     private fun validTeamName(team: String): String {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
@@ -69,14 +69,14 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
 
     override fun origin(
         first: OriginCoordinate,
-        vararg rest: OriginCoordinate,
+        vararg rest: OriginCoordinate
     ) {
         bindCoordinates((listOf(first) + rest).map { it.coordinate to it.value })
     }
 
     override fun volume(
         first: VolumeDelta,
-        vararg rest: VolumeDelta,
+        vararg rest: VolumeDelta
     ) {
         bindCoordinates((listOf(first) + rest).map { it.coordinate to it.value })
     }
@@ -170,20 +170,22 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     }
 
     private fun validateFilters() {
-        typeFilters.validate()
-        nameFilters.validate()
-        gamemodeFilters.validate()
-        teamFilters.validate()
-        tagFilters.validate()
-        nbtFilters.validate()
-        predicateFilters.validate()
+        setOf(
+            typeFilters,
+            nameFilters,
+            gamemodeFilters,
+            teamFilters,
+            tagFilters,
+            nbtFilters,
+            predicateFilters,
+        ).forEach { it.validate() }
     }
 
     private fun bindCoordinates(bindings: List<Pair<SelectorCoordinate, Double>>) {
         val staged = mutableMapOf<SelectorCoordinate, Double>()
         bindings.forEach { (coordinate, value) ->
             check(coordinate !in coordinates && coordinate !in staged) {
-                "Selector argument '${coordinate.argumentName}' may only appear once (vanilla syntax allows a single occurrence)."
+                "Selector argument '${coordinate.argumentName}' may only appear once."
             }
             staged[coordinate] = value
         }
@@ -191,9 +193,9 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     }
 
     private fun validTeamName(team: String): String {
-        require(
-            team.isNotEmpty(),
-        ) { "Team name must not be empty; use team(none) or team(any) to filter by team presence." }
+        require(team.isNotEmpty()) {
+            "Team name must not be empty; use team(none) or team(any) to filter by team presence."
+        }
         require(team.all { it.isAllowedInUnquotedSelectorToken() }) {
             "Team name '$team' contains characters outside vanilla's unquoted-token syntax."
         }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
@@ -24,13 +24,13 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     var level: SelectorIntRange? by once { alreadySet("level") }
         private set
 
-    val typeFilters = SelectorFilterGroup<String>("type", SelectorFilterPolicy.EXCLUSIVE)
-    val nameFilters = SelectorFilterGroup<String>("name", SelectorFilterPolicy.EXCLUSIVE)
-    val gamemodeFilters = SelectorFilterGroup<GameMode>("gamemode", SelectorFilterPolicy.EXCLUSIVE)
-    val teamFilters = SelectorFilterGroup<String>("team", SelectorFilterPolicy.EXCLUSIVE)
-    val tagFilters = SelectorFilterGroup<String>("tag", SelectorFilterPolicy.REPEATABLE)
-    val nbtFilters = SelectorFilterGroup<NbtCompound>("nbt", SelectorFilterPolicy.REPEATABLE)
-    val predicateFilters = SelectorFilterGroup<String>("predicate", SelectorFilterPolicy.REPEATABLE)
+    val typeFilters = SelectorFilterGroup<String>(SelectorArgumentKeyword.TYPE)
+    val nameFilters = SelectorFilterGroup<String>(SelectorArgumentKeyword.NAME)
+    val gamemodeFilters = SelectorFilterGroup<GameMode>(SelectorArgumentKeyword.GAMEMODE)
+    val teamFilters = SelectorFilterGroup<String>(SelectorArgumentKeyword.TEAM)
+    val tagFilters = SelectorFilterGroup<String>(SelectorArgumentKeyword.TAG)
+    val nbtFilters = SelectorFilterGroup<NbtCompound>(SelectorArgumentKeyword.NBT)
+    val predicateFilters = SelectorFilterGroup<String>(SelectorArgumentKeyword.PREDICATE)
 
     val coordinates: Map<SelectorCoordinate, Double>
         field = mutableMapOf()
@@ -206,8 +206,7 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     }
 }
 
-private fun alreadySet(argument: String): String =
-    "Selector argument '$argument' is already set; vanilla syntax allows it only once."
+private fun alreadySet(argument: String): String = selectorSingletonAlreadySetMessage(argument)
 
 private val SelectorPresence.polarity: SelectorFilterPolarity
     get() =

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
@@ -69,14 +69,14 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
 
     override fun origin(
         first: OriginCoordinate,
-        vararg rest: OriginCoordinate
+        vararg rest: OriginCoordinate,
     ) {
         bindCoordinates((listOf(first) + rest).map { it.coordinate to it.value })
     }
 
     override fun volume(
         first: VolumeDelta,
-        vararg rest: VolumeDelta
+        vararg rest: VolumeDelta,
     ) {
         bindCoordinates((listOf(first) + rest).map { it.coordinate to it.value })
     }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
@@ -11,17 +11,17 @@ import net.kyori.adventure.key.Key
  * compile-time: each factory narrows its lambda receiver to a capability scope.
  */
 internal class EntitySelectorBuilder : EntitySelectorScope {
-    var limit: Int? by once { alreadySet("limit") }
+    var limit: Int? by once()
         private set
-    var distance: SelectorRange? by once { alreadySet("distance") }
+    var distance: SelectorRange? by once()
         private set
-    var pitch: SelectorRange? by once { alreadySet("pitch") }
+    var pitch: SelectorRange? by once()
         private set
-    var yaw: SelectorRange? by once { alreadySet("yaw") }
+    var yaw: SelectorRange? by once()
         private set
-    var sort: SelectorSort? by once { alreadySet("sort") }
+    var sort: SelectorSort? by once()
         private set
-    var level: SelectorIntRange? by once { alreadySet("level") }
+    var level: SelectorIntRange? by once()
         private set
 
     val typeFilters = SelectorFilterGroup<String>(SelectorArgumentKeyword.TYPE)
@@ -35,10 +35,10 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     val coordinates: Map<SelectorCoordinate, Double>
         field = mutableMapOf()
 
-    var scores: Map<String, SelectorIntRange>? by once { alreadySet("scores") }
+    var scores: Map<String, SelectorIntRange>? by once()
         private set
 
-    var advancements: Map<Key, AdvancementCondition>? by once { alreadySet("advancements") }
+    var advancements: Map<Key, AdvancementCondition>? by once()
         private set
 
     private var isConfiguring = false
@@ -192,7 +192,9 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
         argument: String,
         current: Any?,
     ) {
-        check(current == null) { alreadySet(argument) }
+        check(current == null) {
+            "Selector argument '$argument' may only appear once (vanilla syntax allows a single occurrence)."
+        }
     }
 
     private fun validTeamName(team: String): String {
@@ -205,8 +207,6 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
         return team
     }
 }
-
-private fun alreadySet(argument: String): String = selectorSingletonAlreadySetMessage(argument)
 
 private val SelectorPresence.polarity: SelectorFilterPolarity
     get() =

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
@@ -55,7 +55,10 @@ private fun SelectorReader.readSelectorArgument(
     val name = readWhile { it != '=' && it != ',' && it != ']' }
     if (name.isEmpty()) failAt(nameOffset, "Expected selector argument")
     if (name in singletonSelectorArgumentNames && !seenSingletons.add(name)) {
-        failAt(nameOffset, selectorSingletonAlreadySetMessage(name))
+        failAt(
+            nameOffset,
+            "Selector argument '$name' may only appear once (vanilla syntax allows a single occurrence).",
+        )
     }
     expect('=', "Expected '=' after selector argument '$name'")
     val argument = readArgumentValue(head, name, nameOffset)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
@@ -33,10 +33,9 @@ private fun SelectorReader.readSelectorArguments(head: EntitySelectorHead): List
     if (consume(']')) return emptyList()
 
     return buildList {
-        val seenSingletons = mutableSetOf<String>()
-        val filterPolarity = mutableMapOf<String, ParseFilterPolarityState>()
+        val occurrences = SelectorArgumentOccurrences()
         while (true) {
-            add(readSelectorArgument(head, seenSingletons, filterPolarity))
+            add(readSelectorArgument(head, occurrences))
             when {
                 consume(']') -> return@buildList
                 consume(',') -> if (peek() == ']') fail("Expected selector argument")
@@ -48,44 +47,14 @@ private fun SelectorReader.readSelectorArguments(head: EntitySelectorHead): List
 
 private fun SelectorReader.readSelectorArgument(
     head: EntitySelectorHead,
-    seenSingletons: MutableSet<String>,
-    filterPolarity: MutableMap<String, ParseFilterPolarityState>,
+    occurrences: SelectorArgumentOccurrences,
 ): EntitySelectorArgument {
     val nameOffset = offset
     val name = readWhile { it != '=' && it != ',' && it != ']' }
     if (name.isEmpty()) failAt(nameOffset, "Expected selector argument")
-    if (name in singletonSelectorArgumentNames && !seenSingletons.add(name)) {
-        failAt(
-            nameOffset,
-            "Selector argument '$name' may only appear once (vanilla syntax allows a single occurrence).",
-        )
-    }
+    occurrences.recordName(name)?.let { failAt(nameOffset, it) }
     expect('=', "Expected '=' after selector argument '$name'")
     val argument = readArgumentValue(head, name, nameOffset)
-    enforceFilterGroupPolicy(argument, name, nameOffset, filterPolarity)
+    occurrences.recordFilter(argument)?.let { failAt(nameOffset, it) }
     return argument
-}
-
-/**
- * Rejects exclusive filter-group violations at the offending argument name offset, using the same
- * policy and messages as [EntitySelector] / [SelectorFilterGroup].
- */
-private fun SelectorReader.enforceFilterGroupPolicy(
-    argument: EntitySelectorArgument,
-    name: String,
-    nameOffset: Int,
-    filterPolarity: MutableMap<String, ParseFilterPolarityState>,
-) {
-    val keyword = argument.keyword ?: return
-    val policy = keyword.filterPolicy ?: return
-    val state = filterPolarity.getOrPut(name) { ParseFilterPolarityState() }
-    val isExclusion = (argument as EntitySelectorArgument.Negatable).isFilterExclusion
-    val violation = policy.violationFor(name, state.hasPositive, state.hasNegative, isExclusion)
-    if (violation != null) failAt(nameOffset, violation)
-    if (isExclusion) state.hasNegative = true else state.hasPositive = true
-}
-
-private class ParseFilterPolarityState {
-    var hasPositive: Boolean = false
-    var hasNegative: Boolean = false
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
@@ -35,8 +35,9 @@ private fun SelectorReader.readSelectorArguments(head: EntitySelectorHead): List
     if (consume(']')) return emptyList()
 
     return buildList {
+        val seenSingletons = mutableSetOf<String>()
         while (true) {
-            add(readSelectorArgument(head))
+            add(readSelectorArgument(head, seenSingletons))
             when {
                 consume(']') -> return@buildList
                 consume(',') -> if (peek() == ']') fail("Expected selector argument")
@@ -46,10 +47,39 @@ private fun SelectorReader.readSelectorArguments(head: EntitySelectorHead): List
     }
 }
 
-private fun SelectorReader.readSelectorArgument(head: EntitySelectorHead): EntitySelectorArgument {
+private fun SelectorReader.readSelectorArgument(
+    head: EntitySelectorHead,
+    seenSingletons: MutableSet<String>,
+): EntitySelectorArgument {
     val nameOffset = offset
     val name = readWhile { it != '=' && it != ',' && it != ']' }
     if (name.isEmpty()) failAt(nameOffset, "Expected selector argument")
+    if (name.isSingletonSelectorArgument() && !seenSingletons.add(name)) {
+        failAt(
+            nameOffset,
+            "Selector argument '$name' is already set; vanilla syntax allows it only once.",
+        )
+    }
     expect('=', "Expected '=' after selector argument '$name'")
     return readArgumentValue(head, name, nameOffset)
 }
+
+private fun String.isSingletonSelectorArgument(): Boolean =
+    when (this) {
+        "limit",
+        "sort",
+        "level",
+        "scores",
+        "advancements",
+        "distance",
+        "x_rotation",
+        "y_rotation",
+        "x",
+        "y",
+        "z",
+        "dx",
+        "dy",
+        "dz",
+        -> true
+        else -> false
+    }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
@@ -65,14 +65,3 @@ private fun SelectorReader.readSelectorArgument(
 }
 
 private fun String.isSingletonSelectorArgument(): Boolean = this in singletonSelectorArgumentNames
-
-private val singletonSelectorArgumentNames: Set<String> =
-    buildSet {
-        addAll(SelectorCoordinate.entries.map { it.argumentName })
-        addAll(SelectorRangeArgument.entries.map { it.argumentName })
-        add(SelectorArgumentKeyword.LIMIT.sourceName)
-        add(SelectorArgumentKeyword.SORT.sourceName)
-        add(SelectorArgumentKeyword.LEVEL.sourceName)
-        add(SelectorArgumentKeyword.SCORES.sourceName)
-        add(SelectorArgumentKeyword.ADVANCEMENTS.sourceName)
-    }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
@@ -2,6 +2,7 @@ package io.github.lmliam.kotventure.core.selector
 
 import io.github.lmliam.kotventure.core.selector.parsing.SelectorReader
 import io.github.lmliam.kotventure.core.selector.parsing.readArgumentValue
+import io.github.lmliam.kotventure.core.selector.readSelectorArgument
 
 /**
  * Parses Java Edition entity-selector source into an [EntitySelector].
@@ -50,7 +51,7 @@ private fun SelectorReader.readSelectorArgument(
     occurrences: SelectorArgumentOccurrences,
 ): EntitySelectorArgument {
     val nameOffset = offset
-    val name = readWhile { it != '=' && it != ',' && it != ']' }
+    val name = readWhile { it !in "=,]" }
     if (name.isEmpty()) failAt(nameOffset, "Expected selector argument")
     occurrences.recordName(name)?.let { failAt(nameOffset, it) }
     expect('=', "Expected '=' after selector argument '$name'")

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
@@ -2,8 +2,6 @@ package io.github.lmliam.kotventure.core.selector
 
 import io.github.lmliam.kotventure.core.selector.parsing.SelectorReader
 import io.github.lmliam.kotventure.core.selector.parsing.readArgumentValue
-import io.github.lmliam.kotventure.core.selector.readSelectorArgument
-import io.github.lmliam.kotventure.core.selector.readSelectorArguments
 
 /**
  * Parses Java Edition entity-selector source into an [EntitySelector].
@@ -36,8 +34,9 @@ private fun SelectorReader.readSelectorArguments(head: EntitySelectorHead): List
 
     return buildList {
         val seenSingletons = mutableSetOf<String>()
+        val filterPolarity = mutableMapOf<String, ParseFilterPolarityState>()
         while (true) {
-            add(readSelectorArgument(head, seenSingletons))
+            add(readSelectorArgument(head, seenSingletons, filterPolarity))
             when {
                 consume(']') -> return@buildList
                 consume(',') -> if (peek() == ']') fail("Expected selector argument")
@@ -50,18 +49,40 @@ private fun SelectorReader.readSelectorArguments(head: EntitySelectorHead): List
 private fun SelectorReader.readSelectorArgument(
     head: EntitySelectorHead,
     seenSingletons: MutableSet<String>,
+    filterPolarity: MutableMap<String, ParseFilterPolarityState>,
 ): EntitySelectorArgument {
     val nameOffset = offset
     val name = readWhile { it != '=' && it != ',' && it != ']' }
     if (name.isEmpty()) failAt(nameOffset, "Expected selector argument")
-    if (name.isSingletonSelectorArgument() && !seenSingletons.add(name)) {
-        failAt(
-            nameOffset,
-            "Selector argument '$name' is already set; vanilla syntax allows it only once.",
-        )
+    if (name in singletonSelectorArgumentNames && !seenSingletons.add(name)) {
+        failAt(nameOffset, selectorSingletonAlreadySetMessage(name))
     }
     expect('=', "Expected '=' after selector argument '$name'")
-    return readArgumentValue(head, name, nameOffset)
+    val argument = readArgumentValue(head, name, nameOffset)
+    enforceFilterGroupPolicy(argument, name, nameOffset, filterPolarity)
+    return argument
 }
 
-private fun String.isSingletonSelectorArgument(): Boolean = this in singletonSelectorArgumentNames
+/**
+ * Rejects exclusive filter-group violations at the offending argument name offset, using the same
+ * policy and messages as [EntitySelector] / [SelectorFilterGroup].
+ */
+private fun SelectorReader.enforceFilterGroupPolicy(
+    argument: EntitySelectorArgument,
+    name: String,
+    nameOffset: Int,
+    filterPolarity: MutableMap<String, ParseFilterPolarityState>,
+) {
+    val keyword = argument.keyword ?: return
+    val policy = keyword.filterPolicy ?: return
+    val state = filterPolarity.getOrPut(name) { ParseFilterPolarityState() }
+    val isExclusion = (argument as EntitySelectorArgument.Negatable).isFilterExclusion
+    val violation = policy.violationFor(name, state.hasPositive, state.hasNegative, isExclusion)
+    if (violation != null) failAt(nameOffset, violation)
+    if (isExclusion) state.hasNegative = true else state.hasPositive = true
+}
+
+private class ParseFilterPolarityState {
+    var hasPositive: Boolean = false
+    var hasNegative: Boolean = false
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
@@ -64,22 +64,15 @@ private fun SelectorReader.readSelectorArgument(
     return readArgumentValue(head, name, nameOffset)
 }
 
-private fun String.isSingletonSelectorArgument(): Boolean =
-    when (this) {
-        "limit",
-        "sort",
-        "level",
-        "scores",
-        "advancements",
-        "distance",
-        "x_rotation",
-        "y_rotation",
-        "x",
-        "y",
-        "z",
-        "dx",
-        "dy",
-        "dz",
-        -> true
-        else -> false
+private fun String.isSingletonSelectorArgument(): Boolean = this in singletonSelectorArgumentNames
+
+private val singletonSelectorArgumentNames: Set<String> =
+    buildSet {
+        addAll(SelectorCoordinate.entries.map { it.argumentName })
+        addAll(SelectorRangeArgument.entries.map { it.argumentName })
+        add(SelectorArgumentKeyword.LIMIT.sourceName)
+        add(SelectorArgumentKeyword.SORT.sourceName)
+        add(SelectorArgumentKeyword.LEVEL.sourceName)
+        add(SelectorArgumentKeyword.SCORES.sourceName)
+        add(SelectorArgumentKeyword.ADVANCEMENTS.sourceName)
     }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorArgumentOccurrences.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorArgumentOccurrences.kt
@@ -1,0 +1,45 @@
+package io.github.lmliam.kotventure.core.selector
+
+/**
+ * Records selector-argument occurrences and reports the first multiplicity violation: singleton
+ * arguments ([singletonSelectorArgumentNames]) may appear only once, and an exclusive filter group
+ * allows one positive value that cannot be mixed with exclusions.
+ *
+ * The single validation behind [EntitySelector]'s constructor and the parser (which surfaces the
+ * returned message at the offending argument's source offset). [SelectorFilterGroup] cannot share
+ * it: DSL polarity is only final when the block ends (`!` negates an entry after it is added), so
+ * the builder validates in two phases instead.
+ */
+internal class SelectorArgumentOccurrences {
+    private val singletons = mutableSetOf<String>()
+    private val positives = mutableSetOf<String>()
+    private val negatives = mutableSetOf<String>()
+
+    /** Records one occurrence of [name], returning the violation for a repeated singleton. */
+    fun recordName(name: String): String? {
+        if (name !in singletonSelectorArgumentNames || singletons.add(name)) return null
+        return "Selector argument '$name' may only appear once (vanilla syntax allows a single occurrence)."
+    }
+
+    /**
+     * Records [argument]'s filter polarity, returning the violation for an exclusive-policy
+     * breach. Singleton and [SelectorFilterPolicy.REPEATABLE] arguments are never violations.
+     */
+    fun recordFilter(argument: EntitySelectorArgument): String? {
+        val keyword = argument.keyword ?: return null
+        if (keyword.filterPolicy != SelectorFilterPolicy.EXCLUSIVE) return null
+
+        val name = keyword.sourceName
+        val isExclusion = (argument as EntitySelectorArgument.Negatable).isFilterExclusion
+        return when {
+            name in positives ->
+                "Selector argument '$name' is already set; vanilla syntax allows one positive value."
+            !isExclusion && name in negatives ->
+                "Selector argument '$name' cannot combine a positive value with exclusions."
+            else -> {
+                if (isExclusion) negatives += name else positives += name
+                null
+            }
+        }
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorArgumentOccurrences.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorArgumentOccurrences.kt
@@ -1,25 +1,33 @@
 package io.github.lmliam.kotventure.core.selector
 
 /**
- * Records selector-argument occurrences and reports the first multiplicity violation: singleton
- * arguments ([singletonSelectorArgumentNames]) may appear only once, and an exclusive filter group
+ * Records selector-argument occurrences and reports the first multiplicity violation:
+singleton
+ * arguments ([singletonSelectorArgumentNames]) may appear only once, and an exclusive
+filter group
  * allows one positive value that cannot be mixed with exclusions.
  *
- * The single validation behind [EntitySelector]'s constructor and the parser (which surfaces the
- * returned message at the offending argument's source offset). [SelectorFilterGroup] cannot share
- * it: DSL polarity is only final when the block ends (`!` negates an entry after it is added), so
- * the builder validates in two phases instead.
+ * This is the single validation behind [EntitySelector]'s constructor and the parser,
+which
+ * surfaces the returned message at the offending argument's source offset.
+[SelectorFilterGroup]
+ * cannot share it: DSL polarity is only final when the block ends (`!` negates an entry
+after it
+ * is added), so the builder validates in two phases instead.
  */
 internal class SelectorArgumentOccurrences {
     private val singletons = mutableSetOf<String>()
-    private val positives = mutableSetOf<String>()
-    private val negatives = mutableSetOf<String>()
+
+    /** Per-name polarity of an exclusive filter group: [SelectorFilterPolarity.NEGATIVE] once any exclusion is recorded. */
+    private val exclusivePolarities = mutableMapOf<String, SelectorFilterPolarity>()
 
     /** Records one occurrence of [name], returning the violation for a repeated singleton. */
-    fun recordName(name: String): String? {
-        if (name !in singletonSelectorArgumentNames || singletons.add(name)) return null
-        return "Selector argument '$name' may only appear once (vanilla syntax allows a single occurrence)."
-    }
+    fun recordName(name: String): String? =
+        when {
+            name !in singletonSelectorArgumentNames -> null
+            singletons.add(name) -> null
+            else -> "Selector argument '$name' may only appear once."
+        }
 
     /**
      * Records [argument]'s filter polarity, returning the violation for an exclusive-policy
@@ -31,13 +39,17 @@ internal class SelectorArgumentOccurrences {
 
         val name = keyword.sourceName
         val isExclusion = (argument as EntitySelectorArgument.Negatable).isFilterExclusion
-        return when {
-            name in positives ->
-                "Selector argument '$name' is already set; vanilla syntax allows one positive value."
-            !isExclusion && name in negatives ->
-                "Selector argument '$name' cannot combine a positive value with exclusions."
-            else -> {
-                if (isExclusion) negatives += name else positives += name
+
+        return when (exclusivePolarities[name]) {
+            SelectorFilterPolarity.POSITIVE ->
+                "Selector argument '$name' is already set."
+
+            SelectorFilterPolarity.NEGATIVE ->
+                if (isExclusion) null else "Selector argument '$name' cannot combine a positive value with exclusions."
+
+            null -> {
+                exclusivePolarities[name] =
+                    if (isExclusion) SelectorFilterPolarity.NEGATIVE else SelectorFilterPolarity.POSITIVE
                 null
             }
         }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorComponentBuilder.kt
@@ -12,10 +12,11 @@ internal class SelectorComponentBuilder(
     pattern: String,
 ) : ComponentBuilder<SelectorComponent, SelectorComponent.Builder>(Component.selector().pattern(pattern)),
     SelectorScope {
-    private var separator: ComponentLike? by once()
+    // once() guard only; the Adventure builder holds the value
+    private var separator: Unit? by once()
 
     override fun separator(separator: ComponentLike) {
-        this.separator = separator
+        this.separator = Unit
         builder.separator(separator)
     }
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorComponentBuilder.kt
@@ -12,7 +12,6 @@ internal class SelectorComponentBuilder(
     pattern: String,
 ) : ComponentBuilder<SelectorComponent, SelectorComponent.Builder>(Component.selector().pattern(pattern)),
     SelectorScope {
-    // once() guard only; the Adventure builder holds the value
     private var separator: Unit? by once()
 
     override fun separator(separator: ComponentLike) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorComponentBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorComponentBuilder.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.kotventure.core.selector
 
 import io.github.lmliam.kotventure.core.component.ComponentBuilder
+import io.github.lmliam.kotventure.core.dsl.once
 import io.github.lmliam.kotventure.core.text.TextScope
 import io.github.lmliam.kotventure.core.text.buildTextComponent
 import net.kyori.adventure.text.Component
@@ -11,11 +12,14 @@ internal class SelectorComponentBuilder(
     pattern: String,
 ) : ComponentBuilder<SelectorComponent, SelectorComponent.Builder>(Component.selector().pattern(pattern)),
     SelectorScope {
+    private var separator: ComponentLike? by once()
+
     override fun separator(separator: ComponentLike) {
+        this.separator = separator
         builder.separator(separator)
     }
 
     override fun separator(init: TextScope.() -> Unit) {
-        builder.separator(buildTextComponent(init))
+        separator(buildTextComponent(init))
     }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterGroup.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterGroup.kt
@@ -3,16 +3,20 @@ package io.github.lmliam.kotventure.core.selector
 /**
  * The entries of one selector argument, in call order.
  *
- * A statement's polarity is final once it completes (`!` applies before the next statement runs),
- * so an exclusive group can reject any addition after a positive entry at the offending call site.
- * The one violation only visible later — exclusions followed by a positive that never gets
+ * A statement's polarity is final once it completes (`!` applies before the next
+statement runs),
+ * so an exclusive group can reject any addition after a positive entry at the offending
+call site.
+ * The one violation only visible later — exclusions followed by a positive that never
+gets
  * negated — is caught by [validate] when the selector block ends.
  *
- * Policy is resolved from [keyword] via [SelectorArgumentKeyword.filterPolicy] so the builder
+ * Policy is resolved from [keyword] via [SelectorArgumentKeyword.filterPolicy] so the
+builder
  * cannot drift from model/parse validation.
  */
 internal class SelectorFilterGroup<T>(
-    keyword: SelectorArgumentKeyword,
+    keyword: SelectorArgumentKeyword
 ) {
     val argument: String = keyword.sourceName
     private val policy: SelectorFilterPolicy =
@@ -25,19 +29,26 @@ internal class SelectorFilterGroup<T>(
 
     fun add(
         owner: EntitySelectorBuilder,
-        value: T,
+        value: T
     ): SelectorFilterExpression = addEntry(owner, value, SelectorFilterPolarity.POSITIVE)
 
+    /**
+     * Adds [value] with a caller-fixed [polarity], returning nothing negatable:
+    presence filters
+     * (`tag(any)`, `team(none)`) already encode their polarity in the value, so `!`
+    must not be
+     * able to flip them again.
+     */
     fun addFixed(
         owner: EntitySelectorBuilder,
         value: T,
-        polarity: SelectorFilterPolarity,
+        polarity: SelectorFilterPolarity
     ) {
         addEntry(owner, value, polarity)
     }
 
     fun validate() {
-        if (policy == SelectorFilterPolicy.REPEATABLE) return
+        if (policy != SelectorFilterPolicy.EXCLUSIVE) return
 
         val hasPositive = entries.any { it.polarity == SelectorFilterPolarity.POSITIVE }
         val hasNegative = entries.any { it.polarity == SelectorFilterPolarity.NEGATIVE }
@@ -49,11 +60,11 @@ internal class SelectorFilterGroup<T>(
     private fun addEntry(
         owner: EntitySelectorBuilder,
         value: T,
-        polarity: SelectorFilterPolarity,
+        polarity: SelectorFilterPolarity
     ): SelectorFilterEntry<T> {
         if (policy == SelectorFilterPolicy.EXCLUSIVE) {
             check(entries.none { it.polarity == SelectorFilterPolarity.POSITIVE }) {
-                "Selector argument '$argument' is already set; vanilla syntax allows one positive value."
+                "Selector argument '$argument' is already set."
             }
         }
         return SelectorFilterEntry(owner, argument, value, polarity).also {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterGroup.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterGroup.kt
@@ -42,7 +42,7 @@ internal class SelectorFilterGroup<T>(
         val hasPositive = entries.any { it.polarity == SelectorFilterPolarity.POSITIVE }
         val hasNegative = entries.any { it.polarity == SelectorFilterPolarity.NEGATIVE }
         check(!(hasPositive && hasNegative)) {
-            exclusivePolarityMixMessage(argument)
+            "Selector argument '$argument' cannot combine a positive value with exclusions."
         }
     }
 
@@ -53,7 +53,7 @@ internal class SelectorFilterGroup<T>(
     ): SelectorFilterEntry<T> {
         if (policy == SelectorFilterPolicy.EXCLUSIVE) {
             check(entries.none { it.polarity == SelectorFilterPolarity.POSITIVE }) {
-                exclusivePositiveAlreadySetMessage(argument)
+                "Selector argument '$argument' is already set; vanilla syntax allows one positive value."
             }
         }
         return SelectorFilterEntry(owner, argument, value, polarity).also {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterGroup.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterGroup.kt
@@ -16,7 +16,7 @@ builder
  * cannot drift from model/parse validation.
  */
 internal class SelectorFilterGroup<T>(
-    keyword: SelectorArgumentKeyword
+    keyword: SelectorArgumentKeyword,
 ) {
     val argument: String = keyword.sourceName
     private val policy: SelectorFilterPolicy =
@@ -29,7 +29,7 @@ internal class SelectorFilterGroup<T>(
 
     fun add(
         owner: EntitySelectorBuilder,
-        value: T
+        value: T,
     ): SelectorFilterExpression = addEntry(owner, value, SelectorFilterPolarity.POSITIVE)
 
     /**
@@ -42,7 +42,7 @@ internal class SelectorFilterGroup<T>(
     fun addFixed(
         owner: EntitySelectorBuilder,
         value: T,
-        polarity: SelectorFilterPolarity
+        polarity: SelectorFilterPolarity,
     ) {
         addEntry(owner, value, polarity)
     }
@@ -60,7 +60,7 @@ internal class SelectorFilterGroup<T>(
     private fun addEntry(
         owner: EntitySelectorBuilder,
         value: T,
-        polarity: SelectorFilterPolarity
+        polarity: SelectorFilterPolarity,
     ): SelectorFilterEntry<T> {
         if (policy == SelectorFilterPolicy.EXCLUSIVE) {
             check(entries.none { it.polarity == SelectorFilterPolarity.POSITIVE }) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterGroup.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterGroup.kt
@@ -7,11 +7,19 @@ package io.github.lmliam.kotventure.core.selector
  * so an exclusive group can reject any addition after a positive entry at the offending call site.
  * The one violation only visible later — exclusions followed by a positive that never gets
  * negated — is caught by [validate] when the selector block ends.
+ *
+ * Policy is resolved from [keyword] via [SelectorArgumentKeyword.filterPolicy] so the builder
+ * cannot drift from model/parse validation.
  */
 internal class SelectorFilterGroup<T>(
-    val argument: String,
-    private val policy: SelectorFilterPolicy,
+    keyword: SelectorArgumentKeyword,
 ) {
+    val argument: String = keyword.sourceName
+    private val policy: SelectorFilterPolicy =
+        requireNotNull(keyword.filterPolicy) {
+            "Selector argument '${keyword.sourceName}' is not a filter group"
+        }
+
     val entries: List<SelectorFilterEntry<T>>
         field = mutableListOf()
 
@@ -34,7 +42,7 @@ internal class SelectorFilterGroup<T>(
         val hasPositive = entries.any { it.polarity == SelectorFilterPolarity.POSITIVE }
         val hasNegative = entries.any { it.polarity == SelectorFilterPolarity.NEGATIVE }
         check(!(hasPositive && hasNegative)) {
-            "Selector argument '$argument' cannot combine a positive value with exclusions."
+            exclusivePolarityMixMessage(argument)
         }
     }
 
@@ -45,7 +53,7 @@ internal class SelectorFilterGroup<T>(
     ): SelectorFilterEntry<T> {
         if (policy == SelectorFilterPolicy.EXCLUSIVE) {
             check(entries.none { it.polarity == SelectorFilterPolarity.POSITIVE }) {
-                "Selector argument '$argument' is already set; vanilla syntax allows one positive value."
+                exclusivePositiveAlreadySetMessage(argument)
             }
         }
         return SelectorFilterEntry(owner, argument, value, polarity).also {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterPolicy.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterPolicy.kt
@@ -44,20 +44,6 @@ internal val SelectorArgumentKeyword.filterPolicy: SelectorFilterPolicy?
         }
 
 /**
- * Error when an exclusive group already holds a positive and another entry is attempted.
- *
- * Used by the DSL (positive already committed), the model, and the parser.
- */
-internal fun exclusivePositiveAlreadySetMessage(argument: String): String =
-    "Selector argument '$argument' is already set; vanilla syntax allows one positive value."
-
-/**
- * Error when an exclusive group mixes a positive value with exclusions.
- */
-internal fun exclusivePolarityMixMessage(argument: String): String =
-    "Selector argument '$argument' cannot combine a positive value with exclusions."
-
-/**
  * Returns an exclusive-policy violation message for recording [isExclusion] against prior polarity
  * flags, or `null` when the addition is allowed (including all [SelectorFilterPolicy.REPEATABLE]
  * cases).
@@ -71,8 +57,12 @@ internal fun SelectorFilterPolicy.violationFor(
     isExclusion: Boolean,
 ): String? {
     if (this == SelectorFilterPolicy.REPEATABLE) return null
-    if (hasPositive) return exclusivePositiveAlreadySetMessage(argument)
-    if (!isExclusion && hasNegative) return exclusivePolarityMixMessage(argument)
+    if (hasPositive) {
+        return "Selector argument '$argument' is already set; vanilla syntax allows one positive value."
+    }
+    if (!isExclusion && hasNegative) {
+        return "Selector argument '$argument' cannot combine a positive value with exclusions."
+    }
     return null
 }
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterPolicy.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterPolicy.kt
@@ -1,6 +1,99 @@
 package io.github.lmliam.kotventure.core.selector
 
+/**
+ * Multiplicity policy for a filter-group selector argument (`name`, `type`, `tag`, …).
+ *
+ * Single source of truth for the DSL builder ([SelectorFilterGroup]), the immutable model
+ * ([EntitySelector]), and the parse path — so the three cannot drift.
+ */
 internal enum class SelectorFilterPolicy {
+    /**
+     * At most one positive value; positives cannot be mixed with exclusions.
+     * Multiple exclusions alone are allowed.
+     */
     EXCLUSIVE,
+
+    /** Any number of positives and exclusions, in any combination. */
     REPEATABLE,
 }
+
+/**
+ * Filter-group multiplicity for this keyword, or `null` when the keyword is a singleton (or not a
+ * filter group).
+ */
+internal val SelectorArgumentKeyword.filterPolicy: SelectorFilterPolicy?
+    get() =
+        when (this) {
+            SelectorArgumentKeyword.TYPE,
+            SelectorArgumentKeyword.NAME,
+            SelectorArgumentKeyword.GAMEMODE,
+            SelectorArgumentKeyword.TEAM,
+            -> SelectorFilterPolicy.EXCLUSIVE
+
+            SelectorArgumentKeyword.TAG,
+            SelectorArgumentKeyword.NBT,
+            SelectorArgumentKeyword.PREDICATE,
+            -> SelectorFilterPolicy.REPEATABLE
+
+            SelectorArgumentKeyword.LEVEL,
+            SelectorArgumentKeyword.LIMIT,
+            SelectorArgumentKeyword.SORT,
+            SelectorArgumentKeyword.SCORES,
+            SelectorArgumentKeyword.ADVANCEMENTS,
+            -> null
+        }
+
+/**
+ * Error when an exclusive group already holds a positive and another entry is attempted.
+ *
+ * Used by the DSL (positive already committed), the model, and the parser.
+ */
+internal fun exclusivePositiveAlreadySetMessage(argument: String): String =
+    "Selector argument '$argument' is already set; vanilla syntax allows one positive value."
+
+/**
+ * Error when an exclusive group mixes a positive value with exclusions.
+ */
+internal fun exclusivePolarityMixMessage(argument: String): String =
+    "Selector argument '$argument' cannot combine a positive value with exclusions."
+
+/**
+ * Returns an exclusive-policy violation message for recording [isExclusion] against prior polarity
+ * flags, or `null` when the addition is allowed (including all [SelectorFilterPolicy.REPEATABLE]
+ * cases).
+ *
+ * Callers update their polarity flags only when this returns `null`.
+ */
+internal fun SelectorFilterPolicy.violationFor(
+    argument: String,
+    hasPositive: Boolean,
+    hasNegative: Boolean,
+    isExclusion: Boolean,
+): String? {
+    if (this == SelectorFilterPolicy.REPEATABLE) return null
+    if (hasPositive) return exclusivePositiveAlreadySetMessage(argument)
+    if (!isExclusion && hasNegative) return exclusivePolarityMixMessage(argument)
+    return null
+}
+
+/**
+ * Whether this filter-group entry is an exclusion for exclusive-policy purposes.
+ *
+ * Named/`!value` filters use [EntitySelectorArgument.Negatable.isNegated]. Presence filters encode
+ * polarity in the presence value itself (`team=!` / `tag=!` → [SelectorPresence.ANY]), so
+ * [SelectorStringCondition.Presence.isNegated] stays `false` and must not be used here.
+ */
+internal val EntitySelectorArgument.Negatable.isFilterExclusion: Boolean
+    get() =
+        when (this) {
+            is EntitySelectorArgument.Tag -> condition.isFilterExclusion
+            is EntitySelectorArgument.Team -> condition.isFilterExclusion
+            else -> isNegated
+        }
+
+private val SelectorStringCondition.isFilterExclusion: Boolean
+    get() =
+        when (this) {
+            is SelectorStringCondition.Named -> isNegated
+            is SelectorStringCondition.Presence -> value == SelectorPresence.ANY
+        }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterPolicy.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterPolicy.kt
@@ -28,19 +28,19 @@ internal val SelectorArgumentKeyword.filterPolicy: SelectorFilterPolicy?
             SelectorArgumentKeyword.NAME,
             SelectorArgumentKeyword.GAMEMODE,
             SelectorArgumentKeyword.TEAM,
-            -> SelectorFilterPolicy.EXCLUSIVE
+                -> SelectorFilterPolicy.EXCLUSIVE
 
             SelectorArgumentKeyword.TAG,
             SelectorArgumentKeyword.NBT,
             SelectorArgumentKeyword.PREDICATE,
-            -> SelectorFilterPolicy.REPEATABLE
+                -> SelectorFilterPolicy.REPEATABLE
 
             SelectorArgumentKeyword.LEVEL,
             SelectorArgumentKeyword.LIMIT,
             SelectorArgumentKeyword.SORT,
             SelectorArgumentKeyword.SCORES,
             SelectorArgumentKeyword.ADVANCEMENTS,
-            -> null
+                -> null
         }
 
 /**

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterPolicy.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterPolicy.kt
@@ -44,29 +44,6 @@ internal val SelectorArgumentKeyword.filterPolicy: SelectorFilterPolicy?
         }
 
 /**
- * Returns an exclusive-policy violation message for recording [isExclusion] against prior polarity
- * flags, or `null` when the addition is allowed (including all [SelectorFilterPolicy.REPEATABLE]
- * cases).
- *
- * Callers update their polarity flags only when this returns `null`.
- */
-internal fun SelectorFilterPolicy.violationFor(
-    argument: String,
-    hasPositive: Boolean,
-    hasNegative: Boolean,
-    isExclusion: Boolean,
-): String? {
-    if (this == SelectorFilterPolicy.REPEATABLE) return null
-    if (hasPositive) {
-        return "Selector argument '$argument' is already set; vanilla syntax allows one positive value."
-    }
-    if (!isExclusion && hasNegative) {
-        return "Selector argument '$argument' cannot combine a positive value with exclusions."
-    }
-    return null
-}
-
-/**
  * Whether this filter-group entry is an exclusion for exclusive-policy purposes.
  *
  * Named/`!value` filters use [EntitySelectorArgument.Negatable.isNegated]. Presence filters encode

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorScope.kt
@@ -12,11 +12,15 @@ import net.kyori.adventure.text.ComponentLike
 public interface SelectorScope : ComponentScope {
     /**
      * Applies [separator] between selected entity names.
+     *
+     * @throws IllegalStateException when the separator is already set in this block.
      */
     public fun separator(separator: ComponentLike)
 
     /**
      * Builds and applies an inline text separator between selected entity names.
+     *
+     * @throws IllegalStateException when the separator is already set in this block.
      */
     public fun separator(init: TextScope.() -> Unit)
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorNumberParsing.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorNumberParsing.kt
@@ -1,7 +1,5 @@
 package io.github.lmliam.kotventure.core.selector.parsing
 
-import io.github.lmliam.kotventure.core.selector.parsing.isAsciiDigit
-
 internal fun SelectorReader.readSelectorBoolean(): Boolean {
     val start = offset
     return when (val token = readValueToken()) {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorNumberParsing.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorNumberParsing.kt
@@ -2,7 +2,7 @@ package io.github.lmliam.kotventure.core.selector.parsing
 
 internal fun SelectorReader.readSelectorBoolean(): Boolean {
     val start = offset
-    return when (val token = readValueToken()) {
+    return when (readValueToken()) {
         "true" -> true
         "false" -> false
         else -> failAt(start, "Expected 'true' or 'false'")
@@ -39,7 +39,8 @@ internal fun SelectorReader.parseSelectorDouble(
 /**
  * Vanilla integers: optional '-' then ASCII digits.
  *
- * `toIntOrNull` is intentionally looser (accepts '+' and non-ASCII digits), so we validate here.
+ * `toIntOrNull` is intentionally looser (accepts '+' and non-ASCII digits), so we
+validate here.
  */
 private fun String.isSelectorInteger(): Boolean {
     val digits = removePrefix("-")
@@ -50,12 +51,13 @@ private fun String.isSelectorInteger(): Boolean {
  * Vanilla decimals: optional '-', ASCII digits, and at most one '.'.
  * Examples allowed: "3", "-2.5", ".5", "1."
  *
- * We split on the first '.' and ensure the concatenated digits are all ASCII digits and non-empty.
+ * We split on the first '.' and ensure the concatenated digits are all ASCII digits and
+non-empty.
  */
 private fun String.isSelectorDecimal(): Boolean {
     val withoutSign = removePrefix("-")
-    val concatenated = withoutSign.split('.', limit = 2).joinToString("")
-    return concatenated.isNotEmpty() && concatenated.all(Char::isAsciiDigit)
+    val digits = withoutSign.split('.', limit = 2).joinToString("")
+    return digits.isNotEmpty() && digits.all(Char::isAsciiDigit)
 }
 
 private fun Char.isAsciiDigit(): Boolean = this in '0'..'9'

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorStringParsing.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorStringParsing.kt
@@ -1,7 +1,6 @@
 package io.github.lmliam.kotventure.core.selector.parsing
 
 import io.github.lmliam.kotventure.core.selector.isAllowedInUnquotedSelectorToken
-import io.github.lmliam.kotventure.core.selector.parsing.handleEscape
 
 /** Reads until the next selector value delimiter (`,`, `]`, or `}`). */
 internal fun SelectorReader.readValueToken(): String = readWhile { it !in ",]}" }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorStringParsing.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorStringParsing.kt
@@ -8,7 +8,8 @@ internal fun SelectorReader.readValueToken(): String = readWhile { it !in ",]}" 
 /**
  * Validate an unquoted token for correct characters.
  *
- * The token must be non-empty and all characters must be allowed in unquoted selector tokens.
+ * The token must be non-empty and all characters must be allowed in unquoted selector
+tokens.
  * Fails at [valueOffset] if validation fails.
  *
  * @param value the token string to validate
@@ -26,20 +27,21 @@ internal fun SelectorReader.validateUnquotedToken(
 }
 
 /**
- * Reads and decodes a `'`- or `"`-delimited string; only the delimiter and `\` may be escaped.
+ * Reads and decodes a `'`- or `"`-delimited string; only the delimiter and `\` may be
+escaped.
  *
- * Callers must establish the opening quote by peeking before calling; the quote character will
+ * Callers must establish the opening quote by peeking before calling; the quote
+character will
  * be consumed and the string returned without delimiters.
  *
  * @return the decoded string (without delimiters)
- * @throws io.github.lmliam.kotventure.core.selector.EntitySelectorParseException if the string is
+ * @throws io.github.lmliam.kotventure.core.selector.EntitySelectorParseException if the
+string is
  * unterminated or contains invalid escapes
  */
 internal fun SelectorReader.readQuotedString(): String {
     val quoteOffset = offset
-    val quote =
-        peek()?.takeIf { it == '\'' || it == '"' }
-            ?: error("readQuotedString requires the cursor to be on a quote")
+    val quote = peek()?.takeIf { it in "'\"" } ?: error("readQuotedString requires the cursor to be on a quote")
     skip()
 
     return buildString {
@@ -59,7 +61,8 @@ internal fun SelectorReader.readQuotedString(): String {
 /**
  * Handle an escape sequence in a quoted string.
  *
- * Valid escapes are the quote character itself or a backslash. Any other escape is invalid.
+ * Valid escapes are the quote character itself or a backslash. Any other escape is
+invalid.
  *
  * @param quoteOffset the offset of the opening quote (for unterminated-string errors)
  * @param escapeOffset the offset of the backslash (for invalid-escape errors)
@@ -70,9 +73,7 @@ private fun SelectorReader.handleEscape(
     escapeOffset: Int,
 ): Char {
     val escaped = peek() ?: failAt(quoteOffset, "Unterminated quoted string")
-    if (escaped != '"' && escaped != '\'' && escaped != '\\') {
-        failAt(escapeOffset, "Invalid quoted-string escape")
-    }
+    if (escaped !in "\"'\\") failAt(escapeOffset, "Invalid quoted-string escape")
     skip()
     return escaped
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/sound/SoundScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/sound/SoundScope.kt
@@ -24,7 +24,8 @@ public interface SoundScope : SoundSourceScope {
     /**
      * Sets the playback volume.
      *
-     * Defaults to `1` when unset.
+     * Defaults to `1` when unset. Passed through to Adventure without Minecraft-range clamping —
+     * values are interpreted by the platform at playback (typically non-negative; `1` is full).
      *
      * @throws IllegalStateException when the volume is already set in this block.
      */
@@ -33,7 +34,9 @@ public interface SoundScope : SoundSourceScope {
     /**
      * Sets the playback pitch.
      *
-     * Defaults to `1` when unset.
+     * Defaults to `1` when unset. Passed through to Adventure without Minecraft-range clamping —
+     * values are interpreted by the platform at playback (commonly around `0.5`–`2.0`; `1` is
+     * natural pitch).
      *
      * @throws IllegalStateException when the pitch is already set in this block.
      */

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarDslTest.kt
@@ -237,5 +237,23 @@ class BossBarDslTest :
                     }
                 }.message shouldBe "'progress' is already set."
             }
+
+            "duplicate progress prefers once-assign over range validation" {
+                shouldThrow<IllegalStateException> {
+                    bossBar {
+                        name { text("a") }
+                        progress(0.5f)
+                        progress(Float.NaN)
+                    }
+                }.message shouldBe "'progress' is already set."
+
+                shouldThrow<IllegalStateException> {
+                    bossBar {
+                        name { text("a") }
+                        progress(0.5f)
+                        progress(1.5f)
+                    }
+                }.message shouldBe "'progress' is already set."
+            }
         },
     )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarDslTest.kt
@@ -17,7 +17,6 @@ import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.bossbar.BossBar
@@ -36,226 +35,174 @@ private class BossBarRecordingAudience : Audience {
     }
 }
 
-class BossBarDslTest :
-    StringSpec(
-        {
-            "builds a fully configured boss bar" {
-                val bar =
-                    bossBar {
-                        name {
-                            text("Ender Dragon") { color(gold) }
-                        }
-                        progress(0.25f)
-                        color(red)
-                        overlay(notched10)
-                        darkenScreen()
-                        playBossMusic()
-                        createWorldFog()
-                    }
-
-                bar.name().childAt(0) shouldContainText "Ender Dragon"
-                bar.name().childAt(0) shouldHaveColor gold
-                bar shouldHaveProgress 0.25f
-                bar shouldHaveColor BossBar.Color.RED
-                bar shouldHaveOverlay BossBar.Overlay.NOTCHED_10
-                bar shouldHaveFlags
-                        setOf(
-                            BossBar.Flag.DARKEN_SCREEN,
-                            BossBar.Flag.PLAY_BOSS_MUSIC,
-                            BossBar.Flag.CREATE_WORLD_FOG,
-                        )
-            }
-
-            "defaults produce a full pink progress bar with no flags" {
-                val bar =
-                    bossBar {
-                        name { text("Raid") }
-                    }
-
-                bar.name().childAt(0) shouldContainText "Raid"
-                bar shouldHaveProgress BossBar.MAX_PROGRESS
-                bar shouldHaveColor BossBar.Color.PINK
-                bar shouldHaveOverlay BossBar.Overlay.PROGRESS
-                bar.shouldHaveNoFlags()
-            }
-
-            "accepts an existing component for the name" {
-                val name = Component.text("Named")
-
-                val bar = bossBar { name(name) }
-
-                bar.name() shouldBe name
-            }
-
-            "scope-bound colour and overlay vals match Adventure enums" {
-                val bar =
-                    bossBar {
-                        name { text("Palette") }
-                        color(blue)
-                        overlay(notched20)
-                    }
-
-                bar shouldHaveColor BossBar.Color.BLUE
-                bar shouldHaveOverlay BossBar.Overlay.NOTCHED_20
-            }
-
-            "progress overlay property coexists with progress function" {
-                val bar =
-                    bossBar {
-                        name { text("Continuous") }
-                        progress(0.5f)
-                        overlay(progress)
-                    }
-
-                bar shouldHaveProgress 0.5f
-                bar shouldHaveOverlay BossBar.Overlay.PROGRESS
-            }
-
-            "shows and hides a built bar" {
-                val audience = BossBarRecordingAudience()
-                val bar = bossBar { name { text("Shown") } }
-
-                audience.show(bar)
-                audience.hide(bar)
-
-                audience.shown shouldContainExactly listOf(bar)
-                audience.hidden shouldContainExactly listOf(bar)
-            }
-
-            "Audience.bossBar builds, shows, and returns the bar" {
-                val audience = BossBarRecordingAudience()
-
-                val bar =
-                    audience.bossBar {
-                        name { text("Raid") }
-                        color(green)
-                    }
-
-                audience.shown shouldContainExactly listOf(bar)
-                bar.name().childAt(0) shouldContainText "Raid"
-                bar shouldHaveColor BossBar.Color.GREEN
-                bar shouldHaveProgress BossBar.MAX_PROGRESS
-            }
-
-            "shows the same bar to every member of a forwarding audience" {
-                val first = BossBarRecordingAudience()
-                val second = BossBarRecordingAudience()
-
-                val bar =
-                    audienceOf(first, second).bossBar {
-                        name { text("Broadcast") }
-                    }
-
-                first.shown shouldHaveSize 1
-                second.shown shouldHaveSize 1
-                first.shown.single() shouldBe bar
-                second.shown.single() shouldBe bar
-            }
-
-            "rejects a missing name" {
-                shouldThrow<IllegalStateException> {
-                    bossBar { progress(0.5f) }
-                }.message shouldBe "'name' is not set."
-            }
-
-            "rejects out-of-range progress without clamping" {
-                shouldThrow<IllegalArgumentException> {
-                    bossBar {
-                        name { text("Bad") }
-                        progress(1.5f)
-                    }
-                }
-                shouldThrow<IllegalArgumentException> {
-                    bossBar {
-                        name { text("Bad") }
-                        progress(-0.1f)
-                    }
-                }
-            }
-
-            listOf(
-                "rejects a duplicate name" to {
-                    bossBar {
-                        name { text("a") }
-                        name { text("b") }
-                    }
-                },
-                "rejects a duplicate progress" to {
-                    bossBar {
-                        name { text("a") }
-                        progress(0.1f)
-                        progress(0.2f)
-                    }
-                },
-                "rejects a duplicate color" to {
-                    bossBar {
-                        name { text("a") }
-                        color(red)
-                        color(blue)
-                    }
-                },
-                "rejects a duplicate overlay" to {
-                    bossBar {
-                        name { text("a") }
-                        overlay(notched6)
-                        overlay(notched12)
-                    }
-                },
-                "rejects a duplicate darkenScreen" to {
-                    bossBar {
-                        name { text("a") }
-                        darkenScreen()
-                        darkenScreen()
-                    }
-                },
-                "rejects a duplicate playBossMusic" to {
-                    bossBar {
-                        name { text("a") }
-                        playBossMusic()
-                        playBossMusic()
-                    }
-                },
-                "rejects a duplicate createWorldFog" to {
-                    bossBar {
-                        name { text("a") }
-                        createWorldFog()
-                        createWorldFog()
-                    }
-                },
-            ).forEach { (name, action) ->
-                name {
-                    shouldThrow<IllegalStateException> { action() }
-                }
-            }
-
-            "duplicate progress message names the progress slot" {
-                shouldThrow<IllegalStateException> {
-                    bossBar {
-                        name { text("a") }
-                        progress(0.1f)
-                        progress(0.2f)
-                    }
-                }.message shouldBe "'progress' is already set."
-            }
-
-            // IllegalStateException (not the range IllegalArgumentException) proves the once-slot
-            // claims the duplicate before validation sees the bad value.
-            "duplicate progress prefers once-assign over range validation" {
-                shouldThrow<IllegalStateException> {
-                    bossBar {
-                        name { text("a") }
-                        progress(0.5f)
-                        progress(Float.NaN)
-                    }
+class BossBarDslTest : StringSpec(
+    {
+        "builds a fully configured boss bar" {
+            val bar =
+                bossBar {
+                    name { text("Ender Dragon") { color(gold) } }
+                    progress(0.25f)
+                    color(red)
+                    overlay(notched10)
+                    darkenScreen()
+                    playBossMusic()
+                    createWorldFog()
                 }
 
-                shouldThrow<IllegalStateException> {
-                    bossBar {
-                        name { text("a") }
-                        progress(0.5f)
-                        progress(1.5f)
-                    }
+            bar.name().childAt(0) shouldContainText "Ender Dragon"
+            bar.name().childAt(0) shouldHaveColor gold
+            bar shouldHaveProgress 0.25f
+            bar shouldHaveColor BossBar.Color.RED
+            bar shouldHaveOverlay BossBar.Overlay.NOTCHED_10
+            bar shouldHaveFlags
+                    setOf(
+                        BossBar.Flag.DARKEN_SCREEN,
+                        BossBar.Flag.PLAY_BOSS_MUSIC,
+                        BossBar.Flag.CREATE_WORLD_FOG,
+                    )
+        }
+
+        "defaults produce a full pink progress bar with no flags" {
+            val bar = bossBar { name { text("Raid") } }
+
+            bar.name().childAt(0) shouldContainText "Raid"
+            bar shouldHaveProgress BossBar.MAX_PROGRESS
+            bar shouldHaveColor BossBar.Color.PINK
+            bar shouldHaveOverlay BossBar.Overlay.PROGRESS
+            bar.shouldHaveNoFlags()
+        }
+
+        "accepts an existing component for the name" {
+            val name = Component.text("Named")
+
+            val bar = bossBar { name(name) }
+
+            bar.name() shouldBe name
+        }
+
+        "scope-bound colour and overlay vals match Adventure enums" {
+            val bar =
+                bossBar {
+                    name { text("Palette") }
+                    color(blue)
+                    overlay(notched20)
+                }
+
+            bar shouldHaveColor BossBar.Color.BLUE
+            bar shouldHaveOverlay BossBar.Overlay.NOTCHED_20
+        }
+
+        "progress overlay property coexists with progress function" {
+            val bar =
+                bossBar {
+                    name { text("Continuous") }
+                    progress(0.5f)
+                    overlay(progress)
+                }
+
+            bar shouldHaveProgress 0.5f
+            bar shouldHaveOverlay BossBar.Overlay.PROGRESS
+        }
+
+        "shows and hides a built bar" {
+            val audience = BossBarRecordingAudience()
+            val bar = bossBar { name { text("Shown") } }
+
+            audience.show(bar)
+            audience.hide(bar)
+
+            audience.shown shouldContainExactly listOf(bar)
+            audience.hidden shouldContainExactly listOf(bar)
+        }
+
+        "Audience.bossBar builds, shows, and returns the bar" {
+            val audience = BossBarRecordingAudience()
+
+            val bar =
+                audience.bossBar {
+                    name { text("Raid") }
+                    color(green)
+                }
+
+            audience.shown shouldContainExactly listOf(bar)
+            bar.name().childAt(0) shouldContainText "Raid"
+            bar shouldHaveColor BossBar.Color.GREEN
+            bar shouldHaveProgress BossBar.MAX_PROGRESS
+        }
+
+        "shows the same bar to every member of a forwarding audience" {
+            val first = BossBarRecordingAudience()
+            val second = BossBarRecordingAudience()
+
+            val bar =
+                audienceOf(first, second).bossBar {
+                    name { text("Broadcast") }
+                }
+
+            first.shown.single() shouldBe bar
+            second.shown.single() shouldBe bar
+        }
+
+        "rejects a missing name" {
+            shouldThrow<IllegalStateException> {
+                bossBar { progress(0.5f) }
+            }.message shouldBe "'name' is not set."
+        }
+
+        "rejects out-of-range progress without clamping" {
+            shouldThrow<IllegalArgumentException> {
+                bossBar {
+                    name { text("Bad") }
+                    progress(1.5f)
                 }
             }
-        },
-    )
+            shouldThrow<IllegalArgumentException> {
+                bossBar {
+                    name { text("Bad") }
+                    progress(-0.1f)
+                }
+            }
+        }
+
+        listOf(
+            "duplicate name" to { bossBar { name { text("a") }; name { text("b") } } },
+            "duplicate progress" to { bossBar { name { text("a") }; progress(0.1f); progress(0.2f) } },
+            "duplicate color" to { bossBar { name { text("a") }; color(red); color(blue) } },
+            "duplicate overlay" to { bossBar { name { text("a") }; overlay(notched6); overlay(notched12) } },
+            "duplicate darkenScreen" to { bossBar { name { text("a") }; darkenScreen(); darkenScreen() } },
+            "duplicate playBossMusic" to { bossBar { name { text("a") }; playBossMusic(); playBossMusic() } },
+            "duplicate createWorldFog" to { bossBar { name { text("a") }; createWorldFog(); createWorldFog() } },
+        ).forEach { (name, action) ->
+            "rejects a $name" {
+                shouldThrow<IllegalStateException> { action() }
+            }
+        }
+
+        "duplicate progress message names the progress slot" {
+            shouldThrow<IllegalStateException> {
+                bossBar {
+                    name { text("a") }
+                    progress(0.1f)
+                    progress(0.2f)
+                }
+            }.message shouldBe "'progress' is already set."
+        }
+
+        "duplicate progress prefers once-assign over range validation" {
+            shouldThrow<IllegalStateException> {
+                bossBar {
+                    name { text("a") }
+                    progress(0.5f)
+                    progress(Float.NaN)
+                }
+            }
+            shouldThrow<IllegalStateException> {
+                bossBar {
+                    name { text("a") }
+                    progress(0.5f)
+                    progress(1.5f)
+                }
+            }
+        }
+    },
+)

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarDslTest.kt
@@ -164,13 +164,13 @@ class BossBarDslTest :
                         name { text("Bad") }
                         progress(1.5f)
                     }
-                }.message shouldBe "'progress' must be in 0.0..1.0, got 1.5."
+                }
                 shouldThrow<IllegalArgumentException> {
                     bossBar {
                         name { text("Bad") }
                         progress(-0.1f)
                     }
-                }.message shouldBe "'progress' must be in 0.0..1.0, got -0.1."
+                }
             }
 
             listOf(
@@ -238,6 +238,8 @@ class BossBarDslTest :
                 }.message shouldBe "'progress' is already set."
             }
 
+            // IllegalStateException (not the range IllegalArgumentException) proves the once-slot
+            // claims the duplicate before validation sees the bad value.
             "duplicate progress prefers once-assign over range validation" {
                 shouldThrow<IllegalStateException> {
                     bossBar {
@@ -245,7 +247,7 @@ class BossBarDslTest :
                         progress(0.5f)
                         progress(Float.NaN)
                     }
-                }.message shouldBe "'progress' is already set."
+                }
 
                 shouldThrow<IllegalStateException> {
                     bossBar {
@@ -253,7 +255,7 @@ class BossBarDslTest :
                         progress(0.5f)
                         progress(1.5f)
                     }
-                }.message shouldBe "'progress' is already set."
+                }
             }
         },
     )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarDslTest.kt
@@ -164,13 +164,13 @@ class BossBarDslTest :
                         name { text("Bad") }
                         progress(1.5f)
                     }
-                }
+                }.message shouldBe "'progress' must be in 0.0..1.0, got 1.5."
                 shouldThrow<IllegalArgumentException> {
                     bossBar {
                         name { text("Bad") }
                         progress(-0.1f)
                     }
-                }
+                }.message shouldBe "'progress' must be in 0.0..1.0, got -0.1."
             }
 
             listOf(

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/BossBarDslTest.kt
@@ -35,7 +35,8 @@ private class BossBarRecordingAudience : Audience {
     }
 }
 
-class BossBarDslTest : StringSpec(
+class BossBarDslTest :
+    StringSpec(
     {
         "builds a fully configured boss bar" {
             val bar =
@@ -165,13 +166,54 @@ class BossBarDslTest : StringSpec(
         }
 
         listOf(
-            "duplicate name" to { bossBar { name { text("a") }; name { text("b") } } },
-            "duplicate progress" to { bossBar { name { text("a") }; progress(0.1f); progress(0.2f) } },
-            "duplicate color" to { bossBar { name { text("a") }; color(red); color(blue) } },
-            "duplicate overlay" to { bossBar { name { text("a") }; overlay(notched6); overlay(notched12) } },
-            "duplicate darkenScreen" to { bossBar { name { text("a") }; darkenScreen(); darkenScreen() } },
-            "duplicate playBossMusic" to { bossBar { name { text("a") }; playBossMusic(); playBossMusic() } },
-            "duplicate createWorldFog" to { bossBar { name { text("a") }; createWorldFog(); createWorldFog() } },
+            "duplicate name" to {
+                bossBar {
+                name { text("a") }
+                name { text("b") }
+            }
+            },
+            "duplicate progress" to {
+                bossBar {
+                name { text("a") }
+                progress(0.1f)
+                progress(0.2f)
+            }
+            },
+            "duplicate color" to {
+                bossBar {
+                name { text("a") }
+                color(red)
+                color(blue)
+            }
+            },
+            "duplicate overlay" to {
+                bossBar {
+                name { text("a") }
+                overlay(notched6)
+                overlay(notched12)
+            }
+            },
+            "duplicate darkenScreen" to {
+                bossBar {
+                name { text("a") }
+                darkenScreen()
+                darkenScreen()
+            }
+            },
+            "duplicate playBossMusic" to {
+                bossBar {
+                name { text("a") }
+                playBossMusic()
+                playBossMusic()
+            }
+            },
+            "duplicate createWorldFog" to {
+                bossBar {
+                name { text("a") }
+                createWorldFog()
+                createWorldFog()
+            }
+            },
         ).forEach { (name, action) ->
             "rejects a $name" {
                 shouldThrow<IllegalStateException> { action() }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarDslTest.kt
@@ -699,5 +699,66 @@ class TimedBossBarDslTest :
                 creator.hidden shouldContainExactly listOf(timed.bar)
                 timed.isRunning shouldBe false
             }
+
+            "cancel from the final onTick does not override onFinish" {
+                val ticker = ManualTicker()
+                val audience = TimedBossBarRecordingAudience()
+                var finishes = 0
+                var cancels = 0
+
+                val timed =
+                    context(ticker) {
+                        audience.bossBar(over = 1.seconds) {
+                            name { text("X") }
+                            every(1.seconds)
+                            onTick { remaining ->
+                                if (remaining == Duration.ZERO) {
+                                    cancel()
+                                }
+                            }
+                            onFinish { finishes++ }
+                            onCancel { cancels++ }
+                        }
+                    }
+
+                ticker.advance(1.seconds)
+
+                finishes shouldBe 1
+                cancels shouldBe 0
+                timed.isRunning shouldBe false
+                audience.hidden shouldContainExactly listOf(timed.bar)
+            }
+
+            "exception from the final onTick still hides viewers, fires onFinish, and rethrows" {
+                val ticker = ManualTicker()
+                val audience = TimedBossBarRecordingAudience()
+                var finishes = 0
+                val boom = IllegalStateException("tick failed")
+
+                val timed =
+                    context(ticker) {
+                        audience.bossBar(over = 1.seconds) {
+                            name { text("X") }
+                            every(1.seconds)
+                            onTick { remaining ->
+                                if (remaining == Duration.ZERO) {
+                                    throw boom
+                                }
+                            }
+                            onFinish { finishes++ }
+                        }
+                    }
+
+                val thrown =
+                    shouldThrow<IllegalStateException> {
+                        ticker.advance(1.seconds)
+                    }
+
+                thrown shouldBe boom
+                finishes shouldBe 1
+                timed.isRunning shouldBe false
+                timed.remaining shouldBe Duration.ZERO
+                audience.hidden shouldContainExactly listOf(timed.bar)
+            }
         },
     )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarDslTest.kt
@@ -347,7 +347,7 @@ class TimedBossBarDslTest :
                             progress(from = 1.5f, to = 0f)
                         }
                     }
-                }.message shouldBe "'progress from' must be in 0.0..1.0, got 1.5."
+                }
                 shouldThrow<IllegalArgumentException> {
                     context(ticker) {
                         audience.bossBar(over = 1.seconds) {
@@ -355,7 +355,7 @@ class TimedBossBarDslTest :
                             progress(from = 0f, to = -0.1f)
                         }
                     }
-                }.message shouldBe "'progress to' must be in 0.0..1.0, got -0.1."
+                }
             }
 
             "rejects non-positive every" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarDslTest.kt
@@ -301,7 +301,7 @@ class TimedBossBarDslTest :
                             progress(from = 1.5f, to = 0f)
                         }
                     }
-                }
+                }.message shouldBe "'progress from' must be in 0.0..1.0, got 1.5."
                 shouldThrow<IllegalArgumentException> {
                     context(ticker) {
                         audience.bossBar(over = 1.seconds) {
@@ -309,7 +309,7 @@ class TimedBossBarDslTest :
                             progress(from = 0f, to = -0.1f)
                         }
                     }
-                }
+                }.message shouldBe "'progress to' must be in 0.0..1.0, got -0.1."
             }
 
             "rejects non-positive every" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarDslTest.kt
@@ -4,6 +4,8 @@ import io.github.lmliam.kotventure.core.audience.bossBar
 import io.github.lmliam.kotventure.core.audience.hide
 import io.github.lmliam.kotventure.core.audience.show
 import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.core.time.Ticker
+import io.github.lmliam.kotventure.core.time.TickerTask
 import io.github.lmliam.kotventure.core.time.ticks
 import io.github.lmliam.kotventure.test.bossbar.shouldHaveColor
 import io.github.lmliam.kotventure.test.bossbar.shouldHaveOverlay
@@ -145,6 +147,50 @@ class TimedBossBarDslTest :
                 timed.isPaused shouldBe false
                 ticker.advance(2.seconds)
                 timed.remaining shouldBe 5.seconds
+            }
+
+            // Controllable ticker: cancel is a no-op so a detached task can still fire — the race
+            // pause/resume leaves when the old callback runs after a replacement is scheduled.
+            "stale ticker after pause/resume does not advance remaining" {
+                val actions = mutableListOf<() -> Unit>()
+                val ticker =
+                    object : Ticker {
+                        override fun repeating(
+                            interval: Duration,
+                            action: () -> Unit,
+                        ): TickerTask {
+                            actions += action
+                            return object : TickerTask {
+                                override fun cancel() {
+                                    // Leave the callback invokable to model an in-flight/late fire.
+                                }
+                            }
+                        }
+                    }
+                val audience = TimedBossBarRecordingAudience()
+
+                val timed =
+                    context(ticker) {
+                        audience.bossBar(over = 10.seconds) {
+                            name { text("Race") }
+                            every(1.seconds)
+                        }
+                    }
+
+                actions shouldHaveSize 1
+                actions[0]()
+                timed.remaining shouldBe 9.seconds
+
+                timed.pause()
+                timed.resume()
+                actions shouldHaveSize 2
+
+                // Stale generation from the pre-pause task must be a no-op after resume.
+                actions[0]()
+                timed.remaining shouldBe 9.seconds
+
+                actions[1]()
+                timed.remaining shouldBe 8.seconds
             }
 
             "dynamic name re-renders each tick" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarDslTest.kt
@@ -10,14 +10,13 @@ import io.github.lmliam.kotventure.core.time.ticks
 import io.github.lmliam.kotventure.test.bossbar.shouldHaveColor
 import io.github.lmliam.kotventure.test.bossbar.shouldHaveOverlay
 import io.github.lmliam.kotventure.test.bossbar.shouldHaveProgress
-import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.time.ManualTicker
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.floats.shouldBeWithinPercentageOf
+import io.kotest.matchers.floats.plusOrMinus
 import io.kotest.matchers.shouldBe
 import net.kyori.adventure.bossbar.BossBar
 import kotlin.time.Duration
@@ -26,7 +25,7 @@ import kotlin.time.Duration.Companion.seconds
 class TimedBossBarDslTest :
     StringSpec(
         {
-            "defaults to a 1→0 countdown and lands exactly on to" {
+            "defaults to a 1->0 countdown and lands exactly on to" {
                 val ticker = ManualTicker()
                 val audience = TimedBossBarRecordingAudience()
 
@@ -44,7 +43,7 @@ class TimedBossBarDslTest :
 
                 ticker.advance(5.seconds)
                 timed.remaining shouldBe 5.seconds
-                timed.bar.progress().shouldBeWithinPercentageOf(0.5f, 0.01)
+                timed.bar.progress() shouldBe (0.5f plusOrMinus 0.001f)
 
                 ticker.advance(5.seconds)
                 timed.remaining shouldBe Duration.ZERO
@@ -53,7 +52,7 @@ class TimedBossBarDslTest :
                 audience.hidden shouldContainExactly listOf(timed.bar)
             }
 
-            "interpolates arbitrary from→to progress" {
+            "interpolates arbitrary from->to progress" {
                 val ticker = ManualTicker()
                 val audience = TimedBossBarRecordingAudience()
 
@@ -68,7 +67,7 @@ class TimedBossBarDslTest :
 
                 timed.bar shouldHaveProgress 0.25f
                 ticker.advance(2.seconds)
-                timed.bar.progress().shouldBeWithinPercentageOf(0.5f, 0.01)
+                timed.bar.progress() shouldBe (0.5f plusOrMinus 0.001f)
                 ticker.advance(2.seconds)
                 timed.bar shouldHaveProgress 0.75f
             }
@@ -88,7 +87,6 @@ class TimedBossBarDslTest :
                 timed.show(extra)
 
                 ticker.advance(1.seconds)
-
                 creator.hidden shouldContainExactly listOf(timed.bar)
                 extra.hidden shouldContainExactly listOf(timed.bar)
                 timed.isRunning shouldBe false
@@ -140,8 +138,7 @@ class TimedBossBarDslTest :
                 timed.isPaused shouldBe true
                 ticker.advance(5.seconds)
                 timed.remaining shouldBe 7.seconds
-                // Countdown 1→0: after 3s of 10s, fill is 0.7 not 0.3.
-                timed.bar.progress().shouldBeWithinPercentageOf(0.7f, 0.01)
+                timed.bar.progress() shouldBe (0.7f plusOrMinus 0.001f)
 
                 timed.resume()
                 timed.isPaused shouldBe false
@@ -149,8 +146,6 @@ class TimedBossBarDslTest :
                 timed.remaining shouldBe 5.seconds
             }
 
-            // Controllable ticker: cancel is a no-op so a detached task can still fire — the race
-            // pause/resume leaves when the old callback runs after a replacement is scheduled.
             "stale ticker after pause/resume does not advance remaining" {
                 val actions = mutableListOf<() -> Unit>()
                 val ticker =
@@ -161,9 +156,7 @@ class TimedBossBarDslTest :
                         ): TickerTask {
                             actions += action
                             return object : TickerTask {
-                                override fun cancel() {
-                                    // Leave the callback invokable to model an in-flight/late fire.
-                                }
+                                override fun cancel() = Unit
                             }
                         }
                     }
@@ -185,7 +178,6 @@ class TimedBossBarDslTest :
                 timed.resume()
                 actions shouldHaveSize 2
 
-                // Stale generation from the pre-pause task must be a no-op after resume.
                 actions[0]()
                 timed.remaining shouldBe 9.seconds
 
@@ -235,7 +227,7 @@ class TimedBossBarDslTest :
                 timed.bar.name() shouldContainText "1s"
             }
 
-            "hook order is progress → name → onTick; onFinish fires once on natural completion" {
+            "hook order is progress -> name -> onTick; onFinish fires once on natural completion" {
                 val ticker = ManualTicker()
                 val audience = TimedBossBarRecordingAudience()
                 val events = mutableListOf<String>()
@@ -251,26 +243,20 @@ class TimedBossBarDslTest :
                             onTick { remaining ->
                                 events += "tick:${remaining.inWholeSeconds}:p=${bar.progress()}"
                             }
-                            onFinish {
-                                events += "finish"
-                            }
-                            onCancel {
-                                events += "cancel"
-                            }
+                            onFinish { events += "finish" }
+                            onCancel { events += "cancel" }
                         }
                     }
 
-                // Initial dynamic name render at construction (not a tick).
                 events.clear()
-
                 ticker.advance(2.seconds)
 
+                events shouldHaveSize 5
                 events[0] shouldBe "name:1"
                 events[1].startsWith("tick:1:p=") shouldBe true
                 events[2] shouldBe "name:0"
                 events[3].startsWith("tick:0:p=") shouldBe true
                 events[4] shouldBe "finish"
-                events shouldHaveSize 5
                 timed.bar shouldHaveProgress BossBar.MIN_PROGRESS
             }
 
@@ -322,16 +308,12 @@ class TimedBossBarDslTest :
 
                 shouldThrow<IllegalArgumentException> {
                     context(ticker) {
-                        audience.bossBar(over = Duration.ZERO) {
-                            name { text("Bad") }
-                        }
+                        audience.bossBar(over = Duration.ZERO) { name { text("Bad") } }
                     }
                 }
                 shouldThrow<IllegalArgumentException> {
                     context(ticker) {
-                        audience.bossBar(over = (-1).seconds) {
-                            name { text("Bad") }
-                        }
+                        audience.bossBar(over = (-1).seconds) { name { text("Bad") } }
                     }
                 }
             }
@@ -392,35 +374,30 @@ class TimedBossBarDslTest :
 
                 shouldThrow<IllegalStateException> {
                     context(ticker) {
-                        audience.bossBar(over = 1.seconds) {
-                            color(red)
-                        }
+                        audience.bossBar(over = 1.seconds) { color(red) }
                     }
                 }.message shouldBe "'name' is not set."
             }
 
             listOf(
-                "rejects a duplicate static name" to {
-                    val ticker = ManualTicker()
-                    context(ticker) {
+                "duplicate static name" to {
+                    context(ManualTicker()) {
                         TimedBossBarRecordingAudience().bossBar(over = 1.seconds) {
                             name { text("a") }
                             name { text("b") }
                         }
                     }
                 },
-                "rejects mixing static and dynamic name" to {
-                    val ticker = ManualTicker()
-                    context(ticker) {
+                "mixed static and dynamic name" to {
+                    context(ManualTicker()) {
                         TimedBossBarRecordingAudience().bossBar(over = 1.seconds) {
                             name { text("a") }
                             name { remaining -> text("$remaining") }
                         }
                     }
                 },
-                "rejects a duplicate progress" to {
-                    val ticker = ManualTicker()
-                    context(ticker) {
+                "duplicate progress" to {
+                    context(ManualTicker()) {
                         TimedBossBarRecordingAudience().bossBar(over = 1.seconds) {
                             name { text("a") }
                             progress(from = 1f, to = 0f)
@@ -428,9 +405,8 @@ class TimedBossBarDslTest :
                         }
                     }
                 },
-                "rejects a duplicate every" to {
-                    val ticker = ManualTicker()
-                    context(ticker) {
+                "duplicate every" to {
+                    context(ManualTicker()) {
                         TimedBossBarRecordingAudience().bossBar(over = 1.seconds) {
                             name { text("a") }
                             every(1.ticks)
@@ -438,9 +414,8 @@ class TimedBossBarDslTest :
                         }
                     }
                 },
-                "rejects a duplicate onTick" to {
-                    val ticker = ManualTicker()
-                    context(ticker) {
+                "duplicate onTick" to {
+                    context(ManualTicker()) {
                         TimedBossBarRecordingAudience().bossBar(over = 1.seconds) {
                             name { text("a") }
                             onTick { }
@@ -448,9 +423,8 @@ class TimedBossBarDslTest :
                         }
                     }
                 },
-                "rejects a duplicate onFinish" to {
-                    val ticker = ManualTicker()
-                    context(ticker) {
+                "duplicate onFinish" to {
+                    context(ManualTicker()) {
                         TimedBossBarRecordingAudience().bossBar(over = 1.seconds) {
                             name { text("a") }
                             onFinish { }
@@ -458,9 +432,8 @@ class TimedBossBarDslTest :
                         }
                     }
                 },
-                "rejects a duplicate onCancel" to {
-                    val ticker = ManualTicker()
-                    context(ticker) {
+                "duplicate onCancel" to {
+                    context(ManualTicker()) {
                         TimedBossBarRecordingAudience().bossBar(over = 1.seconds) {
                             name { text("a") }
                             onCancel { }
@@ -468,9 +441,8 @@ class TimedBossBarDslTest :
                         }
                     }
                 },
-                "rejects a duplicate color" to {
-                    val ticker = ManualTicker()
-                    context(ticker) {
+                "duplicate color" to {
+                    context(ManualTicker()) {
                         TimedBossBarRecordingAudience().bossBar(over = 1.seconds) {
                             name { text("a") }
                             color(red)
@@ -479,7 +451,7 @@ class TimedBossBarDslTest :
                     }
                 },
             ).forEach { (name, action) ->
-                name {
+                "rejects a $name" {
                     shouldThrow<IllegalStateException> { action() }
                 }
             }
@@ -507,9 +479,7 @@ class TimedBossBarDslTest :
 
                 val timed =
                     context(ticker) {
-                        audience.bossBar(over = 10.seconds) {
-                            name { text("X") }
-                        }
+                        audience.bossBar(over = 10.seconds) { name { text("X") } }
                     }
                 timed.cancel()
 
@@ -563,9 +533,7 @@ class TimedBossBarDslTest :
 
                 val timed =
                     context(ticker) {
-                        creator.bossBar(over = 5.seconds) {
-                            name { text("X") }
-                        }
+                        creator.bossBar(over = 5.seconds) { name { text("X") } }
                     }
                 timed.show(extra)
 
@@ -622,7 +590,6 @@ class TimedBossBarDslTest :
                 val timed =
                     context(ticker) {
                         audience.bossBar(over = 4.seconds) {
-                            // Initial 2; ticks render 2, 1, 1, 0 — only two actual changes.
                             name { remaining -> text("${(remaining.inWholeSeconds + 1) / 2}") }
                             every(1.seconds)
                         }
@@ -712,9 +679,7 @@ class TimedBossBarDslTest :
                             name { text("X") }
                             every(1.seconds)
                             onTick { remaining ->
-                                if (remaining == Duration.ZERO) {
-                                    cancel()
-                                }
+                                if (remaining == Duration.ZERO) cancel()
                             }
                             onFinish { finishes++ }
                             onCancel { cancels++ }
@@ -741,20 +706,14 @@ class TimedBossBarDslTest :
                             name { text("X") }
                             every(1.seconds)
                             onTick { remaining ->
-                                if (remaining == Duration.ZERO) {
-                                    throw boom
-                                }
+                                if (remaining == Duration.ZERO) throw boom
                             }
                             onFinish { finishes++ }
                         }
                     }
 
-                val thrown =
-                    shouldThrow<IllegalStateException> {
-                        ticker.advance(1.seconds)
-                    }
+                shouldThrow<IllegalStateException> { ticker.advance(1.seconds) } shouldBe boom
 
-                thrown shouldBe boom
                 finishes shouldBe 1
                 timed.isRunning shouldBe false
                 timed.remaining shouldBe Duration.ZERO

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorModelTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorModelTest.kt
@@ -40,13 +40,13 @@ class EntitySelectorModelTest :
                 assertDoesNotCompile(
                     "SelectorCopyVisibilityTest.kt",
                     """
-                    import io.github.lmliam.kotventure.core.selector.EntitySelector
-                    import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument
+                import io.github.lmliam.kotventure.core.selector.EntitySelector
+                import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument
 
-                    fun invalid(selector: EntitySelector) {
-                        selector.copy(arguments = mutableListOf<EntitySelectorArgument>())
-                    }
-                    """.trimIndent(),
+                fun invalid(selector: EntitySelector) {
+                    selector.copy(arguments = mutableListOf<EntitySelectorArgument>())
+                }
+            """.trimIndent(),
                     "Cannot access",
                 )
             }
@@ -61,25 +61,28 @@ class EntitySelectorModelTest :
                 negatable.count { it.isNegated } shouldBe 2
             }
 
+            data class RejectionCase(
+                val description: String,
+                val head: EntitySelectorHead,
+                val arguments: List<EntitySelectorArgument>,
+            )
+
             listOf(
-                Triple(
-                    "model rejects a duplicate singleton argument",
+                RejectionCase(
+                    "duplicate singleton argument",
                     EntitySelectorHead.ENTITIES,
-                    listOf(
-                        EntitySelectorArgument.Limit(1),
-                        EntitySelectorArgument.Limit(2),
-                    ),
+                    listOf(EntitySelectorArgument.Limit(1), EntitySelectorArgument.Limit(2)),
                 ),
-                Triple(
-                    "model rejects two positive name filters",
+                RejectionCase(
+                    "two positive name filters",
                     EntitySelectorHead.ENTITIES,
                     listOf(
                         EntitySelectorArgument.Name("a", isNegated = false),
                         EntitySelectorArgument.Name("b", isNegated = false),
                     ),
                 ),
-                Triple(
-                    "model rejects two positive type filters",
+                RejectionCase(
+                    "two positive type filters",
                     EntitySelectorHead.ENTITIES,
                     listOf(
                         EntitySelectorArgument.Type(
@@ -92,40 +95,40 @@ class EntitySelectorModelTest :
                         ),
                     ),
                 ),
-                Triple(
-                    "model rejects two positive gamemode filters",
+                RejectionCase(
+                    "two positive gamemode filters",
                     EntitySelectorHead.ALL_PLAYERS,
                     listOf(
                         EntitySelectorArgument.GameMode(GameMode.SURVIVAL, isNegated = false),
                         EntitySelectorArgument.GameMode(GameMode.CREATIVE, isNegated = false),
                     ),
                 ),
-                Triple(
-                    "model rejects two positive team filters",
+                RejectionCase(
+                    "two positive team filters",
                     EntitySelectorHead.ENTITIES,
                     listOf(
                         EntitySelectorArgument.Team(SelectorStringCondition.Named("red")),
                         EntitySelectorArgument.Team(SelectorStringCondition.Named("blue")),
                     ),
                 ),
-                Triple(
-                    "model rejects a name exclusion after a positive name",
+                RejectionCase(
+                    "name exclusion after a positive name",
                     EntitySelectorHead.ENTITIES,
                     listOf(
                         EntitySelectorArgument.Name("a", isNegated = false),
                         EntitySelectorArgument.Name("b", isNegated = true),
                     ),
                 ),
-                Triple(
-                    "model rejects a positive name after name exclusions",
+                RejectionCase(
+                    "positive name after name exclusions",
                     EntitySelectorHead.ENTITIES,
                     listOf(
                         EntitySelectorArgument.Name("a", isNegated = true),
                         EntitySelectorArgument.Name("b", isNegated = false),
                     ),
                 ),
-                Triple(
-                    "model rejects a positive type after a type exclusion",
+                RejectionCase(
+                    "positive type after a type exclusion",
                     EntitySelectorHead.ENTITIES,
                     listOf(
                         EntitySelectorArgument.Type(
@@ -138,29 +141,29 @@ class EntitySelectorModelTest :
                         ),
                     ),
                 ),
-                Triple(
-                    "model rejects a positive gamemode after a gamemode exclusion",
+                RejectionCase(
+                    "positive gamemode after a gamemode exclusion",
                     EntitySelectorHead.ALL_PLAYERS,
                     listOf(
                         EntitySelectorArgument.GameMode(GameMode.SURVIVAL, isNegated = true),
                         EntitySelectorArgument.GameMode(GameMode.CREATIVE, isNegated = false),
                     ),
                 ),
-                Triple(
-                    "model rejects a positive team after a team exclusion",
+                RejectionCase(
+                    "positive team after a team exclusion",
                     EntitySelectorHead.ENTITIES,
                     listOf(
                         EntitySelectorArgument.Team(SelectorStringCondition.Named("red", isNegated = true)),
                         EntitySelectorArgument.Team(SelectorStringCondition.Named("blue")),
                     ),
                 ),
-            ).forEach { (name, head, arguments) ->
-                name {
+            ).forEach { (description, head, arguments) ->
+                "model rejects $description" {
                     shouldThrow<IllegalArgumentException> { EntitySelector(head, arguments) }
                 }
             }
 
-            "allows exclusive exclusions and repeatable mixed filter groups on the model" {
+            "allows exclusive exclusions and repeatable mixed filter groups" {
                 EntitySelector(
                     EntitySelectorHead.ENTITIES,
                     listOf(
@@ -218,22 +221,33 @@ class EntitySelectorModelTest :
                 advancements.advancements.single().advancement shouldBe key("minecraft", "story/root")
             }
 
-            "rejects invalid public argument construction" {
-                shouldThrow<IllegalArgumentException> {
-                    EntitySelectorArgument.Limit(0)
-                }
+            "rejects Limit(0)" {
+                shouldThrow<IllegalArgumentException> { EntitySelectorArgument.Limit(0) }
+            }
+
+            "rejects Coordinate with NaN" {
                 shouldThrow<IllegalArgumentException> {
                     EntitySelectorArgument.Coordinate(SelectorCoordinate.X, Double.NaN)
                 }
-                shouldThrow<IllegalArgumentException> {
-                    SelectorStringCondition.Named("")
-                }
+            }
+
+            "rejects empty Named condition" {
+                shouldThrow<IllegalArgumentException> { SelectorStringCondition.Named("") }
+            }
+
+            "rejects SelectorScoreRequirement with spaces in objective" {
                 shouldThrow<IllegalArgumentException> {
                     SelectorScoreRequirement("bad objective", exactly(1))
                 }
+            }
+
+            "rejects SelectorAdvancementCriterion with spaces in criterion" {
                 shouldThrow<IllegalArgumentException> {
                     SelectorAdvancementCriterion("bad criterion", completed = true)
                 }
+            }
+
+            "rejects malformed SNBT source" {
                 shouldThrow<EntitySelectorParseException> {
                     SnbtCompoundSource.parse("definitely not SNBT")
                 }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorModelTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorModelTest.kt
@@ -61,6 +61,19 @@ class EntitySelectorModelTest :
                 negatable.count { it.isNegated } shouldBe 2
             }
 
+            "rejects duplicate singleton arguments on the model" {
+                shouldThrow<IllegalArgumentException> {
+                    EntitySelector(
+                        EntitySelectorHead.ENTITIES,
+                        listOf(
+                            EntitySelectorArgument.Limit(1),
+                            EntitySelectorArgument.Limit(2),
+                        ),
+                    )
+                }.message shouldBe
+                    "Selector argument 'limit' is already set; vanilla syntax allows it only once."
+            }
+
             "represents direct entity types and type tags without a boolean flag" {
                 val direct =
                     parseSelector("@e[type=minecraft:zombie]")

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorModelTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorModelTest.kt
@@ -73,6 +73,124 @@ class EntitySelectorModelTest :
                 }
             }
 
+            "rejects two positive exclusive filter-group values on the model" {
+                shouldThrow<IllegalArgumentException> {
+                    EntitySelector(
+                        EntitySelectorHead.ENTITIES,
+                        listOf(
+                            EntitySelectorArgument.Name("a", isNegated = false),
+                            EntitySelectorArgument.Name("b", isNegated = false),
+                        ),
+                    )
+                }
+
+                shouldThrow<IllegalArgumentException> {
+                    EntitySelector(
+                        EntitySelectorHead.ENTITIES,
+                        listOf(
+                            EntitySelectorArgument.Type(
+                                SelectorEntityType.Direct(key("minecraft", "zombie")),
+                                isNegated = false,
+                            ),
+                            EntitySelectorArgument.Type(
+                                SelectorEntityType.Direct(key("minecraft", "skeleton")),
+                                isNegated = false,
+                            ),
+                        ),
+                    )
+                }
+
+                shouldThrow<IllegalArgumentException> {
+                    EntitySelector(
+                        EntitySelectorHead.ALL_PLAYERS,
+                        listOf(
+                            EntitySelectorArgument.GameMode(GameMode.SURVIVAL, isNegated = false),
+                            EntitySelectorArgument.GameMode(GameMode.CREATIVE, isNegated = false),
+                        ),
+                    )
+                }
+
+                shouldThrow<IllegalArgumentException> {
+                    EntitySelector(
+                        EntitySelectorHead.ENTITIES,
+                        listOf(
+                            EntitySelectorArgument.Team(SelectorStringCondition.Named("red")),
+                            EntitySelectorArgument.Team(SelectorStringCondition.Named("blue")),
+                        ),
+                    )
+                }
+            }
+
+            "rejects exclusive positive mixed with exclusions on the model" {
+                shouldThrow<IllegalArgumentException> {
+                    EntitySelector(
+                        EntitySelectorHead.ENTITIES,
+                        listOf(
+                            EntitySelectorArgument.Name("a", isNegated = false),
+                            EntitySelectorArgument.Name("b", isNegated = true),
+                        ),
+                    )
+                }
+
+                shouldThrow<IllegalArgumentException> {
+                    EntitySelector(
+                        EntitySelectorHead.ENTITIES,
+                        listOf(
+                            EntitySelectorArgument.Name("a", isNegated = true),
+                            EntitySelectorArgument.Name("b", isNegated = false),
+                        ),
+                    )
+                }
+
+                shouldThrow<IllegalArgumentException> {
+                    EntitySelector(
+                        EntitySelectorHead.ENTITIES,
+                        listOf(
+                            EntitySelectorArgument.Type(
+                                SelectorEntityType.Direct(key("minecraft", "zombie")),
+                                isNegated = true,
+                            ),
+                            EntitySelectorArgument.Type(
+                                SelectorEntityType.Direct(key("minecraft", "skeleton")),
+                                isNegated = false,
+                            ),
+                        ),
+                    )
+                }
+
+                shouldThrow<IllegalArgumentException> {
+                    EntitySelector(
+                        EntitySelectorHead.ALL_PLAYERS,
+                        listOf(
+                            EntitySelectorArgument.GameMode(GameMode.SURVIVAL, isNegated = true),
+                            EntitySelectorArgument.GameMode(GameMode.CREATIVE, isNegated = false),
+                        ),
+                    )
+                }
+
+                shouldThrow<IllegalArgumentException> {
+                    EntitySelector(
+                        EntitySelectorHead.ENTITIES,
+                        listOf(
+                            EntitySelectorArgument.Team(SelectorStringCondition.Named("red", isNegated = true)),
+                            EntitySelectorArgument.Team(SelectorStringCondition.Named("blue")),
+                        ),
+                    )
+                }
+            }
+
+            "allows exclusive exclusions and repeatable mixed filter groups on the model" {
+                EntitySelector(
+                    EntitySelectorHead.ENTITIES,
+                    listOf(
+                        EntitySelectorArgument.Name("a", isNegated = true),
+                        EntitySelectorArgument.Name("b", isNegated = true),
+                        EntitySelectorArgument.Tag(SelectorStringCondition.Named("admin")),
+                        EntitySelectorArgument.Tag(SelectorStringCondition.Named("hidden", isNegated = true)),
+                    ),
+                ) shouldRenderAs "@e[name=!a,name=!b,tag=admin,tag=!hidden]"
+            }
+
             "represents direct entity types and type tags without a boolean flag" {
                 val direct =
                     parseSelector("@e[type=minecraft:zombie]")
@@ -175,7 +293,7 @@ class EntitySelectorModelTest :
             }
 
             "models tag and team presence explicitly" {
-                val parsed = parseSelector("@e[tag=,tag=!,team=red,team=!blue]")
+                val parsed = parseSelector("@e[tag=,tag=!,team=!red,team=!blue]")
 
                 parsed.arguments.filterIsInstance<EntitySelectorArgument.Tag>() shouldBe
                         listOf(
@@ -184,7 +302,7 @@ class EntitySelectorModelTest :
                         )
                 parsed.arguments.filterIsInstance<EntitySelectorArgument.Team>() shouldBe
                         listOf(
-                            EntitySelectorArgument.Team(SelectorStringCondition.Named("red")),
+                            EntitySelectorArgument.Team(SelectorStringCondition.Named("red", isNegated = true)),
                             EntitySelectorArgument.Team(SelectorStringCondition.Named("blue", isNegated = true)),
                         )
             }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorModelTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorModelTest.kt
@@ -61,121 +61,102 @@ class EntitySelectorModelTest :
                 negatable.count { it.isNegated } shouldBe 2
             }
 
-            "rejects duplicate singleton arguments on the model" {
-                shouldThrow<IllegalArgumentException> {
-                    EntitySelector(
-                        EntitySelectorHead.ENTITIES,
-                        listOf(
-                            EntitySelectorArgument.Limit(1),
-                            EntitySelectorArgument.Limit(2),
+            listOf(
+                Triple(
+                    "model rejects a duplicate singleton argument",
+                    EntitySelectorHead.ENTITIES,
+                    listOf(
+                        EntitySelectorArgument.Limit(1),
+                        EntitySelectorArgument.Limit(2),
+                    ),
+                ),
+                Triple(
+                    "model rejects two positive name filters",
+                    EntitySelectorHead.ENTITIES,
+                    listOf(
+                        EntitySelectorArgument.Name("a", isNegated = false),
+                        EntitySelectorArgument.Name("b", isNegated = false),
+                    ),
+                ),
+                Triple(
+                    "model rejects two positive type filters",
+                    EntitySelectorHead.ENTITIES,
+                    listOf(
+                        EntitySelectorArgument.Type(
+                            SelectorEntityType.Direct(key("minecraft", "zombie")),
+                            isNegated = false,
                         ),
-                    )
-                }
-            }
-
-            "rejects two positive exclusive filter-group values on the model" {
-                shouldThrow<IllegalArgumentException> {
-                    EntitySelector(
-                        EntitySelectorHead.ENTITIES,
-                        listOf(
-                            EntitySelectorArgument.Name("a", isNegated = false),
-                            EntitySelectorArgument.Name("b", isNegated = false),
+                        EntitySelectorArgument.Type(
+                            SelectorEntityType.Direct(key("minecraft", "skeleton")),
+                            isNegated = false,
                         ),
-                    )
-                }
-
-                shouldThrow<IllegalArgumentException> {
-                    EntitySelector(
-                        EntitySelectorHead.ENTITIES,
-                        listOf(
-                            EntitySelectorArgument.Type(
-                                SelectorEntityType.Direct(key("minecraft", "zombie")),
-                                isNegated = false,
-                            ),
-                            EntitySelectorArgument.Type(
-                                SelectorEntityType.Direct(key("minecraft", "skeleton")),
-                                isNegated = false,
-                            ),
+                    ),
+                ),
+                Triple(
+                    "model rejects two positive gamemode filters",
+                    EntitySelectorHead.ALL_PLAYERS,
+                    listOf(
+                        EntitySelectorArgument.GameMode(GameMode.SURVIVAL, isNegated = false),
+                        EntitySelectorArgument.GameMode(GameMode.CREATIVE, isNegated = false),
+                    ),
+                ),
+                Triple(
+                    "model rejects two positive team filters",
+                    EntitySelectorHead.ENTITIES,
+                    listOf(
+                        EntitySelectorArgument.Team(SelectorStringCondition.Named("red")),
+                        EntitySelectorArgument.Team(SelectorStringCondition.Named("blue")),
+                    ),
+                ),
+                Triple(
+                    "model rejects a name exclusion after a positive name",
+                    EntitySelectorHead.ENTITIES,
+                    listOf(
+                        EntitySelectorArgument.Name("a", isNegated = false),
+                        EntitySelectorArgument.Name("b", isNegated = true),
+                    ),
+                ),
+                Triple(
+                    "model rejects a positive name after name exclusions",
+                    EntitySelectorHead.ENTITIES,
+                    listOf(
+                        EntitySelectorArgument.Name("a", isNegated = true),
+                        EntitySelectorArgument.Name("b", isNegated = false),
+                    ),
+                ),
+                Triple(
+                    "model rejects a positive type after a type exclusion",
+                    EntitySelectorHead.ENTITIES,
+                    listOf(
+                        EntitySelectorArgument.Type(
+                            SelectorEntityType.Direct(key("minecraft", "zombie")),
+                            isNegated = true,
                         ),
-                    )
-                }
-
-                shouldThrow<IllegalArgumentException> {
-                    EntitySelector(
-                        EntitySelectorHead.ALL_PLAYERS,
-                        listOf(
-                            EntitySelectorArgument.GameMode(GameMode.SURVIVAL, isNegated = false),
-                            EntitySelectorArgument.GameMode(GameMode.CREATIVE, isNegated = false),
+                        EntitySelectorArgument.Type(
+                            SelectorEntityType.Direct(key("minecraft", "skeleton")),
+                            isNegated = false,
                         ),
-                    )
-                }
-
-                shouldThrow<IllegalArgumentException> {
-                    EntitySelector(
-                        EntitySelectorHead.ENTITIES,
-                        listOf(
-                            EntitySelectorArgument.Team(SelectorStringCondition.Named("red")),
-                            EntitySelectorArgument.Team(SelectorStringCondition.Named("blue")),
-                        ),
-                    )
-                }
-            }
-
-            "rejects exclusive positive mixed with exclusions on the model" {
-                shouldThrow<IllegalArgumentException> {
-                    EntitySelector(
-                        EntitySelectorHead.ENTITIES,
-                        listOf(
-                            EntitySelectorArgument.Name("a", isNegated = false),
-                            EntitySelectorArgument.Name("b", isNegated = true),
-                        ),
-                    )
-                }
-
-                shouldThrow<IllegalArgumentException> {
-                    EntitySelector(
-                        EntitySelectorHead.ENTITIES,
-                        listOf(
-                            EntitySelectorArgument.Name("a", isNegated = true),
-                            EntitySelectorArgument.Name("b", isNegated = false),
-                        ),
-                    )
-                }
-
-                shouldThrow<IllegalArgumentException> {
-                    EntitySelector(
-                        EntitySelectorHead.ENTITIES,
-                        listOf(
-                            EntitySelectorArgument.Type(
-                                SelectorEntityType.Direct(key("minecraft", "zombie")),
-                                isNegated = true,
-                            ),
-                            EntitySelectorArgument.Type(
-                                SelectorEntityType.Direct(key("minecraft", "skeleton")),
-                                isNegated = false,
-                            ),
-                        ),
-                    )
-                }
-
-                shouldThrow<IllegalArgumentException> {
-                    EntitySelector(
-                        EntitySelectorHead.ALL_PLAYERS,
-                        listOf(
-                            EntitySelectorArgument.GameMode(GameMode.SURVIVAL, isNegated = true),
-                            EntitySelectorArgument.GameMode(GameMode.CREATIVE, isNegated = false),
-                        ),
-                    )
-                }
-
-                shouldThrow<IllegalArgumentException> {
-                    EntitySelector(
-                        EntitySelectorHead.ENTITIES,
-                        listOf(
-                            EntitySelectorArgument.Team(SelectorStringCondition.Named("red", isNegated = true)),
-                            EntitySelectorArgument.Team(SelectorStringCondition.Named("blue")),
-                        ),
-                    )
+                    ),
+                ),
+                Triple(
+                    "model rejects a positive gamemode after a gamemode exclusion",
+                    EntitySelectorHead.ALL_PLAYERS,
+                    listOf(
+                        EntitySelectorArgument.GameMode(GameMode.SURVIVAL, isNegated = true),
+                        EntitySelectorArgument.GameMode(GameMode.CREATIVE, isNegated = false),
+                    ),
+                ),
+                Triple(
+                    "model rejects a positive team after a team exclusion",
+                    EntitySelectorHead.ENTITIES,
+                    listOf(
+                        EntitySelectorArgument.Team(SelectorStringCondition.Named("red", isNegated = true)),
+                        EntitySelectorArgument.Team(SelectorStringCondition.Named("blue")),
+                    ),
+                ),
+            ).forEach { (name, head, arguments) ->
+                name {
+                    shouldThrow<IllegalArgumentException> { EntitySelector(head, arguments) }
                 }
             }
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorModelTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorModelTest.kt
@@ -70,8 +70,7 @@ class EntitySelectorModelTest :
                             EntitySelectorArgument.Limit(2),
                         ),
                     )
-                }.message shouldBe
-                    "Selector argument 'limit' is already set; vanilla syntax allows it only once."
+                }
             }
 
             "represents direct entity types and type tags without a boolean flag" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParserTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParserTest.kt
@@ -9,31 +9,28 @@ class EntitySelectorParserTest :
     StringSpec(
         {
             "parses and renders all six selector heads" {
-                listOf("@p", "@a", "@r", "@s", "@e", "@n").forEach { source ->
-                    source.shouldBeCanonicalSelector()
+                listOf("@p", "@a", "@r", "@s", "@e", "@n").forEach {
+                    it.shouldBeCanonicalSelector()
                 }
             }
 
             "round trips every typed selector argument" {
-                val source =
-                    buildString {
-                        append("@e[")
-                        append("type=!#my_pack:hostile,")
-                        append("name=\"Boss Mob\",")
-                        append("x=1.5,y=-2,z=3,dx=0,dy=1,dz=-1,")
-                        append("distance=..10,x_rotation=170..-170,y_rotation=-45..45,")
-                        append("level=1..30,gamemode=!creative,limit=2,sort=nearest,")
-                        append("tag=!,tag=!hidden,team=!red,team=!blue,")
-                        append("nbt={Tags:[\"boss\"],Data:[I;1,2]},")
-                        append("nbt={Health:20.0f},")
-                        append("scores={kills=5,balance=-10..},")
-                        append("predicate=!my_pack:hidden,")
-                        append("predicate=my_pack:other,")
-                        append("advancements={minecraft:story/root=true,my_pack:secret={found_item=false}}")
-                        append(']')
-                    }
-
-                source.shouldBeCanonicalSelector()
+                buildString {
+                    append("@e[")
+                    append("type=!#my_pack:hostile,")
+                    append("name=\"Boss Mob\",")
+                    append("x=1.5,y=-2,z=3,dx=0,dy=1,dz=-1,")
+                    append("distance=..10,x_rotation=170..-170,y_rotation=-45..45,")
+                    append("level=1..30,gamemode=!creative,limit=2,sort=nearest,")
+                    append("tag=!,tag=!hidden,team=!red,team=!blue,")
+                    append("nbt={Tags:[\"boss\"],Data:[I;1,2]},")
+                    append("nbt={Health:20.0f},")
+                    append("scores={kills=5,balance=-10..},")
+                    append("predicate=!my_pack:hidden,")
+                    append("predicate=my_pack:other,")
+                    append("advancements={minecraft:story/root=true,my_pack:secret={found_item=false}}")
+                    append(']')
+                }.shouldBeCanonicalSelector()
             }
 
             "canonicalizes empty argument lists" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParserTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParserTest.kt
@@ -23,7 +23,7 @@ class EntitySelectorParserTest :
                         append("x=1.5,y=-2,z=3,dx=0,dy=1,dz=-1,")
                         append("distance=..10,x_rotation=170..-170,y_rotation=-45..45,")
                         append("level=1..30,gamemode=!creative,limit=2,sort=nearest,")
-                        append("tag=!,tag=!hidden,team=!red,team=blue,")
+                        append("tag=!,tag=!hidden,team=!red,team=!blue,")
                         append("nbt={Tags:[\"boss\"],Data:[I;1,2]},")
                         append("nbt={Health:20.0f},")
                         append("scores={kills=5,balance=-10..},")
@@ -63,6 +63,33 @@ class EntitySelectorParserTest :
 
             "allows repeated filter-group arguments" {
                 "@e[tag=a,tag=b,nbt={},nbt=!{}]".shouldBeCanonicalSelector()
+            }
+
+            "allows multiple exclusive exclusions without a positive" {
+                "@e[name=!a,name=!b,type=!minecraft:zombie,type=!minecraft:skeleton]".shouldBeCanonicalSelector()
+                "@a[gamemode=!survival,gamemode=!creative,team=!red,team=!blue]".shouldBeCanonicalSelector()
+                "@e[team=!,team=!red]".shouldBeCanonicalSelector()
+            }
+
+            "rejects two positive exclusive filter-group values" {
+                "@e[name=a," shouldFailToParseAt "name=b]"
+                "@e[type=minecraft:zombie," shouldFailToParseAt "type=minecraft:skeleton]"
+                "@a[gamemode=survival," shouldFailToParseAt "gamemode=creative]"
+                "@e[team=red," shouldFailToParseAt "team=blue]"
+                "@e[team=," shouldFailToParseAt "team=red]"
+            }
+
+            "rejects exclusive positive mixed with exclusions" {
+                "@e[name=a," shouldFailToParseAt "name=!b]"
+                "@e[name=!a," shouldFailToParseAt "name=b]"
+                "@e[type=minecraft:zombie," shouldFailToParseAt "type=!minecraft:skeleton]"
+                "@e[type=!minecraft:zombie," shouldFailToParseAt "type=minecraft:skeleton]"
+                "@a[gamemode=survival," shouldFailToParseAt "gamemode=!creative]"
+                "@a[gamemode=!survival," shouldFailToParseAt "gamemode=creative]"
+                "@e[team=red," shouldFailToParseAt "team=!blue]"
+                "@e[team=!red," shouldFailToParseAt "team=blue]"
+                "@e[team=," shouldFailToParseAt "team=!red]"
+                "@e[team=!," shouldFailToParseAt "team=red]"
             }
         },
     )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParserTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParserTest.kt
@@ -53,5 +53,16 @@ class EntitySelectorParserTest :
                 "@s[" shouldFailToParseAt "limit=1]"
                 "@s[" shouldFailToParseAt "sort=nearest]"
             }
+
+            "rejects duplicate singleton arguments" {
+                "@e[limit=1," shouldFailToParseAt "limit=2]"
+                "@e[x=1," shouldFailToParseAt "x=2]"
+                "@e[distance=..5," shouldFailToParseAt "distance=1..]"
+                "@e[sort=nearest," shouldFailToParseAt "sort=furthest]"
+            }
+
+            "allows repeated filter-group arguments" {
+                "@e[tag=a,tag=b,nbt={},nbt=!{}]".shouldBeCanonicalSelector()
+            }
         },
     )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
@@ -32,112 +32,92 @@ class SelectorDslTest :
             }
 
             "builds a selector component with a configured nearest entity" {
-                val component =
-                    selector(
-                        nearestEntity {
-                            type("minecraft:zombie")
-                            distance(atMost(8.0))
-                            limit(1)
-                        },
-                    ).shouldBeSelectorComponent()
-
-                component shouldHaveSelectorPattern "@n[type=minecraft:zombie,distance=..8,limit=1]"
+                selector(
+                    nearestEntity {
+                        type("minecraft:zombie")
+                        distance(atMost(8.0))
+                        limit(1)
+                    },
+                ).shouldBeSelectorComponent() shouldHaveSelectorPattern
+                        "@n[type=minecraft:zombie,distance=..8,limit=1]"
             }
 
             "builds a selector component with typed negated filters" {
-                val component =
-                    selector(
-                        entities {
-                            typeTag(key("minecraft", "raiders"))
-                            !tag("hidden")
-                        },
-                    ).shouldBeSelectorComponent()
-
-                component shouldHaveSelectorPattern "@e[type=#minecraft:raiders,tag=!hidden]"
+                selector(
+                    entities {
+                        typeTag(key("minecraft", "raiders"))
+                        !tag("hidden")
+                    },
+                ).shouldBeSelectorComponent() shouldHaveSelectorPattern
+                        "@e[type=#minecraft:raiders,tag=!hidden]"
             }
 
             "builds a selector component with typed NBT filters" {
-                val component =
-                    selector(
-                        entities {
-                            nbt {
-                                "Tags" eq list("boss")
-                            }
-                            !nbt { "Silent" eq true }
-                        },
-                    ).shouldBeSelectorComponent()
-
-                component shouldHaveSelectorPattern "@e[nbt={Tags:[\"boss\"]},nbt=!{Silent:1b}]"
+                selector(
+                    entities {
+                        nbt {
+                            "Tags" eq list("boss")
+                        }
+                        !nbt { "Silent" eq true }
+                    },
+                ).shouldBeSelectorComponent() shouldHaveSelectorPattern
+                        "@e[nbt={Tags:[\"boss\"]},nbt=!{Silent:1b}]"
             }
 
             "builds a selector component with typed score filters" {
-                val component =
-                    selector(
-                        allPlayers {
-                            scores {
-                                "kills" eq atLeast(10)
-                                "deaths" eq 0..5
-                            }
-                        },
-                    ).shouldBeSelectorComponent()
-
-                component shouldHaveSelectorPattern "@a[scores={kills=10..,deaths=0..5}]"
+                selector(
+                    allPlayers {
+                        scores {
+                            "kills" eq atLeast(10)
+                            "deaths" eq 0..5
+                        }
+                    },
+                ).shouldBeSelectorComponent() shouldHaveSelectorPattern
+                        "@a[scores={kills=10..,deaths=0..5}]"
             }
 
             "builds a selector component with typed predicate filters" {
-                val component =
-                    selector(
-                        entities {
-                            predicate(key("my_pack", "on_fire"))
-                            !predicate(key("my_pack", "hidden"))
-                        },
-                    ).shouldBeSelectorComponent()
-
-                component shouldHaveSelectorPattern "@e[predicate=my_pack:on_fire,predicate=!my_pack:hidden]"
+                selector(
+                    entities {
+                        predicate(key("my_pack", "on_fire"))
+                        !predicate(key("my_pack", "hidden"))
+                    },
+                ).shouldBeSelectorComponent() shouldHaveSelectorPattern
+                        "@e[predicate=my_pack:on_fire,predicate=!my_pack:hidden]"
             }
 
             "builds a selector component with typed advancement filters" {
-                val component =
-                    selector(
-                        allPlayers {
-                            advancements {
-                                key("minecraft", "story/smelt_iron") eq true
-                                key("my_pack", "boss") eq { "kill_dragon" eq true }
-                            }
-                        },
-                    ).shouldBeSelectorComponent()
-
-                component shouldHaveSelectorPattern
+                selector(
+                    allPlayers {
+                        advancements {
+                            key("minecraft", "story/smelt_iron") eq true
+                            key("my_pack", "boss") eq { "kill_dragon" eq true }
+                        }
+                    },
+                ).shouldBeSelectorComponent() shouldHaveSelectorPattern
                         "@a[advancements={minecraft:story/smelt_iron=true,my_pack:boss={kill_dragon=true}}]"
             }
 
             "builds a selector component with a typed origin and volume" {
-                val component =
-                    selector(
-                        nearestEntity {
-                            origin(10.x, (-4).z)
-                            volume(0.dx, 2.dy)
-                        },
-                    ).shouldBeSelectorComponent()
-
-                component shouldHaveSelectorPattern "@n[x=10,z=-4,dx=0,dy=2]"
+                selector(
+                    nearestEntity {
+                        origin(10.x, (-4).z)
+                        volume(0.dx, 2.dy)
+                    },
+                ).shouldBeSelectorComponent() shouldHaveSelectorPattern "@n[x=10,z=-4,dx=0,dy=2]"
             }
 
             "builds a selector component from parsed source" {
-                val component = selector(parseSelector("@e[distance=..10]")).shouldBeSelectorComponent()
-
-                component shouldHaveSelectorPattern "@e[distance=..10]"
+                selector(parseSelector("@e[distance=..10]"))
+                    .shouldBeSelectorComponent() shouldHaveSelectorPattern "@e[distance=..10]"
             }
 
             "sets a component separator" {
                 val separator = text(", ")
 
-                val component =
-                    selector(allPlayers()) {
-                        separator(separator)
-                    }
-
-                component.shouldBeSelectorComponent() shouldHaveSelectorSeparator separator
+                selector(allPlayers()) {
+                    separator(separator)
+                }.shouldBeSelectorComponent() shouldHaveSelectorSeparator separator
             }
 
             "sets an inline text separator" {
@@ -150,28 +130,24 @@ class SelectorDslTest :
                     }
 
                 val separator = checkNotNull(component.shouldBeSelectorComponent().separator())
-
                 separator shouldHaveColor gray
                 separator shouldContainText " | "
             }
 
             "rejects a duplicate separator" {
-                val first = text(", ")
-                val second = text("; ")
                 shouldThrow<IllegalStateException> {
                     selector(allPlayers()) {
-                        separator(first)
-                        separator(second)
+                        separator(text(", "))
+                        separator(text("; "))
                     }
                 }
             }
 
             "rejects a separator after an inline text separator" {
-                val second = text("; ")
                 shouldThrow<IllegalStateException> {
                     selector(allPlayers()) {
                         separator { content(", ") }
-                        separator(second)
+                        separator(text("; "))
                     }
                 }
             }
@@ -204,15 +180,12 @@ class SelectorDslTest :
             }
 
             "uses entities with arguments" {
-                val component =
-                    selector(
-                        entities {
-                            type("zombie")
-                            limit(5)
-                        },
-                    ).shouldBeSelectorComponent()
-
-                component shouldHaveSelectorPattern "@e[type=minecraft:zombie,limit=5]"
+                selector(
+                    entities {
+                        type("zombie")
+                        limit(5)
+                    },
+                ).shouldBeSelectorComponent() shouldHaveSelectorPattern "@e[type=minecraft:zombie,limit=5]"
             }
         },
     )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
@@ -163,7 +163,7 @@ class SelectorDslTest :
                         separator(first)
                         separator(second)
                     }
-                }.message shouldBe "'separator' is already set."
+                }
             }
 
             "applies style to the selector root" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
@@ -173,7 +173,7 @@ class SelectorDslTest :
                         separator { content(", ") }
                         separator(second)
                     }
-                }.message shouldBe "'separator' is already set."
+                }
             }
 
             "applies style to the selector root" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
@@ -14,6 +14,7 @@ import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
 import io.github.lmliam.kotventure.test.text.shouldHaveSelectorPattern
 import io.github.lmliam.kotventure.test.text.shouldHaveSelectorSeparator
 import io.github.lmliam.kotventure.test.text.shouldNotHaveSelectorSeparator
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import net.kyori.adventure.text.Component
@@ -152,6 +153,17 @@ class SelectorDslTest :
 
                 separator shouldHaveColor gray
                 separator shouldContainText " | "
+            }
+
+            "rejects a duplicate separator" {
+                val first = text(", ")
+                val second = text("; ")
+                shouldThrow<IllegalStateException> {
+                    selector(allPlayers()) {
+                        separator(first)
+                        separator(second)
+                    }
+                }.message shouldBe "'separator' is already set."
             }
 
             "applies style to the selector root" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
@@ -135,19 +135,22 @@ class SelectorDslTest :
             }
 
             "rejects a duplicate separator" {
+                val first = text(", ")
+                val second = text("; ")
                 shouldThrow<IllegalStateException> {
                     selector(allPlayers()) {
-                        separator(text(", "))
-                        separator(text("; "))
+                        separator(first)
+                        separator(second)
                     }
                 }
             }
 
             "rejects a separator after an inline text separator" {
+                val second = text("; ")
                 shouldThrow<IllegalStateException> {
                     selector(allPlayers()) {
                         separator { content(", ") }
-                        separator(text("; "))
+                        separator(second)
                     }
                 }
             }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorDslTest.kt
@@ -166,6 +166,16 @@ class SelectorDslTest :
                 }
             }
 
+            "rejects a separator after an inline text separator" {
+                val second = text("; ")
+                shouldThrow<IllegalStateException> {
+                    selector(allPlayers()) {
+                        separator { content(", ") }
+                        separator(second)
+                    }
+                }.message shouldBe "'separator' is already set."
+            }
+
             "applies style to the selector root" {
                 val component =
                     selector(randomPlayer()) {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterArgumentParsingTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterArgumentParsingTest.kt
@@ -34,8 +34,10 @@ class SelectorFilterArgumentParsingTest :
                 """@e[name="Boss \"Mob\""]""".shouldBeCanonicalSelector()
             }
 
-            "preserves repeated empty-value filters" {
-                """@e[tag=,tag=!,team=,team=!]""".shouldBeCanonicalSelector()
+            "preserves repeated empty-value filters on repeatable groups" {
+                """@e[tag=,tag=!]""".shouldBeCanonicalSelector()
+                """@e[team=]""".shouldBeCanonicalSelector()
+                """@e[team=!]""".shouldBeCanonicalSelector()
             }
 
             "rejects malformed names" {


### PR DESCRIPTION
## Summary

Code-quality hygiene batch from the audit (audience / bossbar / sound / timed boss bar / nbt / object / selector):

- **Audience:** `BoundChatBuilder` is `sealed` with nested `Bound` leaf for signed chat
- **Boss bar:** early `0f..1f` progress validation shared with timed bars
- **Sound:** KDoc documents Adventure passthrough (no invented MC clamps)
- **Timed boss bar:** lifecycle/tick/viewer engine extracted to `TimedBossBarRuntime`
- **Object components:** public `renderObjectFallbacks` and `ObjectFallbackRenderer` split (one top-level type per file)
- **NBT:** SNBT boundary documented on the `nbt { }` entry point
- **Selector:**
  - origin/volume KDoc fail-fast (not “override”)
  - package orientation on `EntitySelector` KDoc
  - `separator` once-assign
  - scalar slots via `once()` (coordinates still map + `checkUnset`)
  - parse + model reject duplicate singleton args (filter groups still multi-valued)
  - unused same-package imports removed
- **Keybind/score:** drop unused Adventure type imports

## Test plan

- [x] `./gradlew build` (tests, ktlint, spotless, kover)
- [x] New/updated tests: parse duplicate singletons, separator once, existing boss-bar out-of-range progress
- [ ] PR CI green

## Notes

No public API removals; selector parse is stricter (duplicate `limit`/`x`/… now fail). Filter-group repeats (`tag`, `nbt`, …) remain allowed.