### PR TITLE
docs(agents): add a section on how to write to the maintainer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,3 +215,23 @@ Write implementation plans in `.agents/plans/`. Git ignores this directory.
 
 - Keep build configuration and module-layout changes small and related to the issue.
 - Do not change the public API of a frozen module without a binary-compatibility baseline update.
+
+## 11. How to write to the maintainer
+
+The maintainer has ADHD. Shape each reply so that it is possible to act on immediately.
+If you have the `i-have-adhd` skill, use it. These rules apply with or without that skill.
+
+- Start with the action. Put the command, the path, or the code first. Give the background after it, or not at all.
+- Do not use an opening sentence that announces your plan ("Let me…", "I'll…", "Great question").
+- Do not use a closing sentence that repeats the work or asks "anything else?".
+- Number a task that has more than one step. Give one action in each step.
+- Restate the position in a sequence each time, for example "Step 3 of 5 done".
+- Give a time estimate in concrete units, for example "about 15 minutes", not "some work".
+- Keep a list to five items. If it becomes longer, divide it into "do now" and "later".
+- Report an error with its cause and its correction. Do not use "Uh oh" or "There seems to be a problem".
+- Show what now operates, with the command that shows it.
+- Finish one subject before you introduce a second one. Offer the second subject as a separate question.
+- End with one action that takes less than two minutes.
+
+Give a full explanation when the maintainer asks you to explain or to review a design. Add headings so that
+the text is easy to scan. The rules about the first sentence and the last sentence continue to apply.


### PR DESCRIPTION
## Summary

Adds section 11 to `AGENTS.md`: how an agent writes to the maintainer.

The maintainer has ADHD. A reply that starts with background, or that buries the action, is difficult to act on. The
new section gives the rules: start with the action, number a task with more than one step, restate the position in a
sequence, give a time estimate in concrete units, and end with one short action.

`CLAUDE.md` is a symbolic link to `AGENTS.md`, so both entry points receive the section.

## Related Issues

None. The maintainer asked for this change directly.

## Motivation

The rules exist today only in a local agent plugin that one machine has. An agent session in a different environment
does not receive them. The section repeats the rules in full, so the guide does not depend on that plugin.

## Notes

The section keeps the guide generic: it states a project-level rule and names no issue and no pull request.

## Checklist

- [x] Use simplified technical English
- [x] Keep the change small and related to one purpose

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W98X3Gbw4WvZg9RSv9FxD8
