### PR TITLE
feat(audience): add the dialog dsl

### DIFF
--- a/modules/core/build.gradle
+++ b/modules/core/build.gradle
@@ -1,5 +1,11 @@
 description = 'Core DSL primitives and explicit extension registry.'
 
+kotlin {
+    compilerOptions {
+        optIn.add('io.github.lmliam.kotventure.core.dsl.InternalKotventureApi')
+    }
+}
+
 apply from: rootProject.file('gradle/vanilla-conformance.gradle')
 
 dependencies {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/dsl/InternalKotventureApi.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/dsl/InternalKotventureApi.kt
@@ -1,0 +1,21 @@
+package io.github.lmliam.kotventure.core.dsl
+
+/**
+ * Marks infrastructure shared between Kotventure modules but not intended as end-user API.
+ *
+ * Opted-in declarations may change without the compatibility guarantees of the public DSL.
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This is internal Kotventure infrastructure and is not intended for end-user code.",
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.TYPEALIAS,
+)
+@MustBeDocumented
+public annotation class InternalKotventureApi

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/dsl/OnceAssign.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/dsl/OnceAssign.kt
@@ -1,30 +1,43 @@
 package io.github.lmliam.kotventure.core.dsl
 
-import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 /**
- * A builder slot that may be assigned at most once.
+ * A write-once property delegate for nullable builder slots.
  *
- * By default the failure message reuses the delegated property's name, so a slot's DSL name and its
- * diagnostic cannot drift apart. Pass [alreadySetMessage] when the backing property name is not the
- * public slot name (e.g. a scope-bound val occupies that name).
+ * Reads return `null` until the first assignment. The first assignment is accepted even when its
+ * value is `null`; every later assignment fails.
+ *
+ * The default failure message includes the delegated property's name. Supply a custom message
+ * when the delegate's property name differs from the public DSL slot name.
+ *
+ * This type is intentionally non-generic: its `getValue`/`setValue` operators are generic
+ * instead, so `by once()` infers its type from the delegated property (the same mechanism as
+ * `kotlin.properties.Delegates.notNull()`), and chains such as `by
+ * once().inRange(1..1024)` (see [inRange]) infer without an explicit type argument.
  */
-internal class OnceAssign<T>(
-    private val alreadySetMessage: (() -> String)? = null,
-) : ReadWriteProperty<Any?, T?> {
+@InternalKotventureApi
+public class OnceAssign internal constructor(
+    internal val alreadySetMessage: (() -> String)? = null,
+) {
     private var assigned = false
-    private var value: T? = null
-
-    override fun getValue(
-        thisRef: Any?,
-        property: KProperty<*>,
-    ): T? = value
+    private var value: Any? = null
 
     /**
-     * @throws IllegalStateException when the property was already assigned.
+     * Returns the assigned value, or `null` before the slot has been assigned.
      */
-    override fun setValue(
+    @Suppress("UNCHECKED_CAST")
+    public operator fun <T> getValue(
+        thisRef: Any?,
+        property: KProperty<*>,
+    ): T? = value as T?
+
+    /**
+     * Assigns the slot once.
+     *
+     * @throws IllegalStateException when the slot has already been assigned.
+     */
+    public operator fun <T> setValue(
         thisRef: Any?,
         property: KProperty<*>,
         value: T?,
@@ -32,15 +45,19 @@ internal class OnceAssign<T>(
         check(!assigned) {
             alreadySetMessage?.invoke() ?: "'${property.name}' is already set."
         }
+
         assigned = true
-        this.value = value
+        this@OnceAssign.value = value
     }
 }
 
 /**
- * Creates a [OnceAssign] slot for a `by`-delegated builder property.
+ * Creates a write-once delegate for a nullable builder property.
  *
- * @param alreadySetMessage optional failure message when the slot is assigned a second time;
- *   defaults to `"'{property.name}' is already set."`.
+ * The optional [alreadySetMessage] is evaluated only when a second assignment is attempted.
+ *
+ * @param alreadySetMessage custom duplicate-assignment message; otherwise the delegated property's
+ *   name is used.
  */
-internal fun <T> once(alreadySetMessage: (() -> String)? = null): OnceAssign<T> = OnceAssign(alreadySetMessage)
+@InternalKotventureApi
+public fun once(alreadySetMessage: (() -> String)? = null): OnceAssign = OnceAssign(alreadySetMessage)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/dsl/OnceValidation.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/dsl/OnceValidation.kt
@@ -1,0 +1,23 @@
+package io.github.lmliam.kotventure.core.dsl
+
+/**
+ * Returns a delegate that additionally rejects values outside [range].
+ *
+ * @throws IllegalArgumentException when an assigned value is outside [range].
+ */
+@InternalKotventureApi
+public fun <T : Comparable<T>> OnceAssign.inRange(range: ClosedRange<T>): ValidatedOnceAssign<T> =
+    ValidatedOnceAssign(alreadySetMessage) { name, value ->
+        require(value in range) { "'$name' must be in $range, was $value." }
+    }
+
+/**
+ * Returns a delegate that additionally rejects non-positive values.
+ *
+ * @throws IllegalArgumentException when an assigned value is not positive.
+ */
+@InternalKotventureApi
+public fun <T> OnceAssign.positive(): ValidatedOnceAssign<T> where T : Number, T : Comparable<T> =
+    ValidatedOnceAssign(alreadySetMessage) { name, value ->
+        require(value.toDouble() > 0.0) { "'$name' must be positive, was $value." }
+    }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/dsl/ValidatedOnceAssign.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/dsl/ValidatedOnceAssign.kt
@@ -1,0 +1,59 @@
+package io.github.lmliam.kotventure.core.dsl
+
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * A write-once property delegate for nullable builder slots that additionally validates every
+ * non-null assignment.
+ *
+ * Reads return `null` until the first assignment. The double-set check runs first: a second
+ * assignment always fails with [IllegalStateException], even if the new value would itself be
+ * valid. [validate] then runs on non-null values; a rejected value does not consume the slot, so
+ * a later, valid assignment still succeeds.
+ *
+ * Built by combinators such as [inRange] and [positive] on [OnceAssign]; not constructed
+ * directly.
+ */
+@InternalKotventureApi
+public class ValidatedOnceAssign<T> internal constructor(
+    private val alreadySetMessage: (() -> String)?,
+    private val validate: (name: String, value: T & Any) -> Unit,
+) : ReadWriteProperty<Any?, T?> {
+    private var assigned = false
+    private var value: T? = null
+
+    /**
+     * Returns the assigned value, or `null` before the slot has been assigned.
+     */
+    override fun getValue(
+        thisRef: Any?,
+        property: KProperty<*>,
+    ): T? = value
+
+    /**
+     * Assigns the slot once.
+     *
+     * A `null` assignment still consumes the slot. A non-null [value] is validated first; a
+     * rejected value does not consume the slot.
+     *
+     * @throws IllegalStateException when the slot has already been assigned.
+     * @throws IllegalArgumentException when [validate] rejects a non-null [value].
+     */
+    override fun setValue(
+        thisRef: Any?,
+        property: KProperty<*>,
+        value: T?,
+    ) {
+        check(!assigned) {
+            alreadySetMessage?.invoke() ?: "'${property.name}' is already set."
+        }
+
+        if (value != null) {
+            validate(property.name, value)
+        }
+
+        assigned = true
+        this@ValidatedOnceAssign.value = value
+    }
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/dsl/InternalKotventureApiTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/dsl/InternalKotventureApiTest.kt
@@ -1,0 +1,21 @@
+package io.github.lmliam.kotventure.core.dsl
+
+import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
+import io.kotest.core.spec.style.StringSpec
+
+class InternalKotventureApiTest :
+    StringSpec(
+        {
+            "requires external callers to opt in to internal APIs" {
+                assertDoesNotCompile(
+                    "InternalApiUsage.kt",
+                    """
+                    import io.github.lmliam.kotventure.core.dsl.once
+
+                    val slot: String? by once()
+                    """.trimIndent(),
+                    "This is internal Kotventure infrastructure and is not intended for end-user code.",
+                )
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/dsl/OnceAssignTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/dsl/OnceAssignTest.kt
@@ -1,0 +1,116 @@
+package io.github.lmliam.kotventure.core.dsl
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class OnceAssignTest :
+    StringSpec(
+        {
+            "accepts a value within range" {
+                var slot: Int? by once().inRange(1..10)
+                slot = 5
+                slot shouldBe 5
+            }
+
+            "rejects a value outside range" {
+                var slot: Int? by once().inRange(1..10)
+
+                shouldThrow<IllegalArgumentException> {
+                    slot = 11
+                }
+            }
+
+            "does not consume the slot when an in-range validation fails" {
+                var slot: Int? by once().inRange(1..10)
+
+                shouldThrow<IllegalArgumentException> {
+                    slot = 11
+                }
+                slot = 5
+
+                slot shouldBe 5
+            }
+
+            "accepts a positive int" {
+                var slot: Int? by once().positive()
+                slot = 3
+                slot shouldBe 3
+            }
+
+            "rejects a non-positive int" {
+                var slot: Int? by once().positive()
+
+                shouldThrow<IllegalArgumentException> {
+                    slot = 0
+                }
+            }
+
+            "accepts a positive float" {
+                var slot: Float? by once().positive()
+                slot = 1.5f
+                slot shouldBe 1.5f
+            }
+
+            "rejects a non-positive float" {
+                var slot: Float? by once().positive()
+
+                shouldThrow<IllegalArgumentException> {
+                    slot = -1f
+                }
+            }
+
+            "does not consume the slot when a positive validation fails" {
+                var slot: Int? by once().positive()
+
+                shouldThrow<IllegalArgumentException> {
+                    slot = 0
+                }
+                slot = 4
+
+                slot shouldBe 4
+            }
+
+            "throws on a double-set before validation" {
+                var slot: Int? by once().inRange(1..10)
+                slot = 5
+
+                shouldThrow<IllegalStateException> {
+                    slot = 20
+                }
+            }
+
+            "infers Int from the property type with no explicit type argument" {
+                var slot: Int? by once()
+                slot = 7
+                slot shouldBe 7
+            }
+
+            "infers the chained inRange type from the property type" {
+                var slot: Int? by once().inRange(1..1024)
+                slot = 512
+                slot shouldBe 512
+            }
+
+            "infers the chained positive type for Int from the property type" {
+                var slot: Int? by once().positive()
+                slot = 2
+                slot shouldBe 2
+            }
+
+            "infers the chained positive type for Float from the property type" {
+                var slot: Float? by once().positive()
+                slot = 2.5f
+                slot shouldBe 2.5f
+            }
+
+            "throws on a double-set of a bare once delegate" {
+                var slot: Int? by once()
+                slot = 1
+
+                shouldThrow<IllegalStateException> {
+                    slot = 2
+                }
+            }
+        },
+    )

--- a/modules/paper/README.md
+++ b/modules/paper/README.md
@@ -44,3 +44,50 @@ The Bukkit scheduler only fires on whole game ticks (50 ms), so `repeating` reje
 honour with an `IllegalArgumentException` instead of silently rounding: `1.seconds`, `500.milliseconds`,
 and `3.ticks` are all fine; `75.milliseconds` is not. In unit tests, swap in the deterministic
 `ManualTicker` from [`kotventure-test`](../test/README.md) — no scheduler, no server.
+
+## Dialogs
+
+Paper's [dialog](https://docs.papermc.io/paper/dev/dialogs) forms get a typed builder in the
+`io.github.lmliam.kotventure.paper.dialog` package. The dialog type is chosen at the call site with a
+`DialogKind` token — `notice`, `confirmation`, `multiAction`, `dialogList`, or `serverLinks` — so
+only that kind's capabilities are in scope. Two entry points:
+
+- `dialog(kind) { … }` builds a `Dialog` value (construction only — no side effects).
+- `Audience.dialog(kind) { … }` builds one and shows it to the audience.
+
+```kotlin
+val reward = dialog(confirmation) {
+    title { text("Daily reward") }              // required; other base slots are optional
+    externalTitle { text("Rewards") }
+    closeOnEscape(false)
+    afterAction(wait)                           // close / none / wait
+    message { text("Claim your reward?") }      // bodies and inputs accumulate in order
+    inputs {
+        boolean("subscribe") { label { text("Subscribe") }; default() }
+    }
+    yes {                                       // confirmation's own yes/no buttons
+        label { text("Claim") }
+        tooltip { text("Adds it to your inventory") }
+        onClick { response, audience -> audience.message { text("Claimed!") } }
+    }
+    no { label { text("Later") } }
+}
+
+player.dialog(notice) { title { text("Welcome") }; button { label { text("Understood") } } }
+```
+
+Each singleton slot rejects a second assignment and a missing `title` throws `IllegalStateException`;
+repeatable bodies and `inputs { … }` blocks accumulate in call order. Each kind's scope adds only what
+Paper accepts: `notice { button { … } }` (button optional), `confirmation { yes { … }; no { … } }` (both
+required), `multiAction { button { … }; columns(…); exitButton { … } }`,
+`dialogList { dialogs(…); columns(…); buttonWidth(…); exitButton { … } }` (dialogs required), and
+`serverLinks { columns(…); buttonWidth(…); exitButton { … } }` (columns and buttonWidth required —
+Paper's factory demands them). Inputs live in `inputs { … }`: `text`,
+`boolean` (with `values { true("yes"); false("no") }`), `range(key, range)` (with
+`format(label, ": ", value)`), and `option` (with `options { "id" { display { … }; default() }; +"id" }`).
+A button chooses at most one action — `onClick { … }`, `runCommand(template)`,
+`custom(key[, additions])`, or `click { … }` (reusing the core click DSL).
+
+Dialogs require a Minecraft **1.21.6+** server and client. Adventure's `showDialog` / `closeDialog` are the
+native transport; on platforms or audiences that do not support dialogs they are documented no-ops, so
+`Audience.dialog { … }` silently does nothing there rather than failing.

--- a/modules/paper/build.gradle
+++ b/modules/paper/build.gradle
@@ -1,5 +1,11 @@
 description = 'Paper platform bundle: a Ticker adapter over the Bukkit scheduler.'
 
+kotlin {
+    compilerOptions {
+        optIn.add('io.github.lmliam.kotventure.core.dsl.InternalKotventureApi')
+    }
+}
+
 repositories {
     maven {
         name = 'papermc'

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogBaseBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogBaseBuilder.kt
@@ -1,0 +1,100 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.dsl.once
+import io.github.lmliam.kotventure.paper.dialog.body.ItemBodyBuilder
+import io.github.lmliam.kotventure.paper.dialog.body.ItemBodyScope
+import io.github.lmliam.kotventure.paper.dialog.input.InputsBuilder
+import io.github.lmliam.kotventure.paper.dialog.input.InputsScope
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.InlinedRegistryBuilderProvider
+import io.papermc.paper.registry.data.dialog.DialogBase
+import io.papermc.paper.registry.data.dialog.DialogBase.DialogAfterAction
+import io.papermc.paper.registry.data.dialog.body.DialogBody
+import io.papermc.paper.registry.data.dialog.input.DialogInput
+import io.papermc.paper.registry.data.dialog.type.DialogType
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+import org.bukkit.inventory.ItemStack
+
+internal class DialogBaseBuilder : DialogScope {
+    private var title: Component? by once()
+    private var externalTitle: Component? by once()
+    private var closeOnEscape: Boolean? by once()
+    private var pausesGame: Boolean? by once()
+    private var afterAction: DialogAfterAction? by once { "'afterAction' is already set." }
+    private val bodies = mutableListOf<DialogBody>()
+    private val inputs = mutableListOf<DialogInput>()
+
+    override val close: DialogAfterAction get() = DialogAfterAction.CLOSE
+    override val none: DialogAfterAction get() = DialogAfterAction.NONE
+    override val wait: DialogAfterAction get() = DialogAfterAction.WAIT_FOR_RESPONSE
+
+    override fun title(init: ComponentScope.() -> Unit) = title(component(init))
+
+    override fun <T : ComponentLike> title(component: T) {
+        title = component.asComponent()
+    }
+
+    override fun externalTitle(init: ComponentScope.() -> Unit) = externalTitle(component(init))
+
+    override fun <T : ComponentLike> externalTitle(component: T) {
+        externalTitle = component.asComponent()
+    }
+
+    override fun closeOnEscape(value: Boolean) {
+        closeOnEscape = value
+    }
+
+    override fun pausesGame(value: Boolean) {
+        pausesGame = value
+    }
+
+    override fun afterAction(action: DialogAfterAction) {
+        afterAction = action
+    }
+
+    override fun message(init: ComponentScope.() -> Unit) = message(component(init))
+
+    override fun <T : ComponentLike> message(component: T) {
+        bodies += DialogBody.plainMessage(component.asComponent())
+    }
+
+    override fun item(
+        stack: ItemStack,
+        init: ItemBodyScope.() -> Unit,
+    ) {
+        bodies += ItemBodyBuilder(stack).apply(init).build()
+    }
+
+    override fun item(stack: ItemStack) {
+        bodies += ItemBodyBuilder(stack).build()
+    }
+
+    override fun inputs(init: InputsScope.() -> Unit) {
+        inputs += InputsBuilder().apply(init).build()
+    }
+
+    private fun buildBase(): DialogBase {
+        val dialogTitle = checkNotNull(title) { "a dialog requires a 'title' slot." }
+
+        return DialogBase
+            .builder(dialogTitle)
+            .apply {
+                externalTitle?.let(::externalTitle)
+                canCloseWithEscape(closeOnEscape ?: true)
+                pause(pausesGame ?: true)
+                afterAction(afterAction ?: DialogAfterAction.CLOSE)
+                body(bodies)
+                inputs(inputs)
+            }.build()
+    }
+
+    internal fun build(type: DialogType): Dialog =
+        InlinedRegistryBuilderProvider.instance().createDialog { factory ->
+            factory.empty().base(buildBase()).type(type)
+        }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogKind.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogKind.kt
@@ -1,0 +1,16 @@
+package io.github.lmliam.kotventure.paper.dialog
+
+import io.papermc.paper.dialog.Dialog
+
+/**
+ * A compile-time token selecting one dialog type. Passed to [dialog] (or
+ * [Audience.dialog][io.github.lmliam.kotventure.paper.dialog.dialog]), its type parameter [S]
+ * fixes which scope the configuration block receives, so the chosen kind's own capabilities — and
+ * only those — are in scope.
+ *
+ * Obtain a kind from the tokens in this package: [notice], [confirmation], [multiAction],
+ * [dialogList], and [serverLinks].
+ */
+public class DialogKind<S : DialogScope> internal constructor(
+    internal val build: (init: S.() -> Unit) -> Dialog,
+)

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogScope.kt
@@ -1,0 +1,119 @@
+package io.github.lmliam.kotventure.paper.dialog
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.paper.dialog.body.ItemBodyScope
+import io.github.lmliam.kotventure.paper.dialog.input.InputsScope
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.DialogBase.DialogAfterAction
+import net.kyori.adventure.text.ComponentLike
+import org.bukkit.inventory.ItemStack
+
+/**
+ * Configures the common [base][io.papermc.paper.registry.data.dialog.DialogBase] of a [Dialog]:
+ * its title, framing, body, and inputs. The dialog type is chosen at the call site with a
+ * [DialogKind] token, so each kind's scope extends this base with only its own capabilities.
+ *
+ * The [title] slot is required; every other base slot is optional. Body and [inputs] calls are
+ * repeatable and accumulate in call order.
+ *
+ * @sample io.github.lmliam.kotventure.paper.dialog.dialogSample
+ */
+@KotventureDslMarker
+public interface DialogScope {
+    /**
+     * The after-action that returns to the previous non-dialog screen when the dialog closes.
+     */
+    public val close: DialogAfterAction
+
+    /**
+     * The after-action that keeps the current screen open when the dialog closes.
+     */
+    public val none: DialogAfterAction
+
+    /**
+     * The after-action that shows a "waiting for response" screen while the dialog is handled.
+     */
+    public val wait: DialogAfterAction
+
+    /**
+     * Builds the required dialog title from a component block.
+     *
+     * @throws IllegalStateException when the title is already set in this block.
+     */
+    public fun title(init: ComponentScope.() -> Unit): Unit
+
+    /**
+     * Sets the required dialog title.
+     *
+     * @throws IllegalStateException when the title is already set in this block.
+     */
+    public fun <T : ComponentLike> title(component: T): Unit
+
+    /**
+     * Builds the optional external title (shown on buttons that open this dialog) from a block.
+     *
+     * @throws IllegalStateException when the external title is already set in this block.
+     */
+    public fun externalTitle(init: ComponentScope.() -> Unit): Unit
+
+    /**
+     * Sets the optional external title, shown on buttons that open this dialog.
+     *
+     * @throws IllegalStateException when the external title is already set in this block.
+     */
+    public fun <T : ComponentLike> externalTitle(component: T): Unit
+
+    /**
+     * Sets whether the dialog can be dismissed with the escape keybind. Called with no argument,
+     * sets it to `true` (defaults to `true` when unset).
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     */
+    public fun closeOnEscape(value: Boolean = true): Unit
+
+    /**
+     * Sets whether the dialog pauses a single-player game while it is open. Called with no
+     * argument, sets it to `true` (defaults to `true` when unset).
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     */
+    public fun pausesGame(value: Boolean = true): Unit
+
+    /**
+     * Sets the action taken after the dialog is closed. Use [close], [none], or [wait].
+     * Defaults to [close] when unset.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     */
+    public fun afterAction(action: DialogAfterAction): Unit
+
+    /**
+     * Appends a plain-message body built from a component block. Repeatable; accumulates in order.
+     */
+    public fun message(init: ComponentScope.() -> Unit): Unit
+
+    /**
+     * Appends a plain-message body. Repeatable; accumulates in order.
+     */
+    public fun <T : ComponentLike> message(component: T): Unit
+
+    /**
+     * Appends an item body for [stack], configured by [init]. Repeatable; accumulates in order.
+     */
+    public fun item(
+        stack: ItemStack,
+        init: ItemBodyScope.() -> Unit,
+    ): Unit
+
+    /**
+     * Appends an item body for [stack] with default framing. Repeatable; accumulates in order.
+     */
+    public fun item(stack: ItemStack): Unit
+
+    /**
+     * Declares dialog inputs configured by [init]. Repeatable; declarations accumulate in call
+     * order across every block.
+     */
+    public fun inputs(init: InputsScope.() -> Unit): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/Dialogs.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/Dialogs.kt
@@ -1,0 +1,86 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog
+
+import io.github.lmliam.kotventure.paper.dialog.type.ConfirmationBuilder
+import io.github.lmliam.kotventure.paper.dialog.type.ConfirmationScope
+import io.github.lmliam.kotventure.paper.dialog.type.DialogListBuilder
+import io.github.lmliam.kotventure.paper.dialog.type.DialogListScope
+import io.github.lmliam.kotventure.paper.dialog.type.MultiActionBuilder
+import io.github.lmliam.kotventure.paper.dialog.type.MultiActionScope
+import io.github.lmliam.kotventure.paper.dialog.type.NoticeBuilder
+import io.github.lmliam.kotventure.paper.dialog.type.NoticeScope
+import io.github.lmliam.kotventure.paper.dialog.type.ServerLinksBuilder
+import io.github.lmliam.kotventure.paper.dialog.type.ServerLinksScope
+import io.papermc.paper.dialog.Dialog
+import net.kyori.adventure.audience.Audience
+
+/**
+ * The notice dialog kind: an informational dialog with a single acknowledgement button.
+ *
+ * @sample io.github.lmliam.kotventure.paper.dialog.showDialogSample
+ */
+public val notice: DialogKind<NoticeScope> =
+    DialogKind { init -> NoticeBuilder(DialogBaseBuilder()).apply(init).build() }
+
+/**
+ * The confirmation dialog kind: a yes/no dialog whose two buttons are both required.
+ *
+ * @sample io.github.lmliam.kotventure.paper.dialog.dialogSample
+ */
+public val confirmation: DialogKind<ConfirmationScope> =
+    DialogKind { init -> ConfirmationBuilder(DialogBaseBuilder()).apply(init).build() }
+
+/**
+ * The multi-action dialog kind: one or more action buttons in an optional column layout with an
+ * optional exit button.
+ */
+public val multiAction: DialogKind<MultiActionScope> =
+    DialogKind { init -> MultiActionBuilder(DialogBaseBuilder()).apply(init).build() }
+
+/**
+ * The dialog-list dialog kind: a menu of entry buttons for a required set of
+ * [dialogs][DialogListScope.dialogs].
+ */
+public val dialogList: DialogKind<DialogListScope> =
+    DialogKind { init -> DialogListBuilder(DialogBaseBuilder()).apply(init).build() }
+
+/**
+ * The server-links dialog kind: the server's link list laid out in a required
+ * [columns][ServerLinksScope.columns] count with buttons of a required
+ * [buttonWidth][ServerLinksScope.buttonWidth].
+ */
+public val serverLinks: DialogKind<ServerLinksScope> =
+    DialogKind { init -> ServerLinksBuilder(DialogBaseBuilder()).apply(init).build() }
+
+/**
+ * Builds a [Dialog] of [kind] configured by [init].
+ *
+ * Construction only — no side effects; the dialog is not shown to anyone. Use this when a
+ * dialog value is stored, reused, or passed to a later display call.
+ *
+ * @throws IllegalStateException when the required title is missing, a singleton slot is set
+ *   twice, or the chosen kind's required configuration is incomplete.
+ * @sample io.github.lmliam.kotventure.paper.dialog.dialogSample
+ */
+public fun <S : DialogScope> dialog(
+    kind: DialogKind<S>,
+    init: S.() -> Unit,
+): Dialog = kind.build(init)
+
+/**
+ * Builds a [Dialog] of [kind] configured by [init] and shows it to this audience.
+ *
+ * Dialogs require a Minecraft 1.21.6+ server and client. On platforms or audiences that do not
+ * support dialogs, Adventure's [Audience.showDialog] is a documented no-op.
+ *
+ * @throws IllegalStateException when the required title is missing, a singleton slot is set
+ *   twice, or the chosen kind's required configuration is incomplete.
+ * @sample io.github.lmliam.kotventure.paper.dialog.showDialogSample
+ */
+public fun <S : DialogScope> Audience.dialog(
+    kind: DialogKind<S>,
+    init: S.() -> Unit,
+) {
+    showDialog(kind.build(init))
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/action/ButtonBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/action/ButtonBuilder.kt
@@ -1,0 +1,98 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog.action
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.dsl.inRange
+import io.github.lmliam.kotventure.core.dsl.once
+import io.github.lmliam.kotventure.core.event.ClickActionScope
+import io.papermc.paper.registry.data.dialog.ActionButton
+import io.papermc.paper.registry.data.dialog.action.DialogAction
+import io.papermc.paper.registry.data.dialog.action.DialogActionCallback
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.nbt.api.BinaryTagHolder
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.text.event.ClickCallback
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+import io.github.lmliam.kotventure.core.event.click as buildClickEvent
+
+internal class ButtonBuilder : ButtonScope {
+    private var label: Component? by once()
+    private var tooltip: Component? by once()
+    private var width: Int? by once().inRange(1..1024)
+    private var selectedAction: DialogAction? by once {
+        "a button action is already selected."
+    }
+
+    override fun label(init: ComponentScope.() -> Unit) = label(component(init))
+
+    override fun <T : ComponentLike> label(component: T) {
+        label = component.asComponent()
+    }
+
+    override fun tooltip(init: ComponentScope.() -> Unit) = tooltip(component(init))
+
+    override fun <T : ComponentLike> tooltip(component: T) {
+        tooltip = component.asComponent()
+    }
+
+    override fun width(value: Int) {
+        width = value
+    }
+
+    override fun onClick(callback: DialogActionCallback) = onClick(ClickCallback.Options.builder().build(), callback)
+
+    override fun onClick(
+        uses: Int,
+        lifetime: Duration,
+        callback: DialogActionCallback,
+    ) = onClick(
+        ClickCallback.Options
+            .builder()
+            .uses(uses)
+            .lifetime(lifetime.toJavaDuration())
+            .build(),
+        callback,
+    )
+
+    override fun onClick(
+        options: ClickCallback.Options,
+        callback: DialogActionCallback,
+    ) {
+        selectedAction = DialogAction.customClick(callback, options)
+    }
+
+    override fun runCommand(template: String) {
+        selectedAction = DialogAction.commandTemplate(template)
+    }
+
+    override fun custom(id: Key) {
+        selectedAction = DialogAction.customClick(id, null)
+    }
+
+    override fun custom(
+        id: Key,
+        additions: BinaryTagHolder,
+    ) {
+        selectedAction = DialogAction.customClick(id, additions)
+    }
+
+    override fun click(init: ClickActionScope.() -> Unit) {
+        selectedAction = DialogAction.staticAction(buildClickEvent(init))
+    }
+
+    internal fun build(): ActionButton {
+        val buttonLabel = checkNotNull(label) { "a button requires a 'label' slot." }
+
+        return ActionButton
+            .builder(buttonLabel)
+            .apply {
+                tooltip?.let(::tooltip)
+                width?.let(::width)
+                selectedAction?.let(::action)
+            }.build()
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/action/ButtonScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/action/ButtonScope.kt
@@ -1,0 +1,117 @@
+package io.github.lmliam.kotventure.paper.dialog.action
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.core.event.ClickActionScope
+import io.papermc.paper.registry.data.dialog.action.DialogActionCallback
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.nbt.api.BinaryTagHolder
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.text.event.ClickCallback
+import kotlin.time.Duration
+
+/**
+ * Configures an action button: its required [label], an optional tooltip and width, and at most
+ * one action to run when clicked.
+ *
+ * Choosing more than one action — [onClick], [runCommand], [custom], or [click] — fails when the
+ * button is built. Choosing none produces a button with no action.
+ */
+@KotventureDslMarker
+public interface ButtonScope {
+    /**
+     * Builds the required button label from a component block.
+     *
+     * @throws IllegalStateException when the label is already set in this block.
+     */
+    public fun label(init: ComponentScope.() -> Unit): Unit
+
+    /**
+     * Sets the required button label.
+     *
+     * @throws IllegalStateException when the label is already set in this block.
+     */
+    public fun <T : ComponentLike> label(component: T): Unit
+
+    /**
+     * Builds the optional hover tooltip from a component block.
+     *
+     * @throws IllegalStateException when the tooltip is already set in this block.
+     */
+    public fun tooltip(init: ComponentScope.() -> Unit): Unit
+
+    /**
+     * Sets the optional hover tooltip.
+     *
+     * @throws IllegalStateException when the tooltip is already set in this block.
+     */
+    public fun <T : ComponentLike> tooltip(component: T): Unit
+
+    /**
+     * Sets the button width in pixels (1..1024).
+     *
+     * @throws IllegalStateException when the width is already set in this block.
+     * @throws IllegalArgumentException when [value] is outside 1..1024.
+     */
+    public fun width(value: Int): Unit
+
+    /**
+     * Selects a server-side callback action invoked with the response and clicking audience.
+     *
+     * @throws IllegalStateException when an action is already selected in this block.
+     */
+    public fun onClick(callback: DialogActionCallback): Unit
+
+    /**
+     * Selects a server-side callback action with a bounded number of [uses] and a [lifetime].
+     *
+     * @throws IllegalStateException when an action is already selected in this block.
+     */
+    public fun onClick(
+        uses: Int,
+        lifetime: Duration,
+        callback: DialogActionCallback,
+    ): Unit
+
+    /**
+     * Selects a server-side callback action with prebuilt [options].
+     *
+     * @throws IllegalStateException when an action is already selected in this block.
+     */
+    public fun onClick(
+        options: ClickCallback.Options,
+        callback: DialogActionCallback,
+    ): Unit
+
+    /**
+     * Selects a command-template action; `$(input_key)` placeholders resolve to input values.
+     *
+     * @throws IllegalStateException when an action is already selected in this block.
+     */
+    public fun runCommand(template: String): Unit
+
+    /**
+     * Selects a custom client action identified by [id].
+     *
+     * @throws IllegalStateException when an action is already selected in this block.
+     */
+    public fun custom(id: Key): Unit
+
+    /**
+     * Selects a custom client action identified by [id] carrying [additions].
+     *
+     * @throws IllegalStateException when an action is already selected in this block.
+     */
+    public fun custom(
+        id: Key,
+        additions: BinaryTagHolder,
+    ): Unit
+
+    /**
+     * Selects a static click-event action, reusing the core click DSL to build the event.
+     *
+     * @throws IllegalStateException when an action is already selected in this block, or when
+     *   [init] does not choose exactly one click action.
+     */
+    public fun click(init: ClickActionScope.() -> Unit): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/body/ItemBodyBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/body/ItemBodyBuilder.kt
@@ -1,0 +1,56 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog.body
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.dsl.inRange
+import io.github.lmliam.kotventure.core.dsl.once
+import io.papermc.paper.registry.data.dialog.body.DialogBody
+import io.papermc.paper.registry.data.dialog.body.ItemDialogBody
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+import org.bukkit.inventory.ItemStack
+
+internal class ItemBodyBuilder(
+    private val stack: ItemStack,
+) : ItemBodyScope {
+    private var description: Component? by once()
+    private var decorations: Boolean? by once { "'decorations' is already set." }
+    private var tooltip: Boolean? by once { "'tooltip' is already set." }
+    private var width: Int? by once().inRange(1..256)
+    private var height: Int? by once().inRange(1..256)
+
+    override fun description(init: ComponentScope.() -> Unit) = description(component(init))
+
+    override fun <T : ComponentLike> description(component: T) {
+        description = component.asComponent()
+    }
+
+    override fun decorations(value: Boolean) {
+        decorations = value
+    }
+
+    override fun tooltip(value: Boolean) {
+        tooltip = value
+    }
+
+    override fun width(value: Int) {
+        width = value
+    }
+
+    override fun height(value: Int) {
+        height = value
+    }
+
+    internal fun build(): ItemDialogBody =
+        DialogBody
+            .item(stack)
+            .apply {
+                description?.let { description(DialogBody.plainMessage(it)) }
+                decorations?.let(::showDecorations)
+                tooltip?.let(::showTooltip)
+                width?.let(::width)
+                height?.let(::height)
+            }.build()
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/body/ItemBodyScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/body/ItemBodyScope.kt
@@ -1,0 +1,57 @@
+package io.github.lmliam.kotventure.paper.dialog.body
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Configures an item dialog body. Every slot is optional; any left unset uses Paper's default.
+ */
+@KotventureDslMarker
+public interface ItemBodyScope {
+    /**
+     * Builds the optional description shown beside the item from a component block.
+     *
+     * @throws IllegalStateException when the description is already set in this block.
+     */
+    public fun description(init: ComponentScope.() -> Unit): Unit
+
+    /**
+     * Sets the optional description shown beside the item.
+     *
+     * @throws IllegalStateException when the description is already set in this block.
+     */
+    public fun <T : ComponentLike> description(component: T): Unit
+
+    /**
+     * Sets whether item decorations (damage bar, stack count) are shown. Called with no argument,
+     * sets it to `true`.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     */
+    public fun decorations(value: Boolean = true): Unit
+
+    /**
+     * Sets whether the item's tooltip is shown on hover. Called with no argument, sets it to
+     * `true`.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     */
+    public fun tooltip(value: Boolean = true): Unit
+
+    /**
+     * Sets the body width in pixels (1..256).
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is outside 1..256.
+     */
+    public fun width(value: Int): Unit
+
+    /**
+     * Sets the body height in pixels (1..256).
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is outside 1..256.
+     */
+    public fun height(value: Int): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/BooleanInputBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/BooleanInputBuilder.kt
@@ -1,0 +1,45 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.dsl.once
+import io.papermc.paper.registry.data.dialog.input.BooleanDialogInput
+import io.papermc.paper.registry.data.dialog.input.DialogInput
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+
+internal class BooleanInputBuilder(
+    private val key: String,
+) : BooleanInputScope {
+    private var label: Component? by once()
+    private var default: Boolean? by once()
+    private var values: BooleanValuesBuilder? by once { "'values' is already set." }
+
+    override fun label(init: ComponentScope.() -> Unit) = label(component(init))
+
+    override fun <T : ComponentLike> label(component: T) {
+        label = component.asComponent()
+    }
+
+    override fun default(value: Boolean) {
+        default = value
+    }
+
+    override fun values(init: BooleanValuesScope.() -> Unit) {
+        values = BooleanValuesBuilder().apply(init)
+    }
+
+    internal fun build(): BooleanDialogInput {
+        val inputLabel = checkNotNull(label) { "a boolean input requires a 'label' slot." }
+
+        return DialogInput
+            .bool(key, inputLabel)
+            .apply {
+                default?.let(::initial)
+                values?.onTrue?.let(::onTrue)
+                values?.onFalse?.let(::onFalse)
+            }.build()
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/BooleanInputScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/BooleanInputScope.kt
@@ -1,0 +1,39 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Configures a boolean dialog input. The label is required; every other slot is optional.
+ */
+@KotventureDslMarker
+public interface BooleanInputScope {
+    /**
+     * Builds the required input label from a component block.
+     *
+     * @throws IllegalStateException when the label is already set in this block.
+     */
+    public fun label(init: ComponentScope.() -> Unit): Unit
+
+    /**
+     * Sets the required input label.
+     *
+     * @throws IllegalStateException when the label is already set in this block.
+     */
+    public fun <T : ComponentLike> label(component: T): Unit
+
+    /**
+     * Sets the default checked state. Called with no argument, sets it to `true`.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     */
+    public fun default(value: Boolean = true): Unit
+
+    /**
+     * Sets the strings substituted into command templates for each state, configured by [init].
+     *
+     * @throws IllegalStateException when the values are already configured in this block.
+     */
+    public fun values(init: BooleanValuesScope.() -> Unit): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/BooleanValuesBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/BooleanValuesBuilder.kt
@@ -1,0 +1,16 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.dsl.once
+
+internal class BooleanValuesBuilder : BooleanValuesScope {
+    internal var onTrue: String? by once { "the 'true' value is already set." }
+    internal var onFalse: String? by once { "the 'false' value is already set." }
+
+    override operator fun Boolean.invoke(value: String) {
+        if (this) {
+            onTrue = value
+        } else {
+            onFalse = value
+        }
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/BooleanValuesScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/BooleanValuesScope.kt
@@ -1,0 +1,17 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+
+/**
+ * Configures the strings substituted into command templates for each state of a boolean input.
+ * `true("yes")` sets the substitution used when the input is on; `false("no")` when it is off.
+ */
+@KotventureDslMarker
+public interface BooleanValuesScope {
+    /**
+     * Sets the substitution for this boolean state (`true` for on, `false` for off).
+     *
+     * @throws IllegalStateException when this state's substitution is already set in this block.
+     */
+    public operator fun Boolean.invoke(value: String): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/InputsBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/InputsBuilder.kt
@@ -1,0 +1,38 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.papermc.paper.registry.data.dialog.input.DialogInput
+
+internal class InputsBuilder : InputsScope {
+    private val inputs = mutableListOf<DialogInput>()
+
+    override fun text(
+        key: String,
+        init: TextInputScope.() -> Unit,
+    ) {
+        inputs += TextInputBuilder(key).apply(init).build()
+    }
+
+    override fun boolean(
+        key: String,
+        init: BooleanInputScope.() -> Unit,
+    ) {
+        inputs += BooleanInputBuilder(key).apply(init).build()
+    }
+
+    override fun range(
+        key: String,
+        range: ClosedFloatingPointRange<Float>,
+        init: NumberRangeInputScope.() -> Unit,
+    ) {
+        inputs += NumberRangeInputBuilder(key, range).apply(init).build()
+    }
+
+    override fun option(
+        key: String,
+        init: SingleOptionInputScope.() -> Unit,
+    ) {
+        inputs += SingleOptionInputBuilder(key).apply(init).build()
+    }
+
+    internal fun build(): List<DialogInput> = inputs.toList()
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/InputsScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/InputsScope.kt
@@ -1,0 +1,52 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+
+/**
+ * Declares a dialog's inputs. Each input is identified by a unique key and accumulates in call
+ * order; grouping inputs here is independent of the dialog type.
+ */
+@KotventureDslMarker
+public interface InputsScope {
+    /**
+     * Declares a text input identified by [key], configured by [init].
+     *
+     * @throws IllegalStateException when [init] does not set the required label.
+     */
+    public fun text(
+        key: String,
+        init: TextInputScope.() -> Unit,
+    ): Unit
+
+    /**
+     * Declares a boolean input identified by [key], configured by [init].
+     *
+     * @throws IllegalStateException when [init] does not set the required label.
+     */
+    public fun boolean(
+        key: String,
+        init: BooleanInputScope.() -> Unit,
+    ): Unit
+
+    /**
+     * Declares a number-range (slider) input identified by [key] over [range], configured by
+     * [init].
+     *
+     * @throws IllegalStateException when [init] does not set the required label.
+     */
+    public fun range(
+        key: String,
+        range: ClosedFloatingPointRange<Float>,
+        init: NumberRangeInputScope.() -> Unit,
+    ): Unit
+
+    /**
+     * Declares a single-option (radio) input identified by [key], configured by [init].
+     *
+     * @throws IllegalStateException when [init] does not set the required label or valid options.
+     */
+    public fun option(
+        key: String,
+        init: SingleOptionInputScope.() -> Unit,
+    ): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/LabelBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/LabelBuilder.kt
@@ -1,0 +1,15 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.once
+
+internal class LabelBuilder(
+    delegate: ComponentScope,
+) : LabelScope,
+    ComponentScope by delegate {
+    internal var visible: Boolean? by once()
+
+    override fun visible(value: Boolean) {
+        visible = value
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/LabelScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/LabelScope.kt
@@ -1,0 +1,16 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+
+/**
+ * Configures an input label: a component block (via the inherited [ComponentScope]) plus whether
+ * the label is shown.
+ */
+public interface LabelScope : ComponentScope {
+    /**
+     * Sets whether the label is shown. Called with no argument, sets it to `true`.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     */
+    public fun visible(value: Boolean = true): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/NumberRangeInputBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/NumberRangeInputBuilder.kt
@@ -1,0 +1,63 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.dsl.inRange
+import io.github.lmliam.kotventure.core.dsl.once
+import io.github.lmliam.kotventure.core.dsl.positive
+import io.papermc.paper.registry.data.dialog.input.DialogInput
+import io.papermc.paper.registry.data.dialog.input.NumberRangeDialogInput
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+
+internal class NumberRangeInputBuilder(
+    private val key: String,
+    private val range: ClosedFloatingPointRange<Float>,
+) : NumberRangeInputScope {
+    private var labelComponent: Component? by once { "'label' is already set." }
+    private var width: Int? by once().inRange(1..1024)
+    private var labelFormat: String? by once { "'format' is already set." }
+    private var default: Float? by once()
+    private var step: Float? by once().positive()
+
+    override val label: String get() = $$"%1$s"
+    override val value: String get() = $$"%2$s"
+
+    override fun label(init: ComponentScope.() -> Unit) = label(component(init))
+
+    override fun <T : ComponentLike> label(component: T) {
+        labelComponent = component.asComponent()
+    }
+
+    override fun width(value: Int) {
+        width = value
+    }
+
+    override fun format(vararg parts: String) {
+        require(parts.isNotEmpty()) { "'format' requires at least one part." }
+        labelFormat = parts.joinToString("")
+    }
+
+    override fun default(value: Float) {
+        default = value
+    }
+
+    override fun step(value: Float) {
+        step = value
+    }
+
+    internal fun build(): NumberRangeDialogInput {
+        val inputLabel = checkNotNull(labelComponent) { "a number-range input requires a 'label' slot." }
+
+        return DialogInput
+            .numberRange(key, inputLabel, range.start, range.endInclusive)
+            .apply {
+                width?.let(::width)
+                labelFormat?.let(::labelFormat)
+                default?.let(::initial)
+                step?.let(::step)
+            }.build()
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/NumberRangeInputScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/NumberRangeInputScope.kt
@@ -1,0 +1,70 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Configures a number-range dialog input. The label is required; every other slot is optional.
+ * The range itself is supplied when the input is declared.
+ */
+@KotventureDslMarker
+public interface NumberRangeInputScope {
+    /**
+     * The `%1$s` placeholder — the input's label — for use in [format].
+     */
+    public val label: String
+
+    /**
+     * The `%2$s` placeholder — the current value — for use in [format].
+     */
+    public val value: String
+
+    /**
+     * Builds the required input label from a component block.
+     *
+     * @throws IllegalStateException when the label is already set in this block.
+     */
+    public fun label(init: ComponentScope.() -> Unit): Unit
+
+    /**
+     * Sets the required input label.
+     *
+     * @throws IllegalStateException when the label is already set in this block.
+     */
+    public fun <T : ComponentLike> label(component: T): Unit
+
+    /**
+     * Sets the input width in pixels (1..1024).
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is outside 1..1024.
+     */
+    public fun width(value: Int): Unit
+
+    /**
+     * Sets the label-format string by joining [parts]. Combine the [label] and [value] placeholder
+     * tokens with literal text — `format(label, ": ", value)` yields `"%1$s: %2$s"`. A single
+     * non-token part doubles as a raw translation-key bridge, e.g.
+     * `format("options.generic_value")`.
+     *
+     * @throws IllegalStateException when the format is already set in this block.
+     * @throws IllegalArgumentException when called with no parts.
+     */
+    public fun format(vararg parts: String): Unit
+
+    /**
+     * Sets the default value on the range.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     */
+    public fun default(value: Float): Unit
+
+    /**
+     * Sets the step size between selectable values.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is not positive.
+     */
+    public fun step(value: Float): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/OptionBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/OptionBuilder.kt
@@ -1,0 +1,28 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.dsl.once
+import io.papermc.paper.registry.data.dialog.input.SingleOptionDialogInput
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+
+internal class OptionBuilder(
+    private val id: String,
+) : OptionScope {
+    private var display: Component? by once()
+    private var default: Boolean? by once { "'default' is already set." }
+
+    override fun display(init: ComponentScope.() -> Unit) = display(component(init))
+
+    override fun <T : ComponentLike> display(component: T) {
+        display = component.asComponent()
+    }
+
+    override fun default() {
+        default = true
+    }
+
+    internal fun build(): SingleOptionDialogInput.OptionEntry =
+        SingleOptionDialogInput.OptionEntry.create(id, display, default ?: false)
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/OptionScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/OptionScope.kt
@@ -1,0 +1,33 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Configures a single option entry. Both slots are optional; at most one option per input may be
+ * marked [default].
+ */
+@KotventureDslMarker
+public interface OptionScope {
+    /**
+     * Builds the optional display label from a component block.
+     *
+     * @throws IllegalStateException when the display is already set in this block.
+     */
+    public fun display(init: ComponentScope.() -> Unit): Unit
+
+    /**
+     * Sets the optional display label.
+     *
+     * @throws IllegalStateException when the display is already set in this block.
+     */
+    public fun <T : ComponentLike> display(component: T): Unit
+
+    /**
+     * Marks this option as the default (initially selected) one.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     */
+    public fun default(): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/OptionsBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/OptionsBuilder.kt
@@ -1,0 +1,19 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.papermc.paper.registry.data.dialog.input.SingleOptionDialogInput
+
+internal class OptionsBuilder : OptionsScope {
+    private val entries = mutableListOf<SingleOptionDialogInput.OptionEntry>()
+
+    override operator fun String.invoke(init: OptionScope.() -> Unit) {
+        entries += OptionBuilder(this).apply(init).build()
+    }
+
+    override operator fun String.unaryPlus() {
+        entries += OptionBuilder(this).build()
+    }
+
+    internal fun build(): List<SingleOptionDialogInput.OptionEntry> = entries.toList()
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/OptionsScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/OptionsScope.kt
@@ -1,0 +1,20 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+
+/**
+ * Declares the options of a single-option input. Each option is identified by its id and
+ * accumulates in call order.
+ */
+@KotventureDslMarker
+public interface OptionsScope {
+    /**
+     * Adds an option with this id, configured by [init].
+     */
+    public operator fun String.invoke(init: OptionScope.() -> Unit): Unit
+
+    /**
+     * Adds an option with this id and no display override.
+     */
+    public operator fun String.unaryPlus(): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/SingleOptionInputBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/SingleOptionInputBuilder.kt
@@ -1,0 +1,67 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.dsl.inRange
+import io.github.lmliam.kotventure.core.dsl.once
+import io.papermc.paper.registry.data.dialog.input.DialogInput
+import io.papermc.paper.registry.data.dialog.input.SingleOptionDialogInput
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+
+internal class SingleOptionInputBuilder(
+    private val key: String,
+) : SingleOptionInputScope {
+    private var label: Component? by once()
+    private var labelVisible: Boolean? by once()
+    private var width: Int? by once().inRange(1..1024)
+    private val entries = mutableListOf<SingleOptionDialogInput.OptionEntry>()
+
+    override fun label(init: LabelScope.() -> Unit) {
+        var visible: Boolean? = null
+        label =
+            component {
+                val labelBuilder = LabelBuilder(this)
+                labelBuilder.init()
+                visible = labelBuilder.visible
+            }
+        labelVisible = visible
+    }
+
+    override fun <T : ComponentLike> label(component: T) {
+        label = component.asComponent()
+    }
+
+    override fun width(value: Int) {
+        width = value
+    }
+
+    override fun options(init: OptionsScope.() -> Unit) {
+        entries += OptionsBuilder().apply(init).build()
+    }
+
+    internal fun build(): SingleOptionDialogInput {
+        val inputLabel = checkNotNull(label) { "a single-option input requires a 'label' slot." }
+        check(entries.isNotEmpty()) { "a single-option input requires at least one option." }
+
+        val duplicate =
+            entries
+                .groupingBy(SingleOptionDialogInput.OptionEntry::id)
+                .eachCount()
+                .entries
+                .firstOrNull { it.value > 1 }
+                ?.key
+        check(duplicate == null) { "option '$duplicate' is declared more than once." }
+        check(entries.count(SingleOptionDialogInput.OptionEntry::initial) <= 1) {
+            "at most one option may be marked default."
+        }
+
+        return DialogInput
+            .singleOption(key, inputLabel, entries)
+            .apply {
+                width?.let(::width)
+                labelVisible?.let(::labelVisible)
+            }.build()
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/SingleOptionInputBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/SingleOptionInputBuilder.kt
@@ -45,16 +45,14 @@ internal class SingleOptionInputBuilder(
         val inputLabel = checkNotNull(label) { "a single-option input requires a 'label' slot." }
         check(entries.isNotEmpty()) { "a single-option input requires at least one option." }
 
-        val duplicate =
-            entries
-                .groupingBy(SingleOptionDialogInput.OptionEntry::id)
-                .eachCount()
-                .entries
-                .firstOrNull { it.value > 1 }
-                ?.key
-        check(duplicate == null) { "option '$duplicate' is declared more than once." }
+        entries
+            .groupingBy(SingleOptionDialogInput.OptionEntry::id)
+            .eachCount()
+            .forEach { (id, count) ->
+                check(count <= 1) { "option '$id' is declared more than once" }
+            }
         check(entries.count(SingleOptionDialogInput.OptionEntry::initial) <= 1) {
-            "at most one option may be marked default."
+            "at most one option may be marked default"
         }
 
         return DialogInput

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/SingleOptionInputScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/SingleOptionInputScope.kt
@@ -1,0 +1,41 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Configures a single-option (radio) dialog input. The label and at least one option are required.
+ */
+@KotventureDslMarker
+public interface SingleOptionInputScope {
+    /**
+     * Builds the required input label — text and visibility — from a [LabelScope] block.
+     *
+     * @throws IllegalStateException when the label is already set in this block.
+     */
+    public fun label(init: LabelScope.() -> Unit): Unit
+
+    /**
+     * Sets the required input label. Visibility follows Paper's default; use the block overload to
+     * set it.
+     *
+     * @throws IllegalStateException when the label is already set in this block.
+     */
+    public fun <T : ComponentLike> label(component: T): Unit
+
+    /**
+     * Sets the input width in pixels (1..1024).
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is outside 1..1024.
+     */
+    public fun width(value: Int): Unit
+
+    /**
+     * Declares the input's options, configured by [init]. Repeatable; options accumulate in order.
+     *
+     * @throws IllegalStateException when no option is declared, an id repeats, or more than one
+     *   option is marked default.
+     */
+    public fun options(init: OptionsScope.() -> Unit): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/TextInputBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/TextInputBuilder.kt
@@ -1,0 +1,71 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.dsl.inRange
+import io.github.lmliam.kotventure.core.dsl.once
+import io.github.lmliam.kotventure.core.dsl.positive
+import io.papermc.paper.registry.data.dialog.input.DialogInput
+import io.papermc.paper.registry.data.dialog.input.TextDialogInput
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+
+internal class TextInputBuilder(
+    private val key: String,
+) : TextInputScope {
+    private var label: Component? by once()
+    private var labelVisible: Boolean? by once()
+    private var width: Int? by once().inRange(1..1024)
+    private var default: String? by once()
+    private var maxLength: Int? by once().positive()
+    private var multilineOptions: TextDialogInput.MultilineOptions? by once()
+
+    override fun label(init: LabelScope.() -> Unit) {
+        var visible: Boolean? = null
+        label =
+            component {
+                val labelBuilder = LabelBuilder(this)
+                labelBuilder.init()
+                visible = labelBuilder.visible
+            }
+        labelVisible = visible
+    }
+
+    override fun <T : ComponentLike> label(component: T) {
+        label = component.asComponent()
+    }
+
+    override fun width(value: Int) {
+        width = value
+    }
+
+    override fun default(value: String) {
+        default = value
+    }
+
+    override fun maxLength(value: Int) {
+        maxLength = value
+    }
+
+    override fun multiline(init: TextMultilineScope.() -> Unit) {
+        multilineOptions =
+            TextMultilineBuilder()
+                .apply(init)
+                .build()
+    }
+
+    internal fun build(): TextDialogInput {
+        val inputLabel = checkNotNull(label) { "a text input requires a 'label' slot." }
+
+        return DialogInput
+            .text(key, inputLabel)
+            .apply {
+                width?.let(::width)
+                labelVisible?.let(::labelVisible)
+                default?.let(::initial)
+                maxLength?.let(::maxLength)
+                multilineOptions?.let(::multiline)
+            }.build()
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/TextInputBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/TextInputBuilder.kt
@@ -22,14 +22,9 @@ internal class TextInputBuilder(
     private var multilineOptions: TextDialogInput.MultilineOptions? by once()
 
     override fun label(init: LabelScope.() -> Unit) {
-        var visible: Boolean? = null
-        label =
-            component {
-                val labelBuilder = LabelBuilder(this)
-                labelBuilder.init()
-                visible = labelBuilder.visible
-            }
-        labelVisible = visible
+        lateinit var labelBuilder: LabelBuilder
+        label = component { labelBuilder = LabelBuilder(this).apply(init) }
+        labelVisible = labelBuilder.visible
     }
 
     override fun <T : ComponentLike> label(component: T) {

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/TextInputScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/TextInputScope.kt
@@ -1,0 +1,55 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Configures a text dialog input. The label is required; every other slot is optional.
+ */
+@KotventureDslMarker
+public interface TextInputScope {
+    /**
+     * Builds the required input label — text and visibility — from a [LabelScope] block.
+     *
+     * @throws IllegalStateException when the label is already set in this block.
+     */
+    public fun label(init: LabelScope.() -> Unit): Unit
+
+    /**
+     * Sets the required input label. Visibility follows Paper's default; use the block overload to
+     * set it.
+     *
+     * @throws IllegalStateException when the label is already set in this block.
+     */
+    public fun <T : ComponentLike> label(component: T): Unit
+
+    /**
+     * Sets the input width in pixels (1..1024).
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is outside 1..1024.
+     */
+    public fun width(value: Int): Unit
+
+    /**
+     * Sets the default text value.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     */
+    public fun default(value: String): Unit
+
+    /**
+     * Sets the maximum input length.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is not positive.
+     */
+    public fun maxLength(value: Int): Unit
+
+    /**
+     * Enables multi-line input configured by [init].
+     *
+     * @throws IllegalStateException when multiline is already configured in this block.
+     */
+    public fun multiline(init: TextMultilineScope.() -> Unit): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/TextMultilineBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/TextMultilineBuilder.kt
@@ -1,0 +1,23 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.dsl.inRange
+import io.github.lmliam.kotventure.core.dsl.once
+import io.github.lmliam.kotventure.core.dsl.positive
+import io.papermc.paper.registry.data.dialog.input.TextDialogInput
+
+internal class TextMultilineBuilder : TextMultilineScope {
+    private var maxLines: Int? by once().positive()
+    private var height: Int? by once().inRange(1..512)
+
+    override fun maxLines(value: Int) {
+        maxLines = value
+    }
+
+    override fun height(value: Int) {
+        height = value
+    }
+
+    internal fun build(): TextDialogInput.MultilineOptions = TextDialogInput.MultilineOptions.create(maxLines, height)
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/TextMultilineScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/input/TextMultilineScope.kt
@@ -1,0 +1,25 @@
+package io.github.lmliam.kotventure.paper.dialog.input
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+
+/**
+ * Configures multi-line options for a text input. Both slots are optional.
+ */
+@KotventureDslMarker
+public interface TextMultilineScope {
+    /**
+     * Sets the maximum number of lines.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is not positive.
+     */
+    public fun maxLines(value: Int): Unit
+
+    /**
+     * Sets the input height in pixels (1..512).
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is outside 1..512.
+     */
+    public fun height(value: Int): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/ConfirmationBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/ConfirmationBuilder.kt
@@ -1,0 +1,35 @@
+package io.github.lmliam.kotventure.paper.dialog.type
+
+import io.github.lmliam.kotventure.core.dsl.once
+import io.github.lmliam.kotventure.paper.dialog.DialogBaseBuilder
+import io.github.lmliam.kotventure.paper.dialog.DialogScope
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonBuilder
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonScope
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.ActionButton
+import io.papermc.paper.registry.data.dialog.type.DialogType
+
+internal class ConfirmationBuilder(
+    private val base: DialogBaseBuilder,
+) : ConfirmationScope,
+    DialogScope by base {
+    private var yes: ActionButton? by once { "'yes' is already set." }
+    private var no: ActionButton? by once { "'no' is already set." }
+
+    override fun yes(init: ButtonScope.() -> Unit) {
+        yes = ButtonBuilder().apply(init).build()
+    }
+
+    override fun no(init: ButtonScope.() -> Unit) {
+        no = ButtonBuilder().apply(init).build()
+    }
+
+    internal fun build(): Dialog {
+        val type =
+            DialogType.confirmation(
+                checkNotNull(yes) { "confirmation requires a 'yes' button." },
+                checkNotNull(no) { "confirmation requires a 'no' button." },
+            )
+        return base.build(type)
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/ConfirmationScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/ConfirmationScope.kt
@@ -1,0 +1,24 @@
+package io.github.lmliam.kotventure.paper.dialog.type
+
+import io.github.lmliam.kotventure.paper.dialog.DialogScope
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonScope
+
+/**
+ * Configures a confirmation dialog. Beyond the base [DialogScope] slots, both the [yes] and [no]
+ * buttons are required.
+ */
+public interface ConfirmationScope : DialogScope {
+    /**
+     * Configures the required confirming button.
+     *
+     * @throws IllegalStateException when the yes button is already configured in this block.
+     */
+    public fun yes(init: ButtonScope.() -> Unit): Unit
+
+    /**
+     * Configures the required denying button.
+     *
+     * @throws IllegalStateException when the no button is already configured in this block.
+     */
+    public fun no(init: ButtonScope.() -> Unit): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/DialogListBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/DialogListBuilder.kt
@@ -1,0 +1,54 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog.type
+
+import io.github.lmliam.kotventure.core.dsl.inRange
+import io.github.lmliam.kotventure.core.dsl.once
+import io.github.lmliam.kotventure.core.dsl.positive
+import io.github.lmliam.kotventure.paper.dialog.DialogBaseBuilder
+import io.github.lmliam.kotventure.paper.dialog.DialogScope
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonBuilder
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonScope
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.ActionButton
+import io.papermc.paper.registry.data.dialog.type.DialogType
+import io.papermc.paper.registry.set.RegistrySet
+
+internal class DialogListBuilder(
+    private val base: DialogBaseBuilder,
+) : DialogListScope,
+    DialogScope by base {
+    private var dialogs: RegistrySet<Dialog>? by once { "'dialogs' is already set." }
+    private var columns: Int? by once().positive()
+    private var buttonWidth: Int? by once().inRange(1..1024)
+    private var exit: ActionButton? by once { "'exitButton' is already set." }
+
+    override fun dialogs(dialogs: RegistrySet<Dialog>) {
+        this.dialogs = dialogs
+    }
+
+    override fun columns(value: Int) {
+        columns = value
+    }
+
+    override fun buttonWidth(value: Int) {
+        buttonWidth = value
+    }
+
+    override fun exitButton(init: ButtonScope.() -> Unit) {
+        exit = ButtonBuilder().apply(init).build()
+    }
+
+    internal fun build(): Dialog {
+        val entries = checkNotNull(dialogs) { "a dialog list requires a 'dialogs' slot." }
+        val type =
+            DialogType
+                .dialogList(entries)
+                .apply {
+                    columns?.let(::columns)
+                    buttonWidth?.let(::buttonWidth)
+                    exit?.let(::exitAction)
+                }.build()
+        return base.build(type)
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/DialogListScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/DialogListScope.kt
@@ -1,0 +1,42 @@
+package io.github.lmliam.kotventure.paper.dialog.type
+
+import io.github.lmliam.kotventure.paper.dialog.DialogScope
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonScope
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.set.RegistrySet
+
+/**
+ * Configures a dialog-list dialog. Beyond the base [DialogScope] slots, the presented [dialogs]
+ * are required; every other slot here is optional.
+ */
+public interface DialogListScope : DialogScope {
+    /**
+     * Sets the required set of dialogs presented as entry buttons.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     */
+    public fun dialogs(dialogs: RegistrySet<Dialog>): Unit
+
+    /**
+     * Sets the number of columns the entries are laid out in.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is not positive.
+     */
+    public fun columns(value: Int): Unit
+
+    /**
+     * Sets the width of each entry button in pixels (1..1024).
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is outside 1..1024.
+     */
+    public fun buttonWidth(value: Int): Unit
+
+    /**
+     * Configures the optional exit button.
+     *
+     * @throws IllegalStateException when the exit button is already configured in this block.
+     */
+    public fun exitButton(init: ButtonScope.() -> Unit): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/MultiActionBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/MultiActionBuilder.kt
@@ -1,0 +1,47 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog.type
+
+import io.github.lmliam.kotventure.core.dsl.once
+import io.github.lmliam.kotventure.core.dsl.positive
+import io.github.lmliam.kotventure.paper.dialog.DialogBaseBuilder
+import io.github.lmliam.kotventure.paper.dialog.DialogScope
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonBuilder
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonScope
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.ActionButton
+import io.papermc.paper.registry.data.dialog.type.DialogType
+
+internal class MultiActionBuilder(
+    private val base: DialogBaseBuilder,
+) : MultiActionScope,
+    DialogScope by base {
+    private val actions = mutableListOf<ActionButton>()
+    private var columns: Int? by once().positive()
+    private var exit: ActionButton? by once { "'exitButton' is already set." }
+
+    override fun button(init: ButtonScope.() -> Unit) {
+        actions += ButtonBuilder().apply(init).build()
+    }
+
+    override fun columns(value: Int) {
+        columns = value
+    }
+
+    override fun exitButton(init: ButtonScope.() -> Unit) {
+        exit = ButtonBuilder().apply(init).build()
+    }
+
+    internal fun build(): Dialog {
+        check(actions.isNotEmpty()) { "multiAction requires at least one 'button'." }
+
+        val type =
+            DialogType
+                .multiAction(actions)
+                .apply {
+                    columns?.let(::columns)
+                    exit?.let(::exitAction)
+                }.build()
+        return base.build(type)
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/MultiActionScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/MultiActionScope.kt
@@ -1,0 +1,30 @@
+package io.github.lmliam.kotventure.paper.dialog.type
+
+import io.github.lmliam.kotventure.paper.dialog.DialogScope
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonScope
+
+/**
+ * Configures a multi-action dialog. Beyond the base [DialogScope] slots, at least one [button] is
+ * required; the column count and exit button are optional.
+ */
+public interface MultiActionScope : DialogScope {
+    /**
+     * Adds an action button configured by [init]. Repeatable; accumulates in call order.
+     */
+    public fun button(init: ButtonScope.() -> Unit): Unit
+
+    /**
+     * Sets the number of columns the buttons are laid out in.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is not positive.
+     */
+    public fun columns(value: Int): Unit
+
+    /**
+     * Configures the optional exit button.
+     *
+     * @throws IllegalStateException when the exit button is already configured in this block.
+     */
+    public fun exitButton(init: ButtonScope.() -> Unit): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/NoticeBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/NoticeBuilder.kt
@@ -1,0 +1,26 @@
+package io.github.lmliam.kotventure.paper.dialog.type
+
+import io.github.lmliam.kotventure.core.dsl.once
+import io.github.lmliam.kotventure.paper.dialog.DialogBaseBuilder
+import io.github.lmliam.kotventure.paper.dialog.DialogScope
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonBuilder
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonScope
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.ActionButton
+import io.papermc.paper.registry.data.dialog.type.DialogType
+
+internal class NoticeBuilder(
+    private val base: DialogBaseBuilder,
+) : NoticeScope,
+    DialogScope by base {
+    private var button: ActionButton? by once { "the notice button is already set." }
+
+    override fun button(init: ButtonScope.() -> Unit) {
+        button = ButtonBuilder().apply(init).build()
+    }
+
+    internal fun build(): Dialog {
+        val type = button?.let(DialogType::notice) ?: DialogType.notice()
+        return base.build(type)
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/NoticeScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/NoticeScope.kt
@@ -1,0 +1,18 @@
+package io.github.lmliam.kotventure.paper.dialog.type
+
+import io.github.lmliam.kotventure.paper.dialog.DialogScope
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonScope
+
+/**
+ * Configures a notice dialog. Beyond the base [DialogScope] slots, its single acknowledgement
+ * [button] is optional; left unset, Paper supplies the default button.
+ */
+public interface NoticeScope : DialogScope {
+    /**
+     * Configures the optional acknowledgement button.
+     *
+     * @throws IllegalStateException when the button is already configured in this block, or when
+     *   [init] does not set the required button label.
+     */
+    public fun button(init: ButtonScope.() -> Unit): Unit
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/ServerLinksBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/ServerLinksBuilder.kt
@@ -1,0 +1,41 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.dialog.type
+
+import io.github.lmliam.kotventure.core.dsl.inRange
+import io.github.lmliam.kotventure.core.dsl.once
+import io.github.lmliam.kotventure.core.dsl.positive
+import io.github.lmliam.kotventure.paper.dialog.DialogBaseBuilder
+import io.github.lmliam.kotventure.paper.dialog.DialogScope
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonBuilder
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonScope
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.ActionButton
+import io.papermc.paper.registry.data.dialog.type.DialogType
+
+internal class ServerLinksBuilder(
+    private val base: DialogBaseBuilder,
+) : ServerLinksScope,
+    DialogScope by base {
+    private var columns: Int? by once().positive()
+    private var buttonWidth: Int? by once().inRange(1..1024)
+    private var exit: ActionButton? by once { "'exitButton' is already set." }
+
+    override fun columns(value: Int) {
+        columns = value
+    }
+
+    override fun buttonWidth(value: Int) {
+        buttonWidth = value
+    }
+
+    override fun exitButton(init: ButtonScope.() -> Unit) {
+        exit = ButtonBuilder().apply(init).build()
+    }
+
+    internal fun build(): Dialog {
+        val linkColumns = checkNotNull(columns) { "server links require a 'columns' slot." }
+        val linkButtonWidth = checkNotNull(buttonWidth) { "server links require a 'buttonWidth' slot." }
+        return base.build(DialogType.serverLinks(exit, linkColumns, linkButtonWidth))
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/ServerLinksScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/dialog/type/ServerLinksScope.kt
@@ -1,0 +1,33 @@
+package io.github.lmliam.kotventure.paper.dialog.type
+
+import io.github.lmliam.kotventure.paper.dialog.DialogScope
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonScope
+
+/**
+ * Configures a server-links dialog. Beyond the base [DialogScope] slots, the [columns] and
+ * [buttonWidth] slots are required; only the exit button is optional.
+ */
+public interface ServerLinksScope : DialogScope {
+    /**
+     * Sets the required number of columns the links are laid out in.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is not positive.
+     */
+    public fun columns(value: Int): Unit
+
+    /**
+     * Sets the required width of each link button in pixels (1..1024).
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalArgumentException when [value] is outside 1..1024.
+     */
+    public fun buttonWidth(value: Int): Unit
+
+    /**
+     * Configures the optional exit button.
+     *
+     * @throws IllegalStateException when the exit button is already configured in this block.
+     */
+    public fun exitButton(init: ButtonScope.() -> Unit): Unit
+}

--- a/modules/paper/src/samples/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogSamples.kt
+++ b/modules/paper/src/samples/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogSamples.kt
@@ -1,0 +1,38 @@
+package io.github.lmliam.kotventure.paper.dialog
+
+import io.github.lmliam.kotventure.core.audience.message
+import io.github.lmliam.kotventure.core.text.text
+import io.papermc.paper.dialog.Dialog
+import net.kyori.adventure.audience.Audience
+
+internal fun dialogSample(): Dialog =
+    dialog(confirmation) {
+        title { text("Daily reward") }
+        externalTitle { text("Rewards") }
+        closeOnEscape(false)
+        afterAction(wait)
+        message { text("Claim your daily reward?") }
+        inputs {
+            boolean("subscribe") {
+                label { text("Subscribe to updates") }
+                default()
+            }
+        }
+        yes {
+            label { text("Claim") }
+            tooltip { text("Adds it to your inventory") }
+            onClick { response, audience ->
+                val subscribed = response.getBoolean("subscribe") == true
+                audience.message { text("Claimed! Subscribed: $subscribed") }
+            }
+        }
+        no { label { text("Later") } }
+    }
+
+internal fun showDialogSample(audience: Audience) {
+    audience.dialog(notice) {
+        title { text("Welcome") }
+        message { text("Thanks for joining!") }
+        button { label { text("Understood") } }
+    }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/ButtonActionTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/ButtonActionTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 package io.github.lmliam.kotventure.paper.dialog
 
 import io.github.lmliam.kotventure.core.audience.emptyAudience
@@ -10,6 +12,7 @@ import io.github.lmliam.kotventure.test.text.shouldHaveContent
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.mockk
@@ -19,7 +22,6 @@ import io.papermc.paper.registry.data.dialog.type.NoticeType
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.nbt.api.BinaryTagHolder
-import net.kyori.adventure.text.Component
 import kotlin.time.Duration.Companion.seconds
 
 private fun noticeButton(init: ButtonScope.() -> Unit) =
@@ -40,8 +42,7 @@ class ButtonActionTest :
                     }
 
                 button.label() shouldHaveContent "Claim"
-                button.tooltip().shouldBeInstanceOf<Component>() shouldHaveContent
-                        "Adds it to your inventory"
+                button.tooltip().shouldNotBeNull() shouldHaveContent "Adds it to your inventory"
                 button.width() shouldBe 200
             }
 
@@ -50,7 +51,7 @@ class ButtonActionTest :
             }
 
             "invokes an onClick callback with the clicking audience" {
-                var received: Audience? = null
+                lateinit var received: Audience
                 val button =
                     noticeButton {
                         label { text("Go") }

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/ButtonActionTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/ButtonActionTest.kt
@@ -1,0 +1,166 @@
+package io.github.lmliam.kotventure.paper.dialog
+
+import io.github.lmliam.kotventure.core.audience.emptyAudience
+import io.github.lmliam.kotventure.core.event.click
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.paper.dialog.action.ButtonScope
+import io.github.lmliam.kotventure.paper.dialog.fixture.FakeCallbackAction
+import io.github.lmliam.kotventure.paper.dialog.fixture.builtDialog
+import io.github.lmliam.kotventure.test.text.shouldHaveContent
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.mockk
+import io.papermc.paper.dialog.DialogResponseView
+import io.papermc.paper.registry.data.dialog.action.DialogAction
+import io.papermc.paper.registry.data.dialog.type.NoticeType
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.nbt.api.BinaryTagHolder
+import net.kyori.adventure.text.Component
+import kotlin.time.Duration.Companion.seconds
+
+private fun noticeButton(init: ButtonScope.() -> Unit) =
+    builtDialog(notice) {
+        title { text("t") }
+        button(init)
+    }.type.shouldBeInstanceOf<NoticeType>().action()
+
+class ButtonActionTest :
+    StringSpec(
+        {
+            "wires a button label, tooltip and width" {
+                val button =
+                    noticeButton {
+                        label { text("Claim") }
+                        tooltip { text("Adds it to your inventory") }
+                        width(200)
+                    }
+
+                button.label() shouldHaveContent "Claim"
+                button.tooltip().shouldBeInstanceOf<Component>() shouldHaveContent
+                        "Adds it to your inventory"
+                button.width() shouldBe 200
+            }
+
+            "leaves the action null when none is chosen" {
+                noticeButton { label { text("OK") } }.action().shouldBeNull()
+            }
+
+            "invokes an onClick callback with the clicking audience" {
+                var received: Audience? = null
+                val button =
+                    noticeButton {
+                        label { text("Go") }
+                        onClick { _, audience -> received = audience }
+                    }
+
+                val action = button.action().shouldBeInstanceOf<FakeCallbackAction>()
+                val audience = emptyAudience()
+                action.callback.accept(mockk<DialogResponseView>(), audience)
+
+                received shouldBe audience
+            }
+
+            "records bounded uses on an onClick callback" {
+                val button =
+                    noticeButton {
+                        label { text("Go") }
+                        onClick(3, 10.seconds) { _, _ -> }
+                    }
+
+                button
+                    .action()
+                    .shouldBeInstanceOf<FakeCallbackAction>()
+                    .options
+                    .uses() shouldBe 3
+            }
+
+            "wires a run-command template action" {
+                val button =
+                    noticeButton {
+                        label { text("Give") }
+                        runCommand("give $(player) diamond")
+                    }
+
+                button
+                    .action()
+                    .shouldBeInstanceOf<DialogAction.CommandTemplateAction>()
+                    .template() shouldBe "give $(player) diamond"
+            }
+
+            "wires a custom action with a key" {
+                val key = Key.key("kotventure", "reward")
+                val button =
+                    noticeButton {
+                        label { text("Custom") }
+                        custom(key)
+                    }
+
+                val action = button.action().shouldBeInstanceOf<DialogAction.CustomClickAction>()
+                action.id() shouldBe key
+                action.additions().shouldBeNull()
+            }
+
+            "wires a custom action carrying additions" {
+                val key = Key.key("kotventure", "reward")
+                val additions = BinaryTagHolder.binaryTagHolder("{reward:1}")
+                val button =
+                    noticeButton {
+                        label { text("Custom") }
+                        custom(key, additions)
+                    }
+
+                button.action().shouldBeInstanceOf<DialogAction.CustomClickAction>().additions() shouldBe additions
+            }
+
+            "wires a static action from the core click DSL" {
+                val button =
+                    noticeButton {
+                        label { text("Run") }
+                        click { run("say hi") }
+                    }
+
+                button
+                    .action()
+                    .shouldBeInstanceOf<DialogAction.StaticAction>()
+                    .value() shouldBe click { run("say hi") }
+            }
+
+            "throws when two actions are selected" {
+                shouldThrow<IllegalStateException> {
+                    noticeButton {
+                        label { text("x") }
+                        runCommand("a")
+                        runCommand("b")
+                    }
+                }
+            }
+
+            "throws when a button label is missing" {
+                shouldThrow<IllegalStateException> {
+                    noticeButton { runCommand("a") }
+                }
+            }
+
+            "throws when the button width is zero" {
+                shouldThrow<IllegalArgumentException> {
+                    noticeButton {
+                        label { text("x") }
+                        width(0)
+                    }
+                }
+            }
+
+            "throws when the button width exceeds 1024" {
+                shouldThrow<IllegalArgumentException> {
+                    noticeButton {
+                        label { text("x") }
+                        width(1025)
+                    }
+                }
+            }
+        },
+    )

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogBaseTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogBaseTest.kt
@@ -1,0 +1,109 @@
+package io.github.lmliam.kotventure.paper.dialog
+
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.paper.dialog.fixture.builtBase
+import io.github.lmliam.kotventure.paper.dialog.fixture.builtDialog
+import io.github.lmliam.kotventure.test.text.shouldHaveContent
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.papermc.paper.registry.data.dialog.DialogBase.DialogAfterAction
+
+class DialogBaseTest :
+    StringSpec(
+        {
+            "lands the required title on the base" {
+                val base = builtBase { title { text("Daily reward") } }
+
+                base.title() shouldHaveContent "Daily reward"
+            }
+
+            "lands the external title on the base" {
+                val base =
+                    builtBase {
+                        title { text("Daily reward") }
+                        externalTitle { text("Rewards") }
+                    }
+
+                base.externalTitle().shouldNotBeNull() shouldHaveContent "Rewards"
+            }
+
+            "leaves the external title unset by default" {
+                val base = builtBase { title { text("Daily reward") } }
+
+                base.externalTitle().shouldBeNull()
+            }
+
+            "defaults closable and pause to true" {
+                val base = builtBase { title { text("t") } }
+
+                base.canCloseWithEscape() shouldBe true
+                base.pause() shouldBe true
+            }
+
+            "sets closeOnEscape and pausesGame to true with no argument" {
+                val base =
+                    builtBase {
+                        title { text("t") }
+                        closeOnEscape()
+                        pausesGame()
+                    }
+
+                base.canCloseWithEscape() shouldBe true
+                base.pause() shouldBe true
+            }
+
+            "lands closable, pause and after-action flags" {
+                val base =
+                    builtBase {
+                        title { text("t") }
+                        closeOnEscape(false)
+                        pausesGame(false)
+                        afterAction(wait)
+                    }
+
+                base.canCloseWithEscape() shouldBe false
+                base.pause() shouldBe false
+                base.afterAction() shouldBe DialogAfterAction.WAIT_FOR_RESPONSE
+            }
+
+            "maps the after-action scope members to the enum" {
+                builtBase {
+                    title { text("t") }
+                    afterAction(close)
+                }.afterAction() shouldBe DialogAfterAction.CLOSE
+
+                builtBase {
+                    title { text("t") }
+                    afterAction(none)
+                }.afterAction() shouldBe DialogAfterAction.NONE
+            }
+
+            "throws when the title is missing" {
+                shouldThrow<IllegalStateException> {
+                    builtDialog { }
+                }
+            }
+
+            "throws when the title is set twice" {
+                shouldThrow<IllegalStateException> {
+                    builtDialog {
+                        title { text("one") }
+                        title { text("two") }
+                    }
+                }
+            }
+
+            "throws when a boolean flag is set twice" {
+                shouldThrow<IllegalStateException> {
+                    builtDialog {
+                        title { text("t") }
+                        pausesGame()
+                        pausesGame(false)
+                    }
+                }
+            }
+        },
+    )

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogBodyTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogBodyTest.kt
@@ -1,0 +1,99 @@
+package io.github.lmliam.kotventure.paper.dialog
+
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.paper.dialog.fixture.builtBase
+import io.github.lmliam.kotventure.test.text.shouldHaveContent
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.mockk
+import io.papermc.paper.registry.data.dialog.body.ItemDialogBody
+import io.papermc.paper.registry.data.dialog.body.PlainMessageDialogBody
+import net.kyori.adventure.text.Component
+import org.bukkit.inventory.ItemStack
+
+class DialogBodyTest :
+    StringSpec(
+        {
+            "accumulates plain-message bodies in call order" {
+                val base =
+                    builtBase {
+                        title { text("t") }
+                        message { text("first") }
+                        message(Component.text("second"))
+                    }
+
+                base.body() shouldHaveSize 2
+                base.body()[0].shouldBeInstanceOf<PlainMessageDialogBody>().contents() shouldHaveContent "first"
+                base.body()[1].shouldBeInstanceOf<PlainMessageDialogBody>().contents() shouldHaveContent "second"
+            }
+
+            "wires an item body with framing knobs and description" {
+                val stack = mockk<ItemStack>()
+                val base =
+                    builtBase {
+                        title { text("t") }
+                        item(stack) {
+                            description { text("shiny") }
+                            decorations(false)
+                            tooltip(false)
+                            width(32)
+                            height(48)
+                        }
+                    }
+
+                val body = base.body().single().shouldBeInstanceOf<ItemDialogBody>()
+                body.item() shouldBe stack
+                body.showDecorations() shouldBe false
+                body.showTooltip() shouldBe false
+                body.width() shouldBe 32
+                body.height() shouldBe 48
+                body.description().shouldNotBeNull().contents() shouldHaveContent "shiny"
+            }
+
+            "sets decorations and tooltip to true with no argument" {
+                val stack = mockk<ItemStack>()
+                val base =
+                    builtBase {
+                        title { text("t") }
+                        item(stack) {
+                            decorations()
+                            tooltip()
+                        }
+                    }
+
+                val body = base.body().single().shouldBeInstanceOf<ItemDialogBody>()
+                body.showDecorations() shouldBe true
+                body.showTooltip() shouldBe true
+            }
+
+            "adds a bare item body with default framing" {
+                val stack = mockk<ItemStack>()
+                val base =
+                    builtBase {
+                        title { text("t") }
+                        item(stack)
+                    }
+
+                base
+                    .body()
+                    .single()
+                    .shouldBeInstanceOf<ItemDialogBody>()
+                    .item() shouldBe stack
+            }
+
+            "throws when an item body width exceeds 256" {
+                val stack = mockk<ItemStack>()
+
+                shouldThrow<IllegalArgumentException> {
+                    builtBase {
+                        title { text("t") }
+                        item(stack) { width(257) }
+                    }
+                }
+            }
+        },
+    )

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogInputTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogInputTest.kt
@@ -1,0 +1,355 @@
+package io.github.lmliam.kotventure.paper.dialog
+
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.paper.dialog.fixture.builtBase
+import io.github.lmliam.kotventure.test.text.shouldHaveContent
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.papermc.paper.registry.data.dialog.input.BooleanDialogInput
+import io.papermc.paper.registry.data.dialog.input.NumberRangeDialogInput
+import io.papermc.paper.registry.data.dialog.input.SingleOptionDialogInput
+import io.papermc.paper.registry.data.dialog.input.TextDialogInput
+
+class DialogInputTest :
+    StringSpec(
+        {
+            "wires a text input with its knobs and multiline options" {
+                val input =
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            text("nickname") {
+                                label {
+                                    text("Name")
+                                    visible(false)
+                                }
+                                maxLength(32)
+                                width(160)
+                                default("Steve")
+                                multiline {
+                                    maxLines(4)
+                                    height(64)
+                                }
+                            }
+                        }
+                    }.inputs().single().shouldBeInstanceOf<TextDialogInput>()
+
+                input.key() shouldBe "nickname"
+                input.label() shouldHaveContent "Name"
+                input.maxLength() shouldBe 32
+                input.width() shouldBe 160
+                input.labelVisible() shouldBe false
+                input.initial() shouldBe "Steve"
+                val multiline = input.multiline().shouldNotBeNull()
+                multiline.maxLines() shouldBe 4
+                multiline.height() shouldBe 64
+            }
+
+            "sets a text input's label visible to true with no argument" {
+                val input =
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            text("nickname") {
+                                label {
+                                    text("Name")
+                                    visible()
+                                }
+                            }
+                        }
+                    }.inputs().single().shouldBeInstanceOf<TextDialogInput>()
+
+                input.labelVisible() shouldBe true
+            }
+
+            "wires a boolean input with default and command values" {
+                val input =
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            boolean("subscribe") {
+                                label { text("Subscribe") }
+                                default()
+                                values {
+                                    true("yes")
+                                    false("no")
+                                }
+                            }
+                        }
+                    }.inputs().single().shouldBeInstanceOf<BooleanDialogInput>()
+
+                input.key() shouldBe "subscribe"
+                input.initial() shouldBe true
+                input.onTrue() shouldBe "yes"
+                input.onFalse() shouldBe "no"
+            }
+
+            "sets a boolean input's default to true with no argument" {
+                val input =
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            boolean("subscribe") {
+                                label { text("Subscribe") }
+                                default()
+                            }
+                        }
+                    }.inputs().single().shouldBeInstanceOf<BooleanDialogInput>()
+
+                input.initial() shouldBe true
+            }
+
+            "throws when the same boolean value polarity is set twice" {
+                shouldThrow<IllegalStateException> {
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            boolean("subscribe") {
+                                label { text("Subscribe") }
+                                values {
+                                    true("yes")
+                                    true("yep")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            "wires a number-range input from the range and knobs" {
+                val input =
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            range("count", 1f..64f) {
+                                label { text("Count") }
+                                step(1f)
+                                default(8f)
+                                width(120)
+                                format(label, ": ", value)
+                            }
+                        }
+                    }.inputs().single().shouldBeInstanceOf<NumberRangeDialogInput>()
+
+                input.start() shouldBe 1f
+                input.end() shouldBe 64f
+                input.step() shouldBe 1f
+                input.initial() shouldBe 8f
+                input.width() shouldBe 120
+                input.labelFormat() shouldBe $$"%1$s: %2$s"
+            }
+
+            "uses a single format part as a raw translation key" {
+                val input =
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            range("count", 1f..64f) {
+                                label { text("Count") }
+                                format("options.generic_value")
+                            }
+                        }
+                    }.inputs().single().shouldBeInstanceOf<NumberRangeDialogInput>()
+
+                input.labelFormat() shouldBe "options.generic_value"
+            }
+
+            "throws when format is called with no parts" {
+                shouldThrow<IllegalArgumentException> {
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            range("count", 1f..64f) {
+                                label { text("Count") }
+                                format()
+                            }
+                        }
+                    }
+                }
+            }
+
+            "wires a single-option input accumulating options in order" {
+                val input =
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            option("class") {
+                                label {
+                                    text("Class")
+                                    visible(false)
+                                }
+                                width(160)
+                                options {
+                                    "mage" {
+                                        display { text("Mage") }
+                                        default()
+                                    }
+                                    +"rogue"
+                                }
+                            }
+                        }
+                    }.inputs().single().shouldBeInstanceOf<SingleOptionDialogInput>()
+
+                input.width() shouldBe 160
+                input.labelVisible() shouldBe false
+                input.entries() shouldHaveSize 2
+                input.entries()[0].id() shouldBe "mage"
+                input.entries()[0].display().shouldNotBeNull() shouldHaveContent "Mage"
+                input.entries()[0].initial() shouldBe true
+                input.entries()[1].id() shouldBe "rogue"
+                input.entries()[1].initial() shouldBe false
+            }
+
+            "throws when a single-option input has no options" {
+                shouldThrow<IllegalStateException> {
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            option("class") {
+                                label { text("Class") }
+                                options {}
+                            }
+                        }
+                    }
+                }
+            }
+
+            "throws when a single-option id is declared twice" {
+                shouldThrow<IllegalStateException> {
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            option("class") {
+                                label { text("Class") }
+                                options {
+                                    +"mage"
+                                    +"mage"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            "throws when more than one single option is marked default" {
+                shouldThrow<IllegalStateException> {
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            option("class") {
+                                label { text("Class") }
+                                options {
+                                    "mage" { default() }
+                                    "rogue" { default() }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            "accumulates inputs across two blocks in call order" {
+                val inputs =
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            boolean("a") { label { text("A") } }
+                        }
+                        inputs {
+                            text("b") { label { text("B") } }
+                        }
+                    }.inputs()
+
+                inputs shouldHaveSize 2
+                inputs[0].key() shouldBe "a"
+                inputs[1].key() shouldBe "b"
+            }
+
+            "throws when an input label is missing" {
+                shouldThrow<IllegalStateException> {
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            text("x") { maxLength(4) }
+                        }
+                    }
+                }
+            }
+
+            "throws when an input knob is set twice" {
+                shouldThrow<IllegalStateException> {
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            text("x") {
+                                label { text("X") }
+                                maxLength(4)
+                                maxLength(8)
+                            }
+                        }
+                    }
+                }
+            }
+
+            "throws when a text input maxLength is not positive" {
+                shouldThrow<IllegalArgumentException> {
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            text("x") {
+                                label { text("X") }
+                                maxLength(0)
+                            }
+                        }
+                    }
+                }
+            }
+
+            "throws when a text multiline height exceeds 512" {
+                shouldThrow<IllegalArgumentException> {
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            text("x") {
+                                label { text("X") }
+                                multiline { height(513) }
+                            }
+                        }
+                    }
+                }
+            }
+
+            "throws when a number-range input step is zero" {
+                shouldThrow<IllegalArgumentException> {
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            range("count", 1f..64f) {
+                                label { text("Count") }
+                                step(0f)
+                            }
+                        }
+                    }
+                }
+            }
+
+            "throws when a single-option input width exceeds 1024" {
+                shouldThrow<IllegalArgumentException> {
+                    builtBase {
+                        title { text("t") }
+                        inputs {
+                            option("class") {
+                                label { text("Class") }
+                                width(1025)
+                                options { +"mage" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    )

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogTypeTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/DialogTypeTest.kt
@@ -1,0 +1,190 @@
+package io.github.lmliam.kotventure.paper.dialog
+
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.paper.dialog.fixture.builtDialog
+import io.github.lmliam.kotventure.test.text.shouldHaveContent
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.RegistryKey
+import io.papermc.paper.registry.data.dialog.type.ConfirmationType
+import io.papermc.paper.registry.data.dialog.type.DialogListType
+import io.papermc.paper.registry.data.dialog.type.MultiActionType
+import io.papermc.paper.registry.data.dialog.type.NoticeType
+import io.papermc.paper.registry.data.dialog.type.ServerLinksType
+import io.papermc.paper.registry.set.RegistrySet
+
+class DialogTypeTest :
+    StringSpec(
+        {
+            "selects a default notice type from the notice kind" {
+                val type =
+                    builtDialog(notice) {
+                        title { text("t") }
+                    }.type
+
+                type.shouldBeInstanceOf<NoticeType>()
+            }
+
+            "selects a notice type with a configured button" {
+                val type =
+                    builtDialog(notice) {
+                        title { text("t") }
+                        button { label { text("Understood") } }
+                    }.type.shouldBeInstanceOf<NoticeType>()
+
+                type.action().label() shouldHaveContent "Understood"
+            }
+
+            "throws when the notice button is configured twice" {
+                shouldThrow<IllegalStateException> {
+                    builtDialog(notice) {
+                        title { text("t") }
+                        button { label { text("One") } }
+                        button { label { text("Two") } }
+                    }
+                }
+            }
+
+            "wires a confirmation type from yes and no buttons" {
+                val type =
+                    builtDialog(confirmation) {
+                        title { text("t") }
+                        yes { label { text("Claim") } }
+                        no { label { text("Later") } }
+                    }.type.shouldBeInstanceOf<ConfirmationType>()
+
+                type.yesButton().label() shouldHaveContent "Claim"
+                type.noButton().label() shouldHaveContent "Later"
+            }
+
+            "throws when confirmation omits the yes button" {
+                shouldThrow<IllegalStateException> {
+                    builtDialog(confirmation) {
+                        title { text("t") }
+                        no { label { text("Later") } }
+                    }
+                }
+            }
+
+            "throws when confirmation omits the no button" {
+                shouldThrow<IllegalStateException> {
+                    builtDialog(confirmation) {
+                        title { text("t") }
+                        yes { label { text("Claim") } }
+                    }
+                }
+            }
+
+            "wires a multi-action type accumulating buttons with columns and exit" {
+                val type =
+                    builtDialog(multiAction) {
+                        title { text("t") }
+                        button { label { text("One") } }
+                        button { label { text("Two") } }
+                        columns(3)
+                        exitButton { label { text("Exit") } }
+                    }.type.shouldBeInstanceOf<MultiActionType>()
+
+                type.actions() shouldHaveSize 2
+                type.actions()[0].label() shouldHaveContent "One"
+                type.actions()[1].label() shouldHaveContent "Two"
+                type.columns() shouldBe 3
+                type.exitAction().shouldNotBeNull().label() shouldHaveContent "Exit"
+            }
+
+            "throws when a multi-action type has no buttons" {
+                shouldThrow<IllegalStateException> {
+                    builtDialog(multiAction) {
+                        title { text("t") }
+                        columns(2)
+                    }
+                }
+            }
+
+            "throws when a multi-action type has non-positive columns" {
+                shouldThrow<IllegalArgumentException> {
+                    builtDialog(multiAction) {
+                        title { text("t") }
+                        button { label { text("One") } }
+                        columns(0)
+                    }
+                }
+            }
+
+            "wires a dialog-list type passing the registry set through" {
+                val entries: RegistrySet<Dialog> = RegistrySet.valueSet(RegistryKey.DIALOG, emptyList())
+                val type =
+                    builtDialog(dialogList) {
+                        title { text("t") }
+                        dialogs(entries)
+                        columns(2)
+                        buttonWidth(120)
+                        exitButton { label { text("Back") } }
+                    }.type.shouldBeInstanceOf<DialogListType>()
+
+                type.dialogs() shouldBeSameInstanceAs entries
+                type.columns() shouldBe 2
+                type.buttonWidth() shouldBe 120
+                type.exitAction().shouldNotBeNull().label() shouldHaveContent "Back"
+            }
+
+            "throws when a dialog list omits the dialogs slot" {
+                shouldThrow<IllegalStateException> {
+                    builtDialog(dialogList) {
+                        title { text("t") }
+                    }
+                }
+            }
+
+            "throws when a dialog-list buttonWidth exceeds 1024" {
+                val entries: RegistrySet<Dialog> = RegistrySet.valueSet(RegistryKey.DIALOG, emptyList())
+
+                shouldThrow<IllegalArgumentException> {
+                    builtDialog(dialogList) {
+                        title { text("t") }
+                        dialogs(entries)
+                        buttonWidth(1025)
+                    }
+                }
+            }
+
+            "wires a server-links type from required columns and width" {
+                val type =
+                    builtDialog(serverLinks) {
+                        title { text("t") }
+                        columns(2)
+                        buttonWidth(150)
+                        exitButton { label { text("Close") } }
+                    }.type.shouldBeInstanceOf<ServerLinksType>()
+
+                type.columns() shouldBe 2
+                type.buttonWidth() shouldBe 150
+                type.exitAction().shouldNotBeNull().label() shouldHaveContent "Close"
+            }
+
+            "throws when server-links omits the columns slot" {
+                shouldThrow<IllegalStateException> {
+                    builtDialog(serverLinks) {
+                        title { text("t") }
+                        buttonWidth(150)
+                    }
+                }
+            }
+
+            "throws when server-links columns is not positive" {
+                shouldThrow<IllegalArgumentException> {
+                    builtDialog(serverLinks) {
+                        title { text("t") }
+                        columns(0)
+                        buttonWidth(200)
+                    }
+                }
+            }
+        },
+    )

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/ShowDialogTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/ShowDialogTest.kt
@@ -1,0 +1,36 @@
+package io.github.lmliam.kotventure.paper.dialog
+
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.paper.dialog.fixture.FakeDialog
+import io.github.lmliam.kotventure.test.text.shouldHaveContent
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.dialog.DialogLike
+
+class ShowDialogTest :
+    StringSpec(
+        {
+            "builds and shows the dialog through the audience" {
+                val shown = slot<DialogLike>()
+                val audience = mockk<Audience>()
+                every { audience.showDialog(capture(shown)) } just Runs
+
+                audience.dialog(notice) {
+                    title { text("Welcome") }
+                }
+
+                verify { audience.showDialog(any()) }
+                shown.captured
+                    .shouldBeInstanceOf<FakeDialog>()
+                    .base
+                    .title() shouldHaveContent "Welcome"
+            }
+        },
+    )

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/DialogTestSupport.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/DialogTestSupport.kt
@@ -1,0 +1,19 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.github.lmliam.kotventure.paper.dialog.DialogKind
+import io.github.lmliam.kotventure.paper.dialog.DialogScope
+import io.github.lmliam.kotventure.paper.dialog.dialog
+import io.github.lmliam.kotventure.paper.dialog.notice
+import io.papermc.paper.registry.data.dialog.DialogBase
+
+/** Builds a dialog of [kind] through the DSL and narrows to the recording [FakeDialog]. */
+internal fun <S : DialogScope> builtDialog(
+    kind: DialogKind<S>,
+    init: S.() -> Unit,
+): FakeDialog = dialog(kind, init) as FakeDialog
+
+/** Builds a notice dialog and narrows to the recording [FakeDialog] for base/type assertions. */
+internal fun builtDialog(init: DialogScope.() -> Unit): FakeDialog = builtDialog(notice, init)
+
+/** Builds a notice dialog through the DSL and returns its recorded [DialogBase]. */
+internal fun builtBase(init: DialogScope.() -> Unit): DialogBase = builtDialog(init).base

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeActionButtonBuilder.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeActionButtonBuilder.kt
@@ -1,0 +1,30 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.mockk.every
+import io.mockk.mockk
+import io.papermc.paper.registry.data.dialog.ActionButton
+import io.papermc.paper.registry.data.dialog.action.DialogAction
+import net.kyori.adventure.text.Component
+
+/** Recording [ActionButton.Builder] whose [build] returns a mockk stub of the captured values. */
+internal class FakeActionButtonBuilder(
+    private val label: Component,
+) : ActionButton.Builder {
+    private var tooltip: Component? = null
+    private var width: Int = 150
+    private var action: DialogAction? = null
+
+    override fun tooltip(tooltip: Component?): ActionButton.Builder = apply { this.tooltip = tooltip }
+
+    override fun width(width: Int): ActionButton.Builder = apply { this.width = width }
+
+    override fun action(action: DialogAction?): ActionButton.Builder = apply { this.action = action }
+
+    override fun build(): ActionButton =
+        mockk {
+            every { this@mockk.label() } returns label
+            every { this@mockk.tooltip() } returns tooltip
+            every { this@mockk.width() } returns width
+            every { this@mockk.action() } returns action
+        }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeBooleanInputBuilder.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeBooleanInputBuilder.kt
@@ -1,0 +1,31 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.mockk.every
+import io.mockk.mockk
+import io.papermc.paper.registry.data.dialog.input.BooleanDialogInput
+import net.kyori.adventure.text.Component
+
+/** Recording [BooleanDialogInput.Builder] whose [build] returns a mockk stub of the captured values. */
+internal class FakeBooleanInputBuilder(
+    private val key: String,
+    private val label: Component,
+) : BooleanDialogInput.Builder {
+    private var initial: Boolean = false
+    private var onTrue: String = "true"
+    private var onFalse: String = "false"
+
+    override fun initial(initial: Boolean): BooleanDialogInput.Builder = apply { this.initial = initial }
+
+    override fun onTrue(onTrue: String): BooleanDialogInput.Builder = apply { this.onTrue = onTrue }
+
+    override fun onFalse(onFalse: String): BooleanDialogInput.Builder = apply { this.onFalse = onFalse }
+
+    override fun build(): BooleanDialogInput =
+        mockk {
+            every { this@mockk.key() } returns key
+            every { this@mockk.label() } returns label
+            every { this@mockk.initial() } returns initial
+            every { this@mockk.onTrue() } returns onTrue
+            every { this@mockk.onFalse() } returns onFalse
+        }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeCallbackAction.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeCallbackAction.kt
@@ -1,0 +1,17 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.papermc.paper.registry.data.dialog.action.DialogAction
+import io.papermc.paper.registry.data.dialog.action.DialogActionCallback
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.nbt.api.BinaryTagHolder
+import net.kyori.adventure.text.event.ClickCallback
+
+/** Recording custom-click action capturing the registered [callback] and [options]. */
+class FakeCallbackAction(
+    val callback: DialogActionCallback,
+    val options: ClickCallback.Options,
+) : DialogAction.CustomClickAction {
+    override fun id(): Key = error("not used")
+
+    override fun additions(): BinaryTagHolder? = error("not used")
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeDialog.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeDialog.kt
@@ -1,0 +1,14 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.DialogBase
+import io.papermc.paper.registry.data.dialog.type.DialogType
+import org.bukkit.NamespacedKey
+
+/** Recording [Dialog] exposing the [base] and [type] captured through the registry builder. */
+class FakeDialog(
+    val base: DialogBase,
+    val type: DialogType,
+) : Dialog {
+    override fun getKey(): NamespacedKey = error("not used")
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeDialogBaseBuilder.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeDialogBaseBuilder.kt
@@ -1,0 +1,48 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.mockk.every
+import io.mockk.mockk
+import io.papermc.paper.registry.data.dialog.DialogBase
+import io.papermc.paper.registry.data.dialog.DialogBase.DialogAfterAction
+import io.papermc.paper.registry.data.dialog.body.DialogBody
+import io.papermc.paper.registry.data.dialog.input.DialogInput
+import net.kyori.adventure.text.Component
+
+/** Recording [DialogBase.Builder] whose [build] returns a mockk stub of the captured values. */
+internal class FakeDialogBaseBuilder(
+    private val title: Component,
+) : DialogBase.Builder {
+    private var externalTitle: Component? = null
+    private var canCloseWithEscape: Boolean = true
+    private var pause: Boolean = true
+    private var afterAction: DialogAfterAction = DialogAfterAction.CLOSE
+    private var body: List<DialogBody> = emptyList()
+    private var inputs: List<DialogInput> = emptyList()
+
+    override fun externalTitle(externalTitle: Component?): DialogBase.Builder =
+        apply { this.externalTitle = externalTitle }
+
+    override fun canCloseWithEscape(canCloseWithEscape: Boolean): DialogBase.Builder =
+        apply { this.canCloseWithEscape = canCloseWithEscape }
+
+    override fun pause(pause: Boolean): DialogBase.Builder = apply { this.pause = pause }
+
+    override fun afterAction(afterAction: DialogAfterAction): DialogBase.Builder =
+        apply { this.afterAction = afterAction }
+
+    override fun body(body: MutableList<out DialogBody>): DialogBase.Builder = apply { this.body = body.toList() }
+
+    override fun inputs(inputs: MutableList<out DialogInput>): DialogBase.Builder =
+        apply { this.inputs = inputs.toList() }
+
+    override fun build(): DialogBase =
+        mockk {
+            every { this@mockk.title() } returns title
+            every { this@mockk.externalTitle() } returns externalTitle
+            every { this@mockk.canCloseWithEscape() } returns canCloseWithEscape
+            every { this@mockk.pause() } returns pause
+            every { this@mockk.afterAction() } returns afterAction
+            every { this@mockk.body() } returns body
+            every { this@mockk.inputs() } returns inputs
+        }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeDialogInstancesProvider.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeDialogInstancesProvider.kt
@@ -1,0 +1,156 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.mockk.every
+import io.mockk.mockk
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.ActionButton
+import io.papermc.paper.registry.data.dialog.DialogBase
+import io.papermc.paper.registry.data.dialog.DialogInstancesProvider
+import io.papermc.paper.registry.data.dialog.action.DialogAction
+import io.papermc.paper.registry.data.dialog.action.DialogActionCallback
+import io.papermc.paper.registry.data.dialog.body.ItemDialogBody
+import io.papermc.paper.registry.data.dialog.body.PlainMessageDialogBody
+import io.papermc.paper.registry.data.dialog.input.BooleanDialogInput
+import io.papermc.paper.registry.data.dialog.input.NumberRangeDialogInput
+import io.papermc.paper.registry.data.dialog.input.SingleOptionDialogInput
+import io.papermc.paper.registry.data.dialog.input.TextDialogInput
+import io.papermc.paper.registry.data.dialog.type.ConfirmationType
+import io.papermc.paper.registry.data.dialog.type.DialogListType
+import io.papermc.paper.registry.data.dialog.type.MultiActionType
+import io.papermc.paper.registry.data.dialog.type.NoticeType
+import io.papermc.paper.registry.data.dialog.type.ServerLinksType
+import io.papermc.paper.registry.set.RegistrySet
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.nbt.api.BinaryTagHolder
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickCallback
+import net.kyori.adventure.text.event.ClickEvent
+import org.bukkit.inventory.ItemStack
+
+/**
+ * ServiceLoader-registered [DialogInstancesProvider] backing the dialog DSL tests.
+ *
+ * Record-only results (buttons, bodies, inputs, types) are built as inline mockk stubs. Only the
+ * fluent builder interfaces, which accumulate state across a chain that mockk fights, are the
+ * small recording classes in their own fixture files.
+ */
+class FakeDialogInstancesProvider : DialogInstancesProvider {
+    override fun dialogBaseBuilder(title: Component): DialogBase.Builder = FakeDialogBaseBuilder(title)
+
+    override fun actionButtonBuilder(label: Component): ActionButton.Builder = FakeActionButtonBuilder(label)
+
+    override fun register(
+        callback: DialogActionCallback,
+        options: ClickCallback.Options,
+    ): DialogAction.CustomClickAction = FakeCallbackAction(callback, options)
+
+    override fun staticAction(value: ClickEvent<*>): DialogAction.StaticAction =
+        mockk { every { value() } returns value }
+
+    override fun commandTemplate(template: String): DialogAction.CommandTemplateAction =
+        mockk { every { template() } returns template }
+
+    override fun customClick(
+        id: Key,
+        additions: BinaryTagHolder?,
+    ): DialogAction.CustomClickAction =
+        mockk {
+            every { this@mockk.id() } returns id
+            every { this@mockk.additions() } returns additions
+        }
+
+    override fun itemDialogBodyBuilder(itemStack: ItemStack): ItemDialogBody.Builder =
+        FakeItemDialogBodyBuilder(itemStack)
+
+    override fun plainMessageDialogBody(component: Component): PlainMessageDialogBody =
+        plainMessageDialogBody(component, 200)
+
+    override fun plainMessageDialogBody(
+        component: Component,
+        width: Int,
+    ): PlainMessageDialogBody =
+        mockk {
+            every { contents() } returns component
+            every { this@mockk.width() } returns width
+        }
+
+    override fun booleanBuilder(
+        key: String,
+        label: Component,
+    ): BooleanDialogInput.Builder = FakeBooleanInputBuilder(key, label)
+
+    override fun numberRangeBuilder(
+        key: String,
+        label: Component,
+        start: Float,
+        end: Float,
+    ): NumberRangeDialogInput.Builder = FakeNumberRangeInputBuilder(key, label, start, end)
+
+    override fun singleOptionBuilder(
+        key: String,
+        label: Component,
+        entries: MutableList<SingleOptionDialogInput.OptionEntry>,
+    ): SingleOptionDialogInput.Builder = FakeSingleOptionInputBuilder(key, label, entries.toList())
+
+    override fun singleOptionEntry(
+        id: String,
+        display: Component?,
+        initial: Boolean,
+    ): SingleOptionDialogInput.OptionEntry =
+        mockk {
+            every { this@mockk.id() } returns id
+            every { this@mockk.display() } returns display
+            every { this@mockk.initial() } returns initial
+        }
+
+    override fun textBuilder(
+        key: String,
+        label: Component,
+    ): TextDialogInput.Builder = FakeTextInputBuilder(key, label)
+
+    override fun multilineOptions(
+        maxLines: Int?,
+        height: Int?,
+    ): TextDialogInput.MultilineOptions =
+        mockk {
+            every { this@mockk.maxLines() } returns maxLines
+            every { this@mockk.height() } returns height
+        }
+
+    override fun confirmation(
+        yesButton: ActionButton,
+        noButton: ActionButton,
+    ): ConfirmationType =
+        mockk {
+            every { this@mockk.yesButton() } returns yesButton
+            every { this@mockk.noButton() } returns noButton
+        }
+
+    override fun dialogList(dialogs: RegistrySet<Dialog>): DialogListType.Builder = FakeDialogListBuilder(dialogs)
+
+    override fun multiAction(actions: MutableList<ActionButton>): MultiActionType.Builder =
+        FakeMultiActionBuilder(actions.toList())
+
+    override fun notice(): NoticeType =
+        notice(
+            mockk {
+                every { label() } returns Component.text("OK")
+                every { tooltip() } returns null
+                every { this@mockk.width() } returns 150
+                every { action() } returns null
+            },
+        )
+
+    override fun notice(action: ActionButton): NoticeType = mockk { every { this@mockk.action() } returns action }
+
+    override fun serverLinks(
+        exitAction: ActionButton?,
+        columns: Int,
+        buttonWidth: Int,
+    ): ServerLinksType =
+        mockk {
+            every { this@mockk.exitAction() } returns exitAction
+            every { this@mockk.columns() } returns columns
+            every { this@mockk.buttonWidth() } returns buttonWidth
+        }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeDialogListBuilder.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeDialogListBuilder.kt
@@ -1,0 +1,31 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.mockk.every
+import io.mockk.mockk
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.ActionButton
+import io.papermc.paper.registry.data.dialog.type.DialogListType
+import io.papermc.paper.registry.set.RegistrySet
+
+/** Recording [DialogListType.Builder] whose [build] returns a mockk stub of the captured values. */
+internal class FakeDialogListBuilder(
+    private val dialogs: RegistrySet<Dialog>,
+) : DialogListType.Builder {
+    private var exitAction: ActionButton? = null
+    private var columns: Int = 2
+    private var buttonWidth: Int = 150
+
+    override fun exitAction(exitAction: ActionButton?): DialogListType.Builder = apply { this.exitAction = exitAction }
+
+    override fun columns(columns: Int): DialogListType.Builder = apply { this.columns = columns }
+
+    override fun buttonWidth(buttonWidth: Int): DialogListType.Builder = apply { this.buttonWidth = buttonWidth }
+
+    override fun build(): DialogListType =
+        mockk {
+            every { this@mockk.dialogs() } returns dialogs
+            every { this@mockk.exitAction() } returns exitAction
+            every { this@mockk.columns() } returns columns
+            every { this@mockk.buttonWidth() } returns buttonWidth
+        }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeDialogRegistry.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeDialogRegistry.kt
@@ -1,0 +1,38 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.tag.Tag
+import io.papermc.paper.registry.tag.TagKey
+import net.kyori.adventure.key.Key
+import org.bukkit.NamespacedKey
+import org.bukkit.Registry
+import java.util.stream.Stream
+
+/**
+ * Minimal [Registry] returning a single placeholder [Dialog] for any lookup, so Paper's [Dialog]
+ * static constants resolve during class initialization. Only the lookup paths the constants use
+ * are implemented; everything else is unused.
+ */
+internal class FakeDialogRegistry(
+    private val dialog: Dialog,
+) : Registry<Dialog> {
+    override fun get(key: NamespacedKey): Dialog = dialog
+
+    override fun getOrThrow(key: Key): Dialog = dialog
+
+    override fun getKey(value: Dialog): NamespacedKey = error("not used")
+
+    override fun hasTag(key: TagKey<Dialog>): Boolean = error("not used")
+
+    override fun getTag(key: TagKey<Dialog>): Tag<Dialog> = error("not used")
+
+    override fun getTags(): Collection<Tag<Dialog>> = error("not used")
+
+    override fun stream(): Stream<Dialog> = error("not used")
+
+    override fun keyStream(): Stream<NamespacedKey> = error("not used")
+
+    override fun size(): Int = 0
+
+    override fun iterator(): MutableIterator<Dialog> = error("not used")
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeDialogRegistryEntryBuilder.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeDialogRegistryEntryBuilder.kt
@@ -1,0 +1,23 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.DialogBase
+import io.papermc.paper.registry.data.dialog.DialogRegistryEntry
+import io.papermc.paper.registry.data.dialog.type.DialogType
+import io.papermc.paper.registry.set.RegistryValueSetBuilder
+
+/** Recording [DialogRegistryEntry.Builder] capturing the base and type set by the DSL. */
+internal class FakeDialogRegistryEntryBuilder : DialogRegistryEntry.Builder {
+    private var base: DialogBase? = null
+    private var type: DialogType? = null
+
+    override fun base(): DialogBase = checkNotNull(base) { "base not set" }
+
+    override fun type(): DialogType = checkNotNull(type) { "type not set" }
+
+    override fun base(dialogBase: DialogBase): DialogRegistryEntry.Builder = apply { base = dialogBase }
+
+    override fun type(dialogType: DialogType): DialogRegistryEntry.Builder = apply { type = dialogType }
+
+    override fun registryValueSet(): RegistryValueSetBuilder<Dialog, DialogRegistryEntry.Builder> = error("not used")
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeInlinedRegistryBuilderProvider.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeInlinedRegistryBuilderProvider.kt
@@ -1,0 +1,48 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.RegistryBuilderFactory
+import io.papermc.paper.registry.TypedKey
+import io.papermc.paper.registry.data.InlinedRegistryBuilderProvider
+import io.papermc.paper.registry.data.InstrumentRegistryEntry
+import io.papermc.paper.registry.data.TrimMaterialRegistryEntry
+import io.papermc.paper.registry.data.TrimPatternRegistryEntry
+import io.papermc.paper.registry.data.dialog.DialogRegistryEntry
+import org.bukkit.MusicInstrument
+import org.bukkit.inventory.meta.trim.TrimMaterial
+import org.bukkit.inventory.meta.trim.TrimPattern
+import java.util.function.Consumer
+
+/**
+ * ServiceLoader-registered [InlinedRegistryBuilderProvider] that runs the DSL's registry consumer
+ * against a recording entry builder and returns a [FakeDialog] carrying the captured base and type.
+ *
+ * Same registry-class-initialization constraint as [FakeRegistryAccess]: no mockk on this path.
+ */
+class FakeInlinedRegistryBuilderProvider : InlinedRegistryBuilderProvider {
+    override fun createDialog(
+        value: Consumer<RegistryBuilderFactory<Dialog, out DialogRegistryEntry.Builder>>,
+    ): Dialog {
+        val entry = FakeDialogRegistryEntryBuilder()
+        value.accept(
+            object : RegistryBuilderFactory<Dialog, DialogRegistryEntry.Builder> {
+                override fun empty(): DialogRegistryEntry.Builder = entry
+
+                override fun copyFrom(key: TypedKey<Dialog>): DialogRegistryEntry.Builder = error("not used")
+            },
+        )
+        return FakeDialog(entry.base(), entry.type())
+    }
+
+    override fun createInstrument(
+        value: Consumer<RegistryBuilderFactory<MusicInstrument, out InstrumentRegistryEntry.Builder>>,
+    ): MusicInstrument = error("not used")
+
+    override fun createTrimMaterial(
+        value: Consumer<RegistryBuilderFactory<TrimMaterial, out TrimMaterialRegistryEntry.Builder>>,
+    ): TrimMaterial = error("not used")
+
+    override fun createTrimPattern(
+        value: Consumer<RegistryBuilderFactory<TrimPattern, out TrimPatternRegistryEntry.Builder>>,
+    ): TrimPattern = error("not used")
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeItemDialogBodyBuilder.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeItemDialogBodyBuilder.kt
@@ -1,0 +1,40 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.mockk.every
+import io.mockk.mockk
+import io.papermc.paper.registry.data.dialog.body.ItemDialogBody
+import io.papermc.paper.registry.data.dialog.body.PlainMessageDialogBody
+import org.bukkit.inventory.ItemStack
+
+/** Recording [ItemDialogBody.Builder] whose [build] returns a mockk stub of the captured values. */
+internal class FakeItemDialogBodyBuilder(
+    private val item: ItemStack,
+) : ItemDialogBody.Builder {
+    private var description: PlainMessageDialogBody? = null
+    private var showDecorations: Boolean = true
+    private var showTooltip: Boolean = true
+    private var width: Int = 16
+    private var height: Int = 16
+
+    override fun description(description: PlainMessageDialogBody?): ItemDialogBody.Builder =
+        apply { this.description = description }
+
+    override fun showDecorations(showDecorations: Boolean): ItemDialogBody.Builder =
+        apply { this.showDecorations = showDecorations }
+
+    override fun showTooltip(showTooltip: Boolean): ItemDialogBody.Builder = apply { this.showTooltip = showTooltip }
+
+    override fun width(width: Int): ItemDialogBody.Builder = apply { this.width = width }
+
+    override fun height(height: Int): ItemDialogBody.Builder = apply { this.height = height }
+
+    override fun build(): ItemDialogBody =
+        mockk {
+            every { this@mockk.item() } returns item
+            every { this@mockk.description() } returns description
+            every { this@mockk.showDecorations() } returns showDecorations
+            every { this@mockk.showTooltip() } returns showTooltip
+            every { this@mockk.width() } returns width
+            every { this@mockk.height() } returns height
+        }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeMultiActionBuilder.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeMultiActionBuilder.kt
@@ -1,0 +1,25 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.mockk.every
+import io.mockk.mockk
+import io.papermc.paper.registry.data.dialog.ActionButton
+import io.papermc.paper.registry.data.dialog.type.MultiActionType
+
+/** Recording [MultiActionType.Builder] whose [build] returns a mockk stub of the captured values. */
+internal class FakeMultiActionBuilder(
+    private val actions: List<ActionButton>,
+) : MultiActionType.Builder {
+    private var exitAction: ActionButton? = null
+    private var columns: Int = 2
+
+    override fun exitAction(exitAction: ActionButton?): MultiActionType.Builder = apply { this.exitAction = exitAction }
+
+    override fun columns(columns: Int): MultiActionType.Builder = apply { this.columns = columns }
+
+    override fun build(): MultiActionType =
+        mockk {
+            every { this@mockk.actions() } returns actions
+            every { this@mockk.exitAction() } returns exitAction
+            every { this@mockk.columns() } returns columns
+        }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeNumberRangeInputBuilder.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeNumberRangeInputBuilder.kt
@@ -1,0 +1,40 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.mockk.every
+import io.mockk.mockk
+import io.papermc.paper.registry.data.dialog.input.NumberRangeDialogInput
+import net.kyori.adventure.text.Component
+
+/** Recording [NumberRangeDialogInput.Builder] whose [build] returns a mockk stub of the captured values. */
+internal class FakeNumberRangeInputBuilder(
+    private val key: String,
+    private val label: Component,
+    private val start: Float,
+    private val end: Float,
+) : NumberRangeDialogInput.Builder {
+    private var width: Int = 200
+    private var labelFormat: String = "options.generic_value"
+    private var initial: Float? = null
+    private var step: Float? = null
+
+    override fun width(width: Int): NumberRangeDialogInput.Builder = apply { this.width = width }
+
+    override fun labelFormat(labelFormat: String): NumberRangeDialogInput.Builder =
+        apply { this.labelFormat = labelFormat }
+
+    override fun initial(initial: Float?): NumberRangeDialogInput.Builder = apply { this.initial = initial }
+
+    override fun step(step: Float?): NumberRangeDialogInput.Builder = apply { this.step = step }
+
+    override fun build(): NumberRangeDialogInput =
+        mockk {
+            every { this@mockk.key() } returns key
+            every { this@mockk.label() } returns label
+            every { this@mockk.start() } returns start
+            every { this@mockk.end() } returns end
+            every { this@mockk.width() } returns width
+            every { this@mockk.labelFormat() } returns labelFormat
+            every { this@mockk.initial() } returns initial
+            every { this@mockk.step() } returns step
+        }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeRegistryAccess.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeRegistryAccess.kt
@@ -1,0 +1,62 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.RegistryAccess
+import io.papermc.paper.registry.RegistryKey
+import io.papermc.paper.registry.data.dialog.ActionButton
+import io.papermc.paper.registry.data.dialog.DialogBase
+import io.papermc.paper.registry.data.dialog.body.DialogBody
+import io.papermc.paper.registry.data.dialog.input.DialogInput
+import io.papermc.paper.registry.data.dialog.type.NoticeType
+import net.kyori.adventure.text.Component
+import org.bukkit.Keyed
+import org.bukkit.Registry
+
+/**
+ * ServiceLoader-registered [RegistryAccess] so that initializing the Paper [Dialog] interface — and
+ * its registry-backed constants — succeeds in a plain unit test without a running server. Every
+ * lookup returns a placeholder [FakeDialog]; the constants themselves are never asserted.
+ *
+ * This runs from inside [org.bukkit.Registry]'s own class initialization (its `<clinit>` eagerly
+ * builds legacy registries for every registry type, [Dialog] included), so every placeholder here
+ * is constructed fresh per call rather than read from a Kotlin `object` singleton or built as a
+ * mockk stub. Both alternatives read a static field during their own initialization: a
+ * singleton's backing field is only assigned once its class finishes initializing, and a mockk
+ * proxy forces its target interface to finish initializing before objenesis can instantiate it.
+ * [Registry] itself is the class already mid-initialization on this thread, so either alternative
+ * re-enters that same not-yet-finished `<clinit>`, reads the not-yet-assigned field, and throws
+ * (`NullPointerException` for the singleton, `ExceptionInInitializerError` for mockk). A plain
+ * constructor call has no such field to race.
+ */
+class FakeRegistryAccess : RegistryAccess {
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun <T : Keyed> getRegistry(type: Class<T>): Registry<T> = registry()
+
+    override fun <T : Keyed> getRegistry(key: RegistryKey<T>): Registry<T> = registry()
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Keyed> registry(): Registry<T> =
+        FakeDialogRegistry(FakeDialog(placeholderBase(), placeholderType())) as Registry<T>
+
+    private fun placeholderBase(): DialogBase =
+        object : DialogBase {
+            override fun title(): Component = Component.text("")
+
+            override fun externalTitle(): Component? = null
+
+            override fun canCloseWithEscape(): Boolean = true
+
+            override fun pause(): Boolean = true
+
+            override fun afterAction(): DialogBase.DialogAfterAction = DialogBase.DialogAfterAction.CLOSE
+
+            override fun body(): List<DialogBody> = emptyList()
+
+            override fun inputs(): List<DialogInput> = emptyList()
+        }
+
+    private fun placeholderType(): NoticeType =
+        object : NoticeType {
+            override fun action(): ActionButton = error("not used")
+        }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeSingleOptionInputBuilder.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeSingleOptionInputBuilder.kt
@@ -1,0 +1,30 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.mockk.every
+import io.mockk.mockk
+import io.papermc.paper.registry.data.dialog.input.SingleOptionDialogInput
+import net.kyori.adventure.text.Component
+
+/** Recording [SingleOptionDialogInput.Builder] whose [build] returns a mockk stub of the captured values. */
+internal class FakeSingleOptionInputBuilder(
+    private val key: String,
+    private val label: Component,
+    private val entries: List<SingleOptionDialogInput.OptionEntry>,
+) : SingleOptionDialogInput.Builder {
+    private var width: Int = 200
+    private var labelVisible: Boolean = true
+
+    override fun width(width: Int): SingleOptionDialogInput.Builder = apply { this.width = width }
+
+    override fun labelVisible(labelVisible: Boolean): SingleOptionDialogInput.Builder =
+        apply { this.labelVisible = labelVisible }
+
+    override fun build(): SingleOptionDialogInput =
+        mockk {
+            every { this@mockk.key() } returns key
+            every { this@mockk.label() } returns label
+            every { this@mockk.entries() } returns entries
+            every { this@mockk.width() } returns width
+            every { this@mockk.labelVisible() } returns labelVisible
+        }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeTextInputBuilder.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeTextInputBuilder.kt
@@ -1,0 +1,41 @@
+package io.github.lmliam.kotventure.paper.dialog.fixture
+
+import io.mockk.every
+import io.mockk.mockk
+import io.papermc.paper.registry.data.dialog.input.TextDialogInput
+import net.kyori.adventure.text.Component
+
+/** Recording [TextDialogInput.Builder] whose [build] returns a mockk stub of the captured values. */
+internal class FakeTextInputBuilder(
+    private val key: String,
+    private val label: Component,
+) : TextDialogInput.Builder {
+    private var width: Int = 200
+    private var labelVisible: Boolean = true
+    private var initial: String = ""
+    private var maxLength: Int = 32
+    private var multiline: TextDialogInput.MultilineOptions? = null
+
+    override fun width(width: Int): TextDialogInput.Builder = apply { this.width = width }
+
+    override fun labelVisible(labelVisible: Boolean): TextDialogInput.Builder =
+        apply { this.labelVisible = labelVisible }
+
+    override fun initial(initial: String): TextDialogInput.Builder = apply { this.initial = initial }
+
+    override fun maxLength(maxLength: Int): TextDialogInput.Builder = apply { this.maxLength = maxLength }
+
+    override fun multiline(multiline: TextDialogInput.MultilineOptions?): TextDialogInput.Builder =
+        apply { this.multiline = multiline }
+
+    override fun build(): TextDialogInput =
+        mockk {
+            every { this@mockk.key() } returns key
+            every { this@mockk.label() } returns label
+            every { this@mockk.width() } returns width
+            every { this@mockk.labelVisible() } returns labelVisible
+            every { this@mockk.initial() } returns initial
+            every { this@mockk.maxLength() } returns maxLength
+            every { this@mockk.multiline() } returns multiline
+        }
+}

--- a/modules/paper/src/test/resources/META-INF/services/io.papermc.paper.registry.RegistryAccess
+++ b/modules/paper/src/test/resources/META-INF/services/io.papermc.paper.registry.RegistryAccess
@@ -1,0 +1,1 @@
+io.github.lmliam.kotventure.paper.dialog.fixture.FakeRegistryAccess

--- a/modules/paper/src/test/resources/META-INF/services/io.papermc.paper.registry.data.InlinedRegistryBuilderProvider
+++ b/modules/paper/src/test/resources/META-INF/services/io.papermc.paper.registry.data.InlinedRegistryBuilderProvider
@@ -1,0 +1,1 @@
+io.github.lmliam.kotventure.paper.dialog.fixture.FakeInlinedRegistryBuilderProvider

--- a/modules/paper/src/test/resources/META-INF/services/io.papermc.paper.registry.data.dialog.DialogInstancesProvider
+++ b/modules/paper/src/test/resources/META-INF/services/io.papermc.paper.registry.data.dialog.DialogInstancesProvider
@@ -1,0 +1,1 @@
+io.github.lmliam.kotventure.paper.dialog.fixture.FakeDialogInstancesProvider


### PR DESCRIPTION
## Summary

Adds the dialog DSL (`io.github.lmliam.kotventure.paper.dialog`): a typed Kotlin surface over Paper's `io.papermc.paper.registry.data.dialog` API covering the full dialog surface — base slots, all five dialog kinds (`notice`, `confirmation`, `multiAction`, `dialogList`, `serverLinks`), both bodies (plain message, item), all four inputs (`text`, `boolean`, `range`, `option`), and all four button actions (`onClick` callback, `runCommand` template, `custom` click, static `click { }` reusing the core click DSL).

The dialog kind is chosen **at the call site with a compile-time token** — `dialog(notice) { }`, `dialog(confirmation) { }` — and the token's type parameter fixes which scope the block receives, so each kind's own capabilities (`yes`/`no`, repeatable `button`s, …) exist only inside that kind's block. "Exactly one dialog type" is a compile-time fact, not a runtime check. All five kinds are plain vals; per-kind required values are required block slots following the `title` precedent — `dialog(dialogList) { dialogs(set); … }`, `dialog(serverLinks) { columns(2); buttonWidth(150); … }` (Paper's `serverLinks` factory has no defaults, so both stay required rather than hardcoding vanilla's).

Two entry points: top-level `dialog(kind) { }` builds an `io.papermc.paper.dialog.Dialog` (construction only, no side effects); `Audience.dialog(kind) { }` builds and shows it, mirroring the `component { }` / `Audience.message { }` duality. Closing stays Adventure-native (`Audience.closeDialog()`).

Also promotes `core/dsl/OnceAssign` (`once()`) from `internal` to `public` and adds `inRange`/`positive` validation combinators, so paper builders reuse the singleton-slot primitive and validate through it (separate commit).

## Related Issues

Closes #82

## DSL Impact

```kotlin
val reward = dialog(confirmation) {
    title { text("Daily reward") }              // required; ISE if missing
    externalTitle { text("Rewards") }
    closeOnEscape(false)
    afterAction(wait)                           // scope members close / none / wait
    message { text("Claim your reward?") }      // bodies accumulate in call order
    inputs {
        boolean("subscribe") {
            label { text("Subscribe") }
            default()
            values {
                true("yes")                     // Boolean.invoke — substitution per state
                false("no")
            }
        }
        range("volume", 0f..100f) {
            label { text("Volume") }
            format(label, ": ", value)          // placeholder tokens, no raw "%s: %s"
            default(50f)
            step(5f)
        }
        option("difficulty") {
            label { text("Difficulty"); visible() }
            options {
                "easy" { display { text("Easy") } }
                "normal" { display { text("Normal") }; default() }
                +"hard"                         // no display override
            }
        }
    }
    yes {                                       // confirmation-only capability
        label { text("Claim") }
        tooltip { text("Adds it to your inventory") }
        onClick { response, audience -> audience.sendMessage(text("Claimed!")) }
    }
    no { label { text("Later") } }
}
player.showDialog(reward)
player.dialog(notice) { title { text("Welcome") }; button { label { text("Understood") } } }
```

House rules applied throughout: singleton slots fail fast with `IllegalStateException` on double-set (via `OnceAssign`), repeatables accumulate, required values are parameters or required slots where Paper requires them (input keys; `dialogs`/`columns`/`buttonWidth` slots), optional knobs live in blocks, and capability scopes model exactly what Paper's builders accept (a button's action is *at most* one because `ActionButton.action()` is nullable). Every range Paper documents is enforced fail-fast with `IllegalArgumentException` by the slot delegate itself (`by once().inRange(1..1024)`, fully type-inferred — widths 1..1024 / 1..256 / 1..512, positive columns/step/maxLength/maxLines). Boolean knobs default to `true` when called with no argument (`default()`, `visible()`, `decorations()`), matching the `bold()` precedent.

Design notes worth a look:
- **`DialogKind<S : DialogScope>`** is the whole compile-time mechanism: a public class with an internal builder factory; plain generics, no context parameters needed. Each kind scope extends the shared `DialogScope` base and its builder composes the base builder via interface delegation (`NoticeBuilder(base) : NoticeScope, DialogScope by base`).
- **`options { "id" { } / +"id" }`** follows the `core/text` `String.invoke` / `String.unaryPlus` precedent; the single-option builder rejects empty option sets, duplicate ids, and multiple `default()`s.
- **`values { true("yes"); false("no") }`** — Boolean literals accept call suffixes, so a scoped `Boolean.invoke(String)` replaces the event-sounding `onTrue`/`onFalse`.
- **`format(label, ": ", value)`** joins placeholder tokens (`%1$s`/`%2$s` scope vals) with literal text, so nobody hand-writes format strings; a single raw part doubles as the translation-key bridge (`format("options.generic_value")`).
- **Label presentation lives in the label block**: `label { text(...); visible(false) }` via a `LabelScope : ComponentScope` (built by wrapping the `component { }` receiver in a delegating builder), only on the input kinds whose Paper builder supports visibility.
- **Button labels are block slots** (`yes { label { text("Claim") } }`), not positional parameters — component-valued required slots follow the `TitleScope.title` precedent (block + `ComponentLike` overload, no `String` overloads), reusing one `ButtonScope` for yes/no/notice/multi-action/exit buttons.
- **Construction routes through `InlinedRegistryBuilderProvider.instance().createDialog`** rather than `Dialog.create(...)`: same delegation target, but `Dialog`'s interface init eagerly resolves registry constants (`Dialog.CUSTOM_OPTIONS`, …) which throws off-server.

## Rationale

Dialogs (MC 1.21.6+) are Paper's biggest new UX surface and the raw API is a maze of ServiceLoader-backed static factories, nullable builder setters, and `List<? extends …>` plumbing. The DSL gives plugin authors one idiomatic, fail-fast Kotlin entry point that composes with the existing component, click-event, and audience DSLs. Unsupported platforms are handled by Adventure's documented no-op `showDialog`/`closeDialog` defaults (stated in KDoc and README).

## Testing

Kotest cases asserting on the **real** Paper interfaces via a compact fixture set: three `META-INF/services`-registered providers (`DialogInstancesProvider`, `InlinedRegistryBuilderProvider`, plus a minimal `RegistryAccess` so `Dialog`'s static init survives off-server) handing out inline mockk stubs. Covers every slot, wiring of each kind/body/input/action variant through its `DialogKind` entry point, accumulation order (including `inputs {}` across multiple blocks), all `IllegalStateException` contracts (duplicate slots, duplicate boolean-value polarity, empty/duplicate/multi-default options), out-of-range rejection (`IllegalArgumentException`) for every validated knob, `format` token joining verified on the built Paper input, and label `visible(false)` reaching the built input. `Audience.dialog(kind) { }` delegation verified with mockk. `./gradlew build` green locally (Kotest, ktlint/spotless, `koverVerify` ≥ 85 %).

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages (paper README Dialogs section; `docs/` untouched — module README is the user-facing home)
- [x] Verified examples build and run (samples source set compiles; wired via `@sample`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Mr16f6aeMBRPT3wvcPFJT
