### PR TITLE
feat(minimessage): delegate placeholders and conversion hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ val message = component {
 ## Why Kotventure
 
 - **Ergonomic component trees** — a composable builder for components, styles, colours, and events.
-- **Typed MiniMessage** — `mini(...)` parsing, typed `placeholder<T>(name)` resolvers, and reusable `MiniTemplate`s
+- **Typed MiniMessage** — `mini(...)` parsing, typed resolvers, and reusable `MiniTemplate`s (`val x by placeholder<T>()`)
   with compile-checked bindings (`player bind value`).
 - **Correctness tooling** — Kotest component matchers, snapshot assertions over canonical JSON, and load-time
   MiniMessage validation that reports malformed tags and missing/extra placeholders.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -227,11 +227,16 @@ context(ticker) {
 
 
 // ── Typed MiniMessage template + validation ────────────────────
-val Welcome = miniTemplate("<gold>Welcome <player>, <count> new messages") {
-    placeholder<Component>("player")
-    placeholder<Int>("count")
+object Welcome : MiniTemplate("<gold>Welcome <player>, <count> new messages</gold>") {
+    val player by placeholder<Component>()
+    val count by placeholder<Int>()
 }
-player.message(Welcome { player = name; count = 3 })
+player.message(
+    Welcome {
+        player bind name
+        count bind 3
+    },
+)
 
 // ── Typed catalog (KSP from messages.yml) ──────────────────────
 Messages.welcome(player = name, count = 3)   // generated, validated placeholders
@@ -274,8 +279,8 @@ update process.
 Three layers, shipped incrementally:
 
 1. **Passthrough** — `mini("<red>hi")` wrapping the parser, plus a tag‑resolver DSL.
-2. **Typed placeholders & templates** — `miniTemplate(...) { placeholder<T>(...) }` producing reusable, type‑checked
-   message factories.
+2. **Typed placeholders & templates** — `object : MiniTemplate("…") { val x by placeholder<T>() }` producing reusable,
+   type‑checked message factories (property name is the tag; optional `placeholder<T>("tag")` when they differ).
 3. **Validation** — detect malformed tags and missing/extra placeholders at load time (runtime API) and at **build time
    ** (Gradle plugin over resource bundles).
 

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslArguments.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslArguments.kt
@@ -7,42 +7,10 @@ internal fun KotlinSourceBuilder.appendArgument(argument: TranslationArgument) {
     when (val value = argument.value()) {
         is Component -> appendComponentArgument("arg", value)
         is Boolean -> line("arg($value)")
-        is Number -> line("arg(${value.toKotlinSource()})")
+        is Number -> line("arg(${kotlinNumberLiteral(value)})")
         else ->
             conversionError(
                 "miniToDsl cannot represent ${value::class.qualifiedName} translatable argument.",
             )
     }
 }
-
-private fun Number.toKotlinSource(): String =
-    when (this) {
-        is Double -> nonFiniteSource() ?: toString()
-        is Float -> nonFiniteSource() ?: "${this}f"
-        is Long -> toKotlinSource()
-        is Byte -> toKotlinSource()
-        is Short -> toKotlinSource()
-        else -> toString()
-    }
-
-private fun Long.toKotlinSource(): String = if (this == Long.MIN_VALUE) "Long.MIN_VALUE" else "${this}L"
-
-private fun Byte.toKotlinSource(): String = "($this).toByte()"
-
-private fun Short.toKotlinSource(): String = "($this).toShort()"
-
-private fun Double.nonFiniteSource(): String? =
-    when {
-        isNaN() -> "Double.NaN"
-        this == Double.POSITIVE_INFINITY -> "Double.POSITIVE_INFINITY"
-        this == Double.NEGATIVE_INFINITY -> "Double.NEGATIVE_INFINITY"
-        else -> null
-    }
-
-private fun Float.nonFiniteSource(): String? =
-    when {
-        isNaN() -> "Float.NaN"
-        this == Float.POSITIVE_INFINITY -> "Float.POSITIVE_INFINITY"
-        this == Float.NEGATIVE_INFINITY -> "Float.NEGATIVE_INFINITY"
-        else -> null
-    }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslLiterals.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslLiterals.kt
@@ -128,7 +128,7 @@ internal fun escapeKotlinString(value: String): String =
                 '\t' -> append("\\t")
                 '$' -> append('\\').append('$')
                 else ->
-                    if (character.isISOControl() && character !in "\n\r\t") {
+                    if (character.isISOControl()) {
                         append("\\u%04X".format(Locale.ROOT, character.code))
                     } else {
                         append(character)

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslLiterals.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslLiterals.kt
@@ -127,7 +127,54 @@ internal fun escapeKotlinString(value: String): String =
                 '\r' -> append("\\r")
                 '\t' -> append("\\t")
                 '$' -> append('\\').append('$')
-                else -> append(character)
+                else ->
+                    if (character.isISOControl() && character !in "\n\r\t") {
+                        append("\\u%04X".format(Locale.ROOT, character.code))
+                    } else {
+                        append(character)
+                    }
             }
         }
+    }
+
+/** Emits a [Byte] literal, parenthesising negatives so the [Byte] type is preserved. */
+internal fun kotlinByteLiteral(value: Byte): String = if (value < 0) "($value).toByte()" else "$value.toByte()"
+
+/** Emits a [Short] literal, parenthesising negatives so the [Short] type is preserved. */
+internal fun kotlinShortLiteral(value: Short): String = if (value < 0) "($value).toShort()" else "$value.toShort()"
+
+/** Emits an [Int] literal, handling the special case of [Int.MIN_VALUE]. */
+internal fun kotlinIntLiteral(value: Int): String = if (value == Int.MIN_VALUE) "Int.MIN_VALUE" else value.toString()
+
+/** Emits a [Long] literal with an `L` suffix, handling the special case of [Long.MIN_VALUE]. */
+internal fun kotlinLongLiteral(value: Long): String = if (value == Long.MIN_VALUE) "Long.MIN_VALUE" else "${value}L"
+
+/** Emits a [Float] literal, including non-finite constants. */
+internal fun kotlinFloatLiteral(value: Float): String =
+    when {
+        value.isNaN() -> "Float.NaN"
+        value == Float.POSITIVE_INFINITY -> "Float.POSITIVE_INFINITY"
+        value == Float.NEGATIVE_INFINITY -> "Float.NEGATIVE_INFINITY"
+        else -> "${value}f"
+    }
+
+/** Emits a [Double] literal, including non-finite constants. */
+internal fun kotlinDoubleLiteral(value: Double): String =
+    when {
+        value.isNaN() -> "Double.NaN"
+        value == Double.POSITIVE_INFINITY -> "Double.POSITIVE_INFINITY"
+        value == Double.NEGATIVE_INFINITY -> "Double.NEGATIVE_INFINITY"
+        else -> value.toString()
+    }
+
+/** Emits a [Number] as the matching Kotlin source literal for MiniMessage ⇄ DSL conversion. */
+internal fun kotlinNumberLiteral(value: Number): String =
+    when (value) {
+        is Double -> kotlinDoubleLiteral(value)
+        is Float -> kotlinFloatLiteral(value)
+        is Long -> kotlinLongLiteral(value)
+        is Byte -> kotlinByteLiteral(value)
+        is Short -> kotlinShortLiteral(value)
+        is Int -> kotlinIntLiteral(value)
+        else -> value.toString()
     }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDsl.kt
@@ -53,21 +53,21 @@ private fun renderCompoundBody(compound: CompoundBinaryTag): String? =
 
 private fun renderTag(tag: BinaryTag): String? =
     when (tag) {
-        is ByteBinaryTag -> renderByteLiteral(tag.value())
-        is ShortBinaryTag -> renderShortLiteral(tag.value())
-        is IntBinaryTag -> renderIntLiteral(tag.value())
-        is LongBinaryTag -> renderLongLiteral(tag.value())
-        is FloatBinaryTag -> "${tag.value()}f"
-        is DoubleBinaryTag -> tag.value().toString()
+        is ByteBinaryTag -> kotlinByteLiteral(tag.value())
+        is ShortBinaryTag -> kotlinShortLiteral(tag.value())
+        is IntBinaryTag -> kotlinIntLiteral(tag.value())
+        is LongBinaryTag -> kotlinLongLiteral(tag.value())
+        is FloatBinaryTag -> kotlinFloatLiteral(tag.value())
+        is DoubleBinaryTag -> kotlinDoubleLiteral(tag.value())
         is StringBinaryTag -> "\"${escapeKotlinString(tag.value())}\""
         is ByteArrayBinaryTag ->
             tag.value().joinToString(", ", prefix = "byteArrayOf(", postfix = ")")
 
         is IntArrayBinaryTag ->
-            tag.value().joinToString(", ", prefix = "intArrayOf(", postfix = ")") { renderIntLiteral(it) }
+            tag.value().joinToString(", ", prefix = "intArrayOf(", postfix = ")") { kotlinIntLiteral(it) }
 
         is LongArrayBinaryTag ->
-            tag.value().joinToString(", ", prefix = "longArrayOf(", postfix = ")") { renderLongLiteral(it) }
+            tag.value().joinToString(", ", prefix = "longArrayOf(", postfix = ")") { kotlinLongLiteral(it) }
 
         is CompoundBinaryTag ->
             renderCompoundBody(tag)?.toCompoundLiteral()
@@ -86,15 +86,3 @@ private fun renderListLiteral(list: ListBinaryTag): String? {
 }
 
 private fun String.toCompoundLiteral(): String = if (isEmpty()) "{ }" else "{ $this }"
-
-/** Emits a [Byte] literal, parenthesising negatives to preserve the [Byte] type. */
-private fun renderByteLiteral(value: Byte): String = if (value < 0) "($value).toByte()" else "$value.toByte()"
-
-/** Emits a [Short] literal, parenthesising negatives to preserve the [Short] type. */
-private fun renderShortLiteral(value: Short): String = if (value < 0) "($value).toShort()" else "$value.toShort()"
-
-/** Emits an [Int] literal, handling the special case of [Int.MIN_VALUE]. */
-private fun renderIntLiteral(value: Int): String = if (value == Int.MIN_VALUE) "Int.MIN_VALUE" else value.toString()
-
-/** Emits a [Long] literal with an `L` suffix, handling the special case of [Long.MIN_VALUE]. */
-private fun renderLongLiteral(value: Long): String = if (value == Long.MIN_VALUE) "Long.MIN_VALUE" else "${value}L"

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/template/MiniTemplate.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/template/MiniTemplate.kt
@@ -6,13 +6,16 @@ import io.github.lmliam.kotventure.minimessage.validation.runValidation
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+import kotlin.properties.PropertyDelegateProvider
+import kotlin.properties.ReadOnlyProperty
 import io.github.lmliam.kotventure.minimessage.placeholder.placeholder as createPlaceholder
 
 /**
  * Typed, reusable MiniMessage template with declared placeholders.
  *
- * Subclass and declare each placeholder as a property; rendering invokes the template and binds every
- * placeholder with the [bind][MiniTemplateBindingScope.bind] infix function:
+ * Subclass and declare each placeholder as a delegated property so the property name is the tag
+ * name (compile-checked at call sites). Render with the [invoke] operator and bind values with
+ * [bind][MiniTemplateBindingScope.bind]:
  *
  * @sample io.github.lmliam.kotventure.minimessage.template.miniTemplateRenderSample
  *
@@ -36,7 +39,26 @@ public abstract class MiniTemplate(
     }
 
     /**
-     * Declares a required placeholder on this template.
+     * Declares a required placeholder whose MiniMessage tag name is this property's name.
+     *
+     * Prefer this form so the Kotlin property and the markup tag cannot drift:
+     * `val player by placeholder<Component>()`.
+     *
+     * @throws IllegalArgumentException when the property name is not a valid MiniMessage tag, is
+     *   already declared, or [T] is unsupported.
+     */
+    protected inline fun <reified T : Any> placeholder():
+        PropertyDelegateProvider<MiniTemplate, ReadOnlyProperty<MiniTemplate, MiniMessagePlaceholder<T>>> =
+        PropertyDelegateProvider { template, property ->
+            val registered = template.register(createPlaceholder<T>(property.name))
+            ReadOnlyProperty { _, _ -> registered }
+        }
+
+    /**
+     * Declares a required placeholder with an explicit MiniMessage tag [name].
+     *
+     * Use only when the tag must differ from the Kotlin property name (interop / legacy markup).
+     * Prefer [placeholder] with no name so the property name is the tag.
      *
      * @throws IllegalArgumentException when [name] is invalid or already declared, or [T] is unsupported.
      */

--- a/modules/minimessage/src/samples/kotlin/io/github/lmliam/kotventure/minimessage/template/MiniTemplateSamples.kt
+++ b/modules/minimessage/src/samples/kotlin/io/github/lmliam/kotventure/minimessage/template/MiniTemplateSamples.kt
@@ -7,8 +7,8 @@ import net.kyori.adventure.text.Component
 internal fun miniTemplateRenderSample() {
     val template =
         object : MiniTemplate("<gold>Welcome <player>, <count> new messages</gold>") {
-            val player = placeholder<Component>("player")
-            val count = placeholder<Int>("count")
+            val player by placeholder<Component>()
+            val count by placeholder<Int>()
         }
 
     val forAlex =

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniTemplateTest.kt
@@ -16,30 +16,36 @@ import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 
 // Fixtures declared at file scope so they exercise the object-init path and are shared across tests.
 
 private object WelcomeTemplate : MiniTemplate("<gold>Welcome <player>, <count> new messages</gold>") {
-    val player = placeholder<Component>("player")
-    val count = placeholder<Int>("count")
+    val player by placeholder<Component>()
+    val count by placeholder<Int>()
 }
 
 /** Declares an "unused" placeholder absent from the markup, making the definition invalid. */
 private object SparseTemplate : MiniTemplate("<gold>Hello <name></gold>") {
-    val name = placeholder<String>("name")
-    val unused = placeholder<Int>("unused")
+    val name by placeholder<String>()
+    val unused by placeholder<Int>()
 }
 
 /** Declares a "player" placeholder of a different type than [WelcomeTemplate]. */
 private object AltTemplate : MiniTemplate("<red>Alt <player>") {
-    val player = placeholder<String>("player")
+    val player by placeholder<String>()
 }
 
 /** Declares a "player" descriptor structurally equal to [WelcomeTemplate]'s, but a distinct object. */
 private object SameTypeAltTemplate : MiniTemplate("<red>Alt <player>") {
-    val player = placeholder<Component>("player")
+    val player by placeholder<Component>()
+}
+
+/** Tag name differs from the property name — explicit-name bridge for legacy/interop markup. */
+private object RenamedTagTemplate : MiniTemplate("<gold>Hi <user></gold>") {
+    val displayName = placeholder<String>("user")
 }
 
 class MiniTemplateTest :
@@ -222,12 +228,25 @@ class MiniTemplateTest :
                 }
             }
 
+            describe("delegated placeholder names") {
+                it("uses the property name as the MiniMessage tag") {
+                    WelcomeTemplate.player.name shouldBe "player"
+                    WelcomeTemplate.count.name shouldBe "count"
+                }
+
+                it("renders when the tag name is set explicitly and differs from the property") {
+                    val rendered = RenamedTagTemplate { displayName bind "Alex" }
+
+                    rendered shouldContainText "Alex"
+                }
+            }
+
             describe("definition validation") {
                 it("rejects duplicate placeholder names at construction") {
                     shouldThrow<IllegalArgumentException> {
                         object : MiniTemplate("<a>") {
                             @Suppress("unused")
-                            val first = placeholder<String>("a")
+                            val a by placeholder<String>()
 
                             @Suppress("unused")
                             val second = placeholder<Int>("a")

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDslTest.kt
@@ -7,6 +7,10 @@ import io.kotest.matchers.shouldBe
 class SnbtToDslTest :
     StringSpec(
         {
+            "escapes ISO control characters in Kotlin string literals" {
+                quoted("a\u0001b\u007fc") shouldBe "\"a\\u0001b\\u007Fc\""
+            }
+
             "parses a single byte entry" {
                 snbtToDslBody("{kotventure:1b}") shouldBe
                         "\"kotventure\" eq 1.toByte()"

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/external/MiniTemplateExternalDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/external/MiniTemplateExternalDslTest.kt
@@ -9,8 +9,8 @@ import io.kotest.core.spec.style.StringSpec
 import net.kyori.adventure.text.Component
 
 private object ExternalWelcomeTemplate : MiniTemplate("<gold>Welcome <player>, <count> new messages</gold>") {
-    val player = placeholder<Component>("player")
-    val count = placeholder<Int>("count")
+    val player by placeholder<Component>()
+    val count by placeholder<Int>()
 }
 
 class MiniTemplateExternalDslTest :


### PR DESCRIPTION
## Summary

MiniMessage audit slice (F-MM-1, F-MM-4, F-MM-5, F-MM-6; F-MM-2/3 unchanged keep):

- **Templates:** primary API is `val player by placeholder<Component>()` so the property name is the MiniMessage tag (Theme-style `PropertyDelegateProvider`). Explicit `placeholder<T>("tag")` remains for tag ≠ property interop only.
- **Conversion:** `escapeKotlinString` emits `\uXXXX` for remaining ISO controls; shared `kotlin*Literal` helpers unify SNBT + translation-argument numeric emission (no god-file collapse).
- **Docs:** DESIGN sketch and README match the shipped `MiniTemplate` object + bind API.

## Call sites

```kotlin
object Welcome : MiniTemplate("<gold>Welcome <player>, <count> new messages</gold>") {
    val player by placeholder<Component>()
    val count by placeholder<Int>()
}

Welcome {
    player bind name
    count bind 3
}
```

## Test plan

- [x] `./gradlew :minimessage:test build`
- [x] Delegate name + explicit rename tag tests
- [x] Control-char escape test
- [ ] PR CI green