### PR TITLE
feat(paper): add item, display-name and lore builders

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -66,7 +66,7 @@ behaviour, and **KSP** for compile‑time codegen. The previous `ServiceLoader`/
 | `ansi`                | `core`                                 | Render a `Component` to coloured terminal output                                                               |
 | `coroutines`          | `core`, `kotlinx-coroutines`           | suspend click‑callbacks, async sending, animation scheduling                                                   |
 | `annotations` + `ksp` | —                                      | Typed message‑catalog codegen + compile‑time style validation                                                  |
-| `paper`               | `core` (+ Paper)                       | Scheduler/audience adapter, item **lore**/display‑name builders                                                |
+| `paper`               | `core` (+ Paper)                       | Scheduler/audience adapter, item creation and **lore**/display‑name builders                                  |
 | `velocity`            | `core` (+ Velocity)                    | Proxy scheduler/audience adapter                                                                               |
 | `fabric`              | `core` (+ `adventure-platform-fabric`) | Fabric adapter                                                                                                 |
 | `gradle-plugin`       | (own build)                            | Validate / pre‑compile MiniMessage resource bundles at build time                                              |

--- a/modules/paper/README.md
+++ b/modules/paper/README.md
@@ -54,6 +54,26 @@ mid-flight, Paper stops the task. In unit tests, swap in the deterministic `Manu
 A plugin that consumes this module must declare `folia-supported: true` in its own `plugin.yml` to load on
 Folia. Kotventure needs no extra runtime setup.
 
+## Item name & lore
+
+The `io.github.lmliam.kotventure.paper.item` package creates item stacks and replaces custom names or lore through
+either Paper's data components or the stable `ItemMeta` view. Every non-empty line is explicitly non-italic unless
+the line opts into italics, avoiding Minecraft's inherited italic item-text default.
+
+```kotlin
+val sword = item(Material.DIAMOND_SWORD) {
+    name("Excalibur") { color(gold) }
+    lore {
+        +"A legendary blade"
+        "+5 Strength" { color(gray) }
+        blank()
+    }
+}
+
+sword.lore { +"Bound to soul" }             // Paper data-component path
+sword.editMeta { meta -> meta.lore { +"Soulbound" } } // stable ItemMeta path
+```
+
 ## Dialogs
 
 Paper's [dialog](https://docs.papermc.io/paper/dev/dialogs) forms get a typed builder in the

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/Item.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/Item.kt
@@ -1,0 +1,20 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.item
+
+import org.bukkit.Material
+import org.bukkit.inventory.ItemStack
+
+/**
+ * Creates an [ItemStack] of [material] and [amount], then configures its text through [init].
+ *
+ * Construction only — the item is not added to an inventory or otherwise displayed.
+ *
+ * @throws IllegalArgumentException when [material] is not an item or [amount] is less than one.
+ * @sample io.github.lmliam.kotventure.paper.item.itemSample
+ */
+public fun item(
+    material: Material,
+    amount: Int = 1,
+    init: ItemScope.() -> Unit,
+): ItemStack = ItemStack.of(material, amount).also { ItemBuilder(it).apply(init) }

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/ItemBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/ItemBuilder.kt
@@ -1,0 +1,19 @@
+package io.github.lmliam.kotventure.paper.item
+
+import io.github.lmliam.kotventure.core.text.TextScope
+import org.bukkit.inventory.ItemStack
+
+internal class ItemBuilder(
+    private val stack: ItemStack,
+) : ItemScope {
+    override fun name(
+        value: String,
+        init: TextScope.() -> Unit,
+    ) {
+        stack.name(value, init)
+    }
+
+    override fun lore(init: LoreScope.() -> Unit) {
+        stack.lore(init)
+    }
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/ItemMetaItems.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/ItemMetaItems.kt
@@ -1,0 +1,30 @@
+package io.github.lmliam.kotventure.paper.item
+
+import io.github.lmliam.kotventure.core.text.TextScope
+import io.github.lmliam.kotventure.core.text.text
+import org.bukkit.inventory.meta.ItemMeta
+
+/**
+ * Replaces this metadata's custom name with styled literal [value].
+ *
+ * The resulting component is explicitly non-italic unless [init] sets an italic state.
+ *
+ * @sample io.github.lmliam.kotventure.paper.item.editItemMetaSample
+ */
+public fun ItemMeta.name(
+    value: String,
+    init: TextScope.() -> Unit = {},
+) {
+    customName(text(value, init).nonItalicByDefault())
+}
+
+/**
+ * Replaces this metadata's lore with the lines accumulated by [init].
+ *
+ * Each non-empty line is explicitly non-italic unless that line sets an italic state.
+ *
+ * @sample io.github.lmliam.kotventure.paper.item.editItemMetaSample
+ */
+public fun ItemMeta.lore(init: LoreScope.() -> Unit) {
+    lore(LoreBuilder().apply(init).build())
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/ItemScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/ItemScope.kt
@@ -1,0 +1,27 @@
+package io.github.lmliam.kotventure.paper.item
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.core.text.TextScope
+
+/**
+ * Configures the text data components of a newly created item.
+ */
+@KotventureDslMarker
+public interface ItemScope {
+    /**
+     * Replaces the item's custom name with styled literal [value].
+     *
+     * The resulting component is explicitly non-italic unless [init] sets an italic state.
+     */
+    public fun name(
+        value: String,
+        init: TextScope.() -> Unit = {},
+    )
+
+    /**
+     * Replaces the item's lore with the lines accumulated by [init].
+     *
+     * Each non-empty line is explicitly non-italic unless that line sets an italic state.
+     */
+    public fun lore(init: LoreScope.() -> Unit)
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/ItemStackItems.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/ItemStackItems.kt
@@ -1,0 +1,34 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.item
+
+import io.github.lmliam.kotventure.core.text.TextScope
+import io.github.lmliam.kotventure.core.text.text
+import io.papermc.paper.datacomponent.DataComponentTypes
+import io.papermc.paper.datacomponent.item.ItemLore
+import org.bukkit.inventory.ItemStack
+
+/**
+ * Replaces this item's custom-name data component with styled literal [value].
+ *
+ * The resulting component is explicitly non-italic unless [init] sets an italic state.
+ *
+ * @sample io.github.lmliam.kotventure.paper.item.itemSample
+ */
+public fun ItemStack.name(
+    value: String,
+    init: TextScope.() -> Unit = {},
+) {
+    setData(DataComponentTypes.CUSTOM_NAME, text(value, init).nonItalicByDefault())
+}
+
+/**
+ * Replaces this item's lore data component with the lines accumulated by [init].
+ *
+ * Each non-empty line is explicitly non-italic unless that line sets an italic state.
+ *
+ * @sample io.github.lmliam.kotventure.paper.item.itemSample
+ */
+public fun ItemStack.lore(init: LoreScope.() -> Unit) {
+    setData(DataComponentTypes.LORE, ItemLore.lore(LoreBuilder().apply(init).build()))
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/LoreBuilder.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/LoreBuilder.kt
@@ -1,0 +1,29 @@
+package io.github.lmliam.kotventure.paper.item
+
+import io.github.lmliam.kotventure.core.text.TextScope
+import io.github.lmliam.kotventure.core.text.text
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+
+internal class LoreBuilder : LoreScope {
+    val lines: List<Component>
+        field = mutableListOf()
+
+    override fun String.unaryPlus() {
+        lines += text(this).nonItalicByDefault()
+    }
+
+    override fun String.invoke(init: TextScope.() -> Unit) {
+        lines += text(this, init).nonItalicByDefault()
+    }
+
+    override fun ComponentLike.unaryPlus() {
+        lines += asComponent().nonItalicByDefault()
+    }
+
+    override fun blank() {
+        lines += Component.empty()
+    }
+
+    internal fun build(): List<Component> = lines
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/LoreScope.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/LoreScope.kt
@@ -1,0 +1,33 @@
+package io.github.lmliam.kotventure.paper.item
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.core.text.TextScope
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Accumulates item lore lines in call order.
+ */
+@KotventureDslMarker
+public interface LoreScope {
+    /**
+     * Adds this string as a plain, explicitly non-italic lore line.
+     */
+    public operator fun String.unaryPlus()
+
+    /**
+     * Adds this string as a styled lore line configured by [init].
+     *
+     * The line is explicitly non-italic unless [init] sets an italic state.
+     */
+    public operator fun String.invoke(init: TextScope.() -> Unit)
+
+    /**
+     * Adds this component-like value as a lore line, explicitly non-italic unless it sets an italic state.
+     */
+    public operator fun ComponentLike.unaryPlus()
+
+    /**
+     * Adds an empty spacer line.
+     */
+    public fun blank()
+}

--- a/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/NonItalicName.kt
+++ b/modules/paper/src/main/kotlin/io/github/lmliam/kotventure/paper/item/NonItalicName.kt
@@ -1,0 +1,7 @@
+package io.github.lmliam.kotventure.paper.item
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextDecoration
+
+internal fun Component.nonItalicByDefault(): Component =
+    decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)

--- a/modules/paper/src/samples/kotlin/io/github/lmliam/kotventure/paper/item/ItemSamples.kt
+++ b/modules/paper/src/samples/kotlin/io/github/lmliam/kotventure/paper/item/ItemSamples.kt
@@ -1,0 +1,22 @@
+package io.github.lmliam.kotventure.paper.item
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.color.gray
+import org.bukkit.Material
+import org.bukkit.inventory.ItemStack
+
+internal fun itemSample(): ItemStack =
+    item(Material.DIAMOND_SWORD) {
+        name("Excalibur") { color(gold) }
+        lore {
+            +"A legendary blade"
+            "+5 Strength" { color(gray) }
+            blank()
+        }
+    }
+
+internal fun editItemMetaSample(stack: ItemStack) {
+    stack.editMeta { meta ->
+        meta.lore { +"Bound to soul" }
+    }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeRegistryAccess.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/dialog/fixture/FakeRegistryAccess.kt
@@ -2,10 +2,10 @@
 
 package io.github.lmliam.kotventure.paper.dialog.fixture
 
+import io.github.lmliam.kotventure.paper.item.fixture.FakeDataComponentRegistry
 import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.RegistryAccess
 import io.papermc.paper.registry.RegistryKey
-import io.papermc.paper.registry.data.dialog.ActionButton
 import io.papermc.paper.registry.data.dialog.DialogBase
 import io.papermc.paper.registry.data.dialog.body.DialogBody
 import io.papermc.paper.registry.data.dialog.input.DialogInput
@@ -15,9 +15,9 @@ import org.bukkit.Keyed
 import org.bukkit.Registry
 
 /**
- * ServiceLoader-registered [RegistryAccess] so that initializing the Paper [Dialog] interface — and
- * its registry-backed constants — succeeds in a plain unit test without a running server. Every
- * lookup returns a placeholder [FakeDialog]; the constants themselves are never asserted.
+ * ServiceLoader-registered [RegistryAccess] so that initializing registry-backed Paper constants
+ * succeeds in a plain unit test without a running server. Dialog lookups return a placeholder
+ * [FakeDialog], while the data-component registry returns keyed placeholder component types.
  *
  * This runs from inside [org.bukkit.Registry]'s own class initialization (its `<clinit>` eagerly
  * builds legacy registries for every registry type, [Dialog] included), so every placeholder here
@@ -34,7 +34,13 @@ class FakeRegistryAccess : RegistryAccess {
     @Suppress("OVERRIDE_DEPRECATION")
     override fun <T : Keyed> getRegistry(type: Class<T>): Registry<T> = registry()
 
-    override fun <T : Keyed> getRegistry(key: RegistryKey<T>): Registry<T> = registry()
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Keyed> getRegistry(key: RegistryKey<T>): Registry<T> =
+        if (key.key().value() == "data_component_type") {
+            FakeDataComponentRegistry() as Registry<T>
+        } else {
+            registry()
+        }
 
     @Suppress("UNCHECKED_CAST")
     private fun <T : Keyed> registry(): Registry<T> =

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/ItemBuilderTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/ItemBuilderTest.kt
@@ -1,0 +1,43 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.item
+
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import io.papermc.paper.datacomponent.DataComponentTypes
+import io.papermc.paper.datacomponent.item.ItemLore
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.format.TextDecoration.State
+import org.bukkit.inventory.ItemStack
+
+class ItemBuilderTest :
+    StringSpec(
+        {
+            "forwards name and lore to the item stack extensions" {
+                val stack = mockk<ItemStack>(relaxed = true)
+                val expectedName = Component.text("X").decoration(TextDecoration.ITALIC, State.FALSE)
+                val expectedLore = listOf(Component.text("line").decoration(TextDecoration.ITALIC, State.FALSE))
+                val itemLore = mockk<ItemLore>()
+                mockkStatic(ItemLore::class)
+                every { ItemLore.lore(expectedLore) } returns itemLore
+
+                try {
+                    ItemBuilder(stack).apply {
+                        name("X")
+                        lore { +"line" }
+                    }
+
+                    verify { stack.setData(DataComponentTypes.CUSTOM_NAME, expectedName) }
+                    verify { ItemLore.lore(expectedLore) }
+                    verify { stack.setData(DataComponentTypes.LORE, itemLore) }
+                } finally {
+                    unmockkStatic(ItemLore::class)
+                }
+            }
+        },
+    )

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/ItemMetaItemsTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/ItemMetaItemsTest.kt
@@ -1,0 +1,39 @@
+package io.github.lmliam.kotventure.paper.item
+
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.mockk
+import io.mockk.verify
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.format.TextDecoration.State
+import org.bukkit.inventory.meta.ItemMeta
+
+class ItemMetaItemsTest :
+    StringSpec(
+        {
+            "applies a non-italic custom name" {
+                val meta = mockk<ItemMeta>(relaxed = true)
+                val expected = Component.text("X").decoration(TextDecoration.ITALIC, State.FALSE)
+
+                meta.name("X")
+
+                verify { meta.customName(expected) }
+            }
+
+            "applies non-italic lore in call order" {
+                val meta = mockk<ItemMeta>(relaxed = true)
+                val expected =
+                    listOf(
+                        Component.text("a").decoration(TextDecoration.ITALIC, State.FALSE),
+                        Component.text("b").decoration(TextDecoration.ITALIC, State.FALSE),
+                    )
+
+                meta.lore {
+                    +"a"
+                    +"b"
+                }
+
+                verify { meta.lore(expected) }
+            }
+        },
+    )

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/ItemStackItemsTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/ItemStackItemsTest.kt
@@ -1,0 +1,54 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.item
+
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import io.papermc.paper.datacomponent.DataComponentTypes
+import io.papermc.paper.datacomponent.item.ItemLore
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.format.TextDecoration.State
+import org.bukkit.inventory.ItemStack
+
+class ItemStackItemsTest :
+    StringSpec(
+        {
+            "applies a non-italic custom name data component" {
+                val stack = mockk<ItemStack>(relaxed = true)
+                val expected = Component.text("X").decoration(TextDecoration.ITALIC, State.FALSE)
+
+                stack.name("X")
+
+                verify { stack.setData(DataComponentTypes.CUSTOM_NAME, expected) }
+            }
+
+            "applies non-italic lore data component in call order" {
+                val stack = mockk<ItemStack>(relaxed = true)
+                val expected =
+                    listOf(
+                        Component.text("a").decoration(TextDecoration.ITALIC, State.FALSE),
+                        Component.text("b").decoration(TextDecoration.ITALIC, State.FALSE),
+                    )
+                val itemLore = mockk<ItemLore>()
+                mockkStatic(ItemLore::class)
+                every { ItemLore.lore(expected) } returns itemLore
+
+                try {
+                    stack.lore {
+                        +"a"
+                        +"b"
+                    }
+
+                    verify { ItemLore.lore(expected) }
+                    verify { stack.setData(DataComponentTypes.LORE, itemLore) }
+                } finally {
+                    unmockkStatic(ItemLore::class)
+                }
+            }
+        },
+    )

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/LoreBuilderTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/LoreBuilderTest.kt
@@ -71,15 +71,15 @@ class LoreBuilderTest :
                     }
 
                 lines shouldContainExactly
-                    listOf(
-                        Component.text("first").decoration(TextDecoration.ITALIC, State.FALSE),
-                        Component
-                            .text("second")
-                            .color(NamedTextColor.GRAY)
-                            .decoration(TextDecoration.ITALIC, State.FALSE),
-                        Component.text("third").decoration(TextDecoration.ITALIC, State.FALSE),
-                        Component.empty(),
-                    )
+                        listOf(
+                            Component.text("first").decoration(TextDecoration.ITALIC, State.FALSE),
+                            Component
+                                .text("second")
+                                .color(NamedTextColor.GRAY)
+                                .decoration(TextDecoration.ITALIC, State.FALSE),
+                            Component.text("third").decoration(TextDecoration.ITALIC, State.FALSE),
+                            Component.empty(),
+                        )
             }
         },
     )

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/LoreBuilderTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/LoreBuilderTest.kt
@@ -1,0 +1,87 @@
+package io.github.lmliam.kotventure.paper.item
+
+import io.github.lmliam.kotventure.core.color.gray
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.test.text.shouldBeItalic
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
+import io.github.lmliam.kotventure.test.text.shouldHaveContent
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.github.lmliam.kotventure.test.text.shouldNotBeItalic
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.format.TextDecoration.State
+
+class LoreBuilderTest :
+    StringSpec(
+        {
+            "adds a plain line with an explicit non-italic default" {
+                val lines = lore { +"A" }
+
+                lines shouldHaveSize 1
+                lines.single() shouldHaveContent "A"
+                lines.single().shouldHaveDecoration(TextDecoration.ITALIC, State.FALSE)
+                lines.single().shouldNotBeItalic()
+            }
+
+            "adds a styled line with an explicit non-italic default" {
+                val lines = lore { "B" { color(gray) } }
+
+                lines shouldHaveSize 1
+                lines.single() shouldHaveContent "B"
+                lines.single() shouldHaveColor NamedTextColor.GRAY
+                lines.single().shouldHaveDecoration(TextDecoration.ITALIC, State.FALSE)
+                lines.single().shouldNotBeItalic()
+            }
+
+            "preserves an explicit italic decoration" {
+                val lines = lore { "B" { italic() } }
+
+                lines.single().shouldBeItalic()
+            }
+
+            "adds a prebuilt component as a line" {
+                val prebuilt = text("prebuilt")
+
+                val lines = lore { +prebuilt }
+
+                lines.single() shouldHaveContent "prebuilt"
+                lines.single().shouldHaveDecoration(TextDecoration.ITALIC, State.FALSE)
+            }
+
+            "adds an empty spacer line" {
+                val lines = lore { blank() }
+
+                lines.single() shouldBe Component.empty()
+            }
+
+            "accumulates lines in call order" {
+                val prebuilt = text("third")
+
+                val lines =
+                    lore {
+                        +"first"
+                        "second" { color(gray) }
+                        +prebuilt
+                        blank()
+                    }
+
+                lines shouldContainExactly
+                    listOf(
+                        Component.text("first").decoration(TextDecoration.ITALIC, State.FALSE),
+                        Component
+                            .text("second")
+                            .color(NamedTextColor.GRAY)
+                            .decoration(TextDecoration.ITALIC, State.FALSE),
+                        Component.text("third").decoration(TextDecoration.ITALIC, State.FALSE),
+                        Component.empty(),
+                    )
+            }
+        },
+    )
+
+private fun lore(init: LoreScope.() -> Unit): List<Component> = LoreBuilder().apply(init).build()

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/NonItalicNameTest.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/NonItalicNameTest.kt
@@ -1,0 +1,27 @@
+package io.github.lmliam.kotventure.paper.item
+
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.test.text.shouldBeItalic
+import io.github.lmliam.kotventure.test.text.shouldHaveDecoration
+import io.github.lmliam.kotventure.test.text.shouldNotBeItalic
+import io.kotest.core.spec.style.StringSpec
+import net.kyori.adventure.text.format.TextDecoration
+import net.kyori.adventure.text.format.TextDecoration.State
+
+class NonItalicNameTest :
+    StringSpec(
+        {
+            "applies an explicit non-italic default" {
+                val name = text("X").nonItalicByDefault()
+
+                name.shouldHaveDecoration(TextDecoration.ITALIC, State.FALSE)
+                name.shouldNotBeItalic()
+            }
+
+            "preserves an explicit italic decoration" {
+                val name = text("X") { italic() }.nonItalicByDefault()
+
+                name.shouldBeItalic()
+            }
+        },
+    )

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/fixture/FakeDataComponentRegistry.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/fixture/FakeDataComponentRegistry.kt
@@ -1,0 +1,44 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.item.fixture
+
+import io.papermc.paper.datacomponent.DataComponentType
+import io.papermc.paper.registry.tag.Tag
+import io.papermc.paper.registry.tag.TagKey
+import net.kyori.adventure.key.Key
+import org.bukkit.NamespacedKey
+import org.bukkit.Registry
+import java.util.stream.Stream
+
+internal class FakeDataComponentRegistry : Registry<DataComponentType> {
+    override fun get(key: NamespacedKey): DataComponentType = type(key)
+
+    override fun getOrThrow(key: Key): DataComponentType = type(NamespacedKey(key.namespace(), key.value()))
+
+    override fun getKey(value: DataComponentType): NamespacedKey = value.key
+
+    override fun hasTag(key: TagKey<DataComponentType>): Boolean = error("not used")
+
+    override fun getTag(key: TagKey<DataComponentType>): Tag<DataComponentType> = error("not used")
+
+    override fun getTags(): Collection<Tag<DataComponentType>> = error("not used")
+
+    override fun stream(): Stream<DataComponentType> = error("not used")
+
+    override fun keyStream(): Stream<NamespacedKey> = error("not used")
+
+    override fun size(): Int = 0
+
+    override fun iterator(): MutableIterator<DataComponentType> = error("not used")
+
+    private fun type(key: NamespacedKey): DataComponentType =
+        if (key.key in nonValuedKeys) {
+            FakeNonValuedDataComponentType(key)
+        } else {
+            FakeValuedDataComponentType(key)
+        }
+
+    private companion object {
+        val nonValuedKeys: Set<String> = setOf("unbreakable", "intangible_projectile", "glider")
+    }
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/fixture/FakeNonValuedDataComponentType.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/fixture/FakeNonValuedDataComponentType.kt
@@ -1,0 +1,14 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.item.fixture
+
+import io.papermc.paper.datacomponent.DataComponentType
+import org.bukkit.NamespacedKey
+
+internal class FakeNonValuedDataComponentType(
+    private val key: NamespacedKey,
+) : DataComponentType.NonValued {
+    override fun getKey(): NamespacedKey = key
+
+    override fun isPersistent(): Boolean = true
+}

--- a/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/fixture/FakeValuedDataComponentType.kt
+++ b/modules/paper/src/test/kotlin/io/github/lmliam/kotventure/paper/item/fixture/FakeValuedDataComponentType.kt
@@ -1,0 +1,14 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.lmliam.kotventure.paper.item.fixture
+
+import io.papermc.paper.datacomponent.DataComponentType
+import org.bukkit.NamespacedKey
+
+internal class FakeValuedDataComponentType(
+    private val key: NamespacedKey,
+) : DataComponentType.Valued<Any> {
+    override fun getKey(): NamespacedKey = key
+
+    override fun isPersistent(): Boolean = true
+}


### PR DESCRIPTION
## Summary

Adds an item DSL under paper's `item` feature package: an `item(material) { … }` builder plus non-italic-by-default display-name and lore builders, exposed on **both** `ItemStack` (Paper Data Component API) and `ItemMeta` (stable Adventure methods).

## Related Issues

Closes #43

## DSL Impact

New public surface in `io.github.lmliam.kotventure.paper.item`:

```kotlin
val sword = item(Material.DIAMOND_SWORD) {
    name("Excalibur") { color(gold) }
    lore {
        +"A legendary blade"
        "+5 Strength" { color(gray) }
        blank()
        +"Right-click to smite"
    }
}
stack.lore { +"Bound to soul" }                      // ItemStack → data components
stack.editMeta { meta -> meta.lore { +"Bound to soul" } }   // ItemMeta path
```

- Lore lines are string-led: `+"…"`, `"…" { … }`, `+component`, `blank()`.
- `name` mirrors core `text()` (`name("X")` / `name("X") { color(gold) }`).
- The non-italic default is non-destructive — `Component.decorationIfAbsent(ITALIC, FALSE)` — so an explicit `italic(true)` survives.

## Rationale

Item lore and display names render italic by default in vanilla; every GUI/menu author strips it by hand. This makes the correct thing the default and gives item creation a clean DSL. Building on **both** the modern Data Component API and the stable `ItemMeta` methods (a view over the same field on modern Paper) serves plugins in either paradigm with no double-write.

## Testing

- `LoreBuilderTest` — non-italic default per line, explicit italic preserved, call order, `blank()`, prebuilt-component lines (server-free; dogfoods the `test` matchers).
- `NonItalicNameTest` — the decoration-default helper.
- `ItemMetaItemsTest` — mocked `ItemMeta`, verifies `customName` / `lore`.
- `ItemStackItemsTest` / `ItemBuilderTest` — mocked `ItemStack` plus an extended fake data-component registry (ServiceLoader bootstrap reused from the dialog tests); a static seam covers the headless-only `ItemLore.lore`.
- `ItemSamples.kt` compiles the surface. `./gradlew build` is green (tests + ktlint/spotless + koverVerify 85%).

## Checklist

- [x] Linked related issue
- [x] Updated README and relevant `/docs` pages
- [x] Verified examples build and run
