### PR TITLE
docs(docs): refresh roadmap stages and record design decisions

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -339,8 +339,9 @@ and convenience functions:
 - **Publication:** During the pre-alpha and alpha stages, JitPack builds from Git tags. At beta or version `1.0`, Maven
   Central uses the `io.github.lmliam` namespace and GPG signatures.
 - The **BOM** module aligns versions across all artefacts.
-- **Versions:** `0.0.x` is unstable, `0.x` is alpha, and `0.9.x` is beta with a frozen API. Version `1.0.0` starts the
-  semantic-versioning commitment. CI builds, tests, and lints pull requests. Tags start publication.
+- **Versions:** every pre-1.0 release is a `0.x` minor. Alpha lasts until the API freeze; the `0.x` line after the
+  freeze is beta. Version `1.0.0` starts the semantic-versioning commitment. CI builds, tests, and lints pull
+  requests. Tags start publication.
 
 > **Note:** To add or update a GitHub Actions workflow, use a token with the `workflow` scope. Use
 > `gh auth refresh -s workflow` to add the scope. A separate issue tracks CI on `master`.
@@ -368,14 +369,14 @@ Roadmap issues with 5.x notes are serialisers (#30), click events (#21), rendere
 Each phase is a GitHub **milestone**. Each subissue is a small vertical slice with its own tests. The project can
 release each slice independently.
 
-| Phase | Milestone         | Focus                                                                                                                                                                 |
-|-------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **0** | Pre‑Alpha `0.0.x` | Foundations: drop SPI, restructure, CI, JitPack, BOM stub. **First slice:** `component { text { color/decorate } }` + first matcher + `toMiniMessage()`. Tag `0.0.1`. |
-| **1** | Alpha `0.1–0.3`   | Core DSL: full components, styles, events, gradients, and themes. MiniMessage typed templates, validation, and converter. Serialiser extensions. Test matchers and snapshots.   |
-| **2** | Alpha `0.4–0.6`   | Audience & UX: send DSL (message/actionbar/title/book/sound/tablist), managed boss bars/titles, pagination, GUI/lore builders (Paper), coroutines.                    |
-| **3** | Alpha `0.7–0.8`   | Animation frame flows + built‑ins, MiniMessage environment, i18n registry + locale DSL, typed message catalogue (catalog compiler), ANSI preview, Gradle build plugin, Maven Central, binary‑compatibility dumps. |
-| **4** | Beta `0.9.x`      | Velocity + Fabric bundles, static style validation (detekt), compatibility matrix, API freeze, perf pass, docs/cookbook, integration tests.                           |
-| **5** | `1.0.0`           | Maven Central signed publishing, semver commitment, sample plugin, migration guide, final docs.                                                                       |
+| Phase | Stage     | Focus                                                                                                                                                                 |
+|-------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **0** | Pre‑Alpha | Foundations: drop SPI, restructure, CI, JitPack, BOM stub. **First slice:** `component { text { color/decorate } }` + first matcher + `toMiniMessage()`.              |
+| **1** | Alpha     | Core DSL: full components, styles, events, gradients, and themes. MiniMessage typed templates, validation, and converter. Serialiser extensions. Test matchers and snapshots.   |
+| **2** | Alpha     | Audience & UX: send DSL (message/actionbar/title/book/sound/tablist), managed boss bars/titles, pagination, GUI/lore builders (Paper), coroutines.                    |
+| **3** | Alpha     | Animation frame flows + built‑ins, MiniMessage environment, i18n registry + locale DSL, typed message catalogue (catalog compiler), ANSI preview, Gradle build plugin, Maven Central, binary‑compatibility dumps. |
+| **4** | Beta      | Velocity + Fabric bundles, static style validation (detekt), compatibility matrix, API freeze, perf pass, docs/cookbook, integration tests.                           |
+| **5** | Release   | Maven Central signed publishing, semver commitment, sample plugin, migration guide, final docs.                                                                       |
 
 ## 12. Feature → phase matrix
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -18,7 +18,7 @@ Three primary features distinguish it from other libraries:
 2. **A component test toolkit** supplies Kotest and JUnit matchers. It also supplies snapshot tests for Adventure
    components.
 3. **Developer tools** render components in a terminal with ANSI. They generate a typed message catalogue from
-   resource files with KSP. They also validate MiniMessage bundles during a Gradle build.
+   resource files with the catalogue compiler. They also validate MiniMessage bundles during a Gradle build.
 
 Kotventure also supports all component types, styles, themes, and audience operations. Audience operations include
 titles, boss bars, books, sounds, and tab lists. The target scope also includes pagination, animation,
@@ -53,20 +53,20 @@ component builder.
 ## 4. Architecture & module map
 
 The architecture uses three mechanisms. An idiomatic DSL supplies most of the API. Small, **explicit registries**
-supply runtime extension points. **KSP** generates code at compile time. The project does not use the previous
+supply runtime extension points. The **catalogue compiler** generates code at build time. The project does not use the previous
 `ServiceLoader` and `@ServiceContract` factory indirection.
 
 | Module                | Depends on                             | Purpose                                                                                                        |
 |-----------------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| `core`                | `adventure-api`                        | Component/style/colour/gradient DSL, theme engine, the registry, audience‑send DSL, animation **abstractions** |
+| `core`                | `adventure-api`                        | Component/style/colour/gradient DSL, theme engine, the registry, audience‑send DSL, `Ticker` abstraction       |
 | `serializer`          | `adventure-api`, concrete serialisers  | Optional `Component` serialiser extensions such as MiniMessage and plain text                                  |
 | `minimessage`         | `core`, `adventure-text-minimessage`   | Typed tag/placeholder DSL, typed templates, validation, MiniMessage ⇄ DSL converter                            |
 | `i18n`                | `core`, `minimessage`                  | Translation registry + per‑player locale DSL                                                                   |
 | `test`                | `core` (test‑scoped for consumers)     | Kotest/JUnit structural component matchers                                                                     |
 | `test-snapshot`       | `adventure-api`, `serializer`          | Snapshot testing over canonical component JSON                                                                 |
 | `ansi`                | `core`                                 | Render a `Component` to coloured terminal output                                                               |
-| `coroutines`          | `core`, `kotlinx-coroutines`           | suspend click‑callbacks, async sending, animation scheduling                                                   |
-| `annotations` + `ksp` | —                                      | Typed message‑catalogue codegen + compile‑time style validation                                                |
+| `coroutines`          | `core`, `kotlinx-coroutines`           | suspend click‑callbacks, awaited prompts, tick dispatch, animation frame flows                                 |
+| `catalog-compiler`    | `minimessage`                          | Typed message‑catalogue model, validation and codegen; Gradle task and tooling frontends                       |
 | `paper`               | `core` (+ Paper)                       | Scheduler/audience adapter, item creation and **lore**/display‑name builders                                  |
 | `velocity`            | `core` (+ Velocity)                    | Proxy scheduler/audience adapter                                                                               |
 | `fabric`              | `core` (+ `adventure-platform-fabric`) | Fabric adapter                                                                                                 |
@@ -83,14 +83,16 @@ hidden process-wide registry or scan the class path.
 
 - **Theme providers** use a `ThemeRegistry` instance for dynamic lookup and interoperability. Direct Kotlin callers
   use compiler-checked properties such as `Brand.header`.
-- **Custom MiniMessage tags**, **animation drivers**, and **platform adapters** must use the same pattern. The feature
+- **Custom MiniMessage tags** and **platform adapters** must use the same pattern. The feature
   owns an explicit registry. It does not use ambient global state.
 
 This design keeps usual operations direct and permits the replacement of variable parts.
 
-**Animation layers** arrive in Phase 3. The `core` module defines the frame model, ticker, and driver interface.
-Concrete **animation drivers** use the applicable registry. The `coroutines` module and platform schedulers control
-the runtime schedule. The composition flow is **abstractions → registered driver → scheduled frame execution**.
+**Animation** arrives in Phase 3 as flows, not as an engine. Effects are functions from components to
+`Flow<Component>` frame sources. A suspending sink presents a frame flow to an audience target. `Ticker`
+implementations and their coroutine mappings pace the frames, and structured concurrency controls cancellation.
+There is no separate driver interface or driver registry: the platform `Ticker` registrations already fill that
+role. The composition flow is **effect → frame flow → paced collection → audience target**.
 
 ## 5. Canonical DSL surface (illustrative)
 
@@ -245,7 +247,7 @@ player.message(
     },
 )
 
-// ── Typed catalog (KSP from messages.yml) ──────────────────────
+// ── Typed catalog (generated from messages.yml) ────────────────
 Messages.welcome(player = name, count = 3)   // generated, validated placeholders
 
 // ── Normalising & traversing ───────────────────────────────────
@@ -306,18 +308,22 @@ arguments. Invalid patterns cause an exception that gives the applicable offset.
 
 - **`ansi`** renders a `Component` as ANSI for tests and logs. It supports colours, decorations, and approximate
   gradients. Developers can examine output without a server.
-- **`ksp`** generates a typed message catalogue from `messages.yml` or property files. The generated accessors have
-  required, validated placeholders. It can also validate styles at compile time.
-- **`gradle-plugin`** stops a build when resource bundles contain malformed MiniMessage or absent placeholders. It can
-  also precompile bundles.
+- **`catalog-compiler`** parses `messages.yml` or property files, validates markup and placeholders, and generates a
+  typed message catalogue with required, validated placeholders. It is a pure library with no Gradle dependency, so
+  build, IDE, and CLI frontends share one implementation.
+- **`gradle-plugin`** stops a build when resource bundles contain malformed MiniMessage or absent placeholders, using
+  the `catalog-compiler` diagnostics. It can also precompile bundles.
+- A **detekt rule set** flags illegal style/component constructs that the type system cannot express. KSP is not used
+  for this: it resolves declarations, not the expression bodies inside DSL blocks.
 
 ## 9. Platforms
 
 `core` depends only on `adventure-api`. Thus, it works on all Adventure platforms. Small bundles add platform adapters
 and convenience functions:
 
-- **`paper`** supplies an animation scheduler, audience functions, and item lore and name builders.
-- **`velocity`** supplies a proxy scheduler and audience adapter.
+- **`paper`** supplies Paper and Folia tickers, audience functions, dialogs, and item lore and name builders.
+- **`velocity`** supplies a proxy scheduler ticker and lifecycle wiring. Velocity is natively Adventure, so no
+  audience adapter is needed.
 - **`fabric`** uses `adventure-platform-fabric`.
 
 ## 10. Build, publishing & versioning
@@ -367,8 +373,8 @@ release each slice independently.
 | **0** | Pre‑Alpha `0.0.x` | Foundations: drop SPI, restructure, CI, JitPack, BOM stub. **First slice:** `component { text { color/decorate } }` + first matcher + `toMiniMessage()`. Tag `0.0.1`. |
 | **1** | Alpha `0.1–0.3`   | Core DSL: full components, styles, events, gradients, and themes. MiniMessage typed templates, validation, and converter. Serialiser extensions. Test matchers and snapshots.   |
 | **2** | Alpha `0.4–0.6`   | Audience & UX: send DSL (message/actionbar/title/book/sound/tablist), managed boss bars/titles, pagination, GUI/lore builders (Paper), coroutines.                    |
-| **3** | Alpha `0.7–0.8`   | Animation engine + built‑ins, i18n registry + locale DSL, typed message catalogue (KSP), ANSI preview, Gradle build plugin.                                           |
-| **4** | Beta `0.9.x`      | Velocity + Fabric bundles, compile‑time style validation (KSP), API freeze, perf pass, docs/cookbook, integration tests.                                              |
+| **3** | Alpha `0.7–0.8`   | Animation frame flows + built‑ins, MiniMessage environment, i18n registry + locale DSL, typed message catalogue (catalog compiler), ANSI preview, Gradle build plugin, Maven Central, binary‑compatibility dumps. |
+| **4** | Beta `0.9.x`      | Velocity + Fabric bundles, static style validation (detekt), compatibility matrix, API freeze, perf pass, docs/cookbook, integration tests.                           |
 | **5** | `1.0.0`           | Maven Central signed publishing, semver commitment, sample plugin, migration guide, final docs.                                                                       |
 
 ## 12. Feature → phase matrix
@@ -397,4 +403,7 @@ release each slice independently.
 - Optional **Sponge** / **BungeeCord** bundles post‑1.0.
 - IDE inspections / detekt rules for the DSL (long‑term tooling).
 - A hosted **playground** / cookbook docs site.
-- Scoreboard and sidebar helpers are not part of Adventure core. Evaluate them as a Paper bundle extra.
+- Scoreboard and sidebar helpers are not part of Adventure. **Decision:** deferred to a possible dedicated
+  `paper-ui` module after the message toolchain ships. It would wrap the Bukkit scoreboard API — a documented
+  exception to the wrap-`net.kyori.*` rule, isolated so `core` and `paper` stay pure Adventure. Sidebars only;
+  inventory menus, commands, and generic server utilities stay out of scope.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -88,11 +88,11 @@ hidden process-wide registry or scan the class path.
 
 This design keeps usual operations direct and permits the replacement of variable parts.
 
-**Animation** arrives in Phase 3 as flows, not as an engine. Effects are functions from components to
-`Flow<Component>` frame sources. A suspending sink presents a frame flow to an audience target. `Ticker`
-implementations and their coroutine mappings pace the frames, and structured concurrency controls cancellation.
-There is no separate driver interface or driver registry: the platform `Ticker` registrations already fill that
-role. The composition flow is **effect → frame flow → paced collection → audience target**.
+**Animation** is part of Phase 3. Animation uses flows, not an engine. An effect is a function from components to
+a `Flow<Component>` frame source. A suspending sink sends a frame flow to an audience target. `Ticker`
+implementations and their coroutine mappings control the frame schedule. Structured concurrency controls
+cancellation. A separate driver interface or driver registry is not necessary. The platform `Ticker` registrations
+supply the schedule. The composition flow is **effect → frame flow → paced collection → audience target**.
 
 ## 5. Canonical DSL surface (illustrative)
 
@@ -308,13 +308,13 @@ arguments. Invalid patterns cause an exception that gives the applicable offset.
 
 - **`ansi`** renders a `Component` as ANSI for tests and logs. It supports colours, decorations, and approximate
   gradients. Developers can examine output without a server.
-- **`catalog-compiler`** parses `messages.yml` or property files, validates markup and placeholders, and generates a
-  typed message catalogue with required, validated placeholders. It is a pure library with no Gradle dependency, so
-  build, IDE, and CLI frontends share one implementation.
-- **`gradle-plugin`** stops a build when resource bundles contain malformed MiniMessage or absent placeholders, using
-  the `catalog-compiler` diagnostics. It can also precompile bundles.
-- A **detekt rule set** flags illegal style/component constructs that the type system cannot express. KSP is not used
-  for this: it resolves declarations, not the expression bodies inside DSL blocks.
+- **`catalog-compiler`** parses `messages.yml` or property files. It validates markup and placeholders. It generates
+  a typed message catalogue with required, validated placeholders. It is a pure library with no Gradle dependency.
+  Thus, the build, IDE, and CLI frontends share one implementation.
+- **`gradle-plugin`** stops a build when resource bundles contain malformed MiniMessage or absent placeholders. It
+  uses the `catalog-compiler` diagnostics. It can also precompile bundles.
+- A **detekt rule set** identifies illegal style and component constructs that the type system cannot express. KSP is
+  not applicable for these checks. KSP resolves declarations, not the expression bodies in DSL blocks.
 
 ## 9. Platforms
 
@@ -322,8 +322,8 @@ arguments. Invalid patterns cause an exception that gives the applicable offset.
 and convenience functions:
 
 - **`paper`** supplies Paper and Folia tickers, audience functions, dialogs, and item lore and name builders.
-- **`velocity`** supplies a proxy scheduler ticker and lifecycle wiring. Velocity is natively Adventure, so no
-  audience adapter is needed.
+- **`velocity`** supplies a proxy scheduler ticker and lifecycle wiring. Velocity supports Adventure natively.
+  Thus, an audience adapter is not necessary.
 - **`fabric`** uses `adventure-platform-fabric`.
 
 ## 10. Build, publishing & versioning
@@ -339,9 +339,9 @@ and convenience functions:
 - **Publication:** During the pre-alpha and alpha stages, JitPack builds from Git tags. At beta or version `1.0`, Maven
   Central uses the `io.github.lmliam` namespace and GPG signatures.
 - The **BOM** module aligns versions across all artefacts.
-- **Versions:** every pre-1.0 release is a `0.x` minor. Alpha lasts until the API freeze; the `0.x` line after the
-  freeze is beta. Version `1.0.0` starts the semantic-versioning commitment. CI builds, tests, and lints pull
-  requests. Tags start publication.
+- **Versions:** each release before 1.0 is a `0.x` minor version. The Alpha stage continues until the API freeze.
+  The `0.x` releases after the freeze are the Beta stage. Version `1.0.0` starts the semantic-versioning
+  commitment. CI builds, tests, and lints pull requests. Tags start publication.
 
 > **Note:** To add or update a GitHub Actions workflow, use a token with the `workflow` scope. Use
 > `gh auth refresh -s workflow` to add the scope. A separate issue tracks CI on `master`.
@@ -404,7 +404,8 @@ release each slice independently.
 - Optional **Sponge** / **BungeeCord** bundles post‑1.0.
 - IDE inspections / detekt rules for the DSL (long‑term tooling).
 - A hosted **playground** / cookbook docs site.
-- Scoreboard and sidebar helpers are not part of Adventure. **Decision:** deferred to a possible dedicated
-  `paper-ui` module after the message toolchain ships. It would wrap the Bukkit scoreboard API — a documented
-  exception to the wrap-`net.kyori.*` rule, isolated so `core` and `paper` stay pure Adventure. Sidebars only;
-  inventory menus, commands, and generic server utilities stay out of scope.
+- Scoreboard and sidebar helpers are not part of Adventure. **Decision:** this feature is deferred to a possible
+  `paper-ui` module after the message toolchain is complete. The module would wrap the Bukkit scoreboard API. This
+  is a documented exception to the wrap-`net.kyori.*` rule. The exception stays in its own module, and `core` and
+  `paper` remain pure Adventure. The scope includes only sidebars. Inventory menus, commands, and general server
+  utilities remain out of scope.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,10 +3,12 @@
 > **Lifecycle Stages:** Pre‑Alpha → Alpha → Beta → Release
 >
 > This roadmap gives the purpose of each stage. The published version and changelog identify the current version.
+> Stage transitions follow the milestone criteria below, not fixed version numbers: every pre-1.0 release is a
+> `0.x` minor, and the Beta stage begins when the API freeze lands.
 
 ---
 
-## Alpha (`0.1.x`–`0.8.x`)
+## Alpha (current)
 
 **Focus:**
 
@@ -19,7 +21,7 @@
 
 ---
 
-## Beta (`0.9.x`)
+## Beta (after the API freeze)
 
 **Focus:**
 
@@ -57,9 +59,9 @@
 
 ## 📆 Timeline
 
-| Stage     | Target Range | Key Deliverable                      |
-|-----------|--------------|--------------------------------------|
-| Pre‑Alpha | 0.0.x        | Core DSL spike + snapshot publish    |
-| Alpha     | 0.1.x–0.8.x  | Public API expansion + feedback loop |
-| Beta      | 0.9.x        | API freeze, stability, doc polish    |
-| Release   | 1.0.0        | Production‑ready stable release      |
+| Stage     | Versions                    | Key Deliverable                      |
+|-----------|-----------------------------|--------------------------------------|
+| Pre‑Alpha | `0.0.x`                     | Core DSL spike + snapshot publish    |
+| Alpha     | `0.x` until the API freeze  | Public API expansion + feedback loop |
+| Beta      | `0.x` after the API freeze  | API freeze, stability, doc polish    |
+| Release   | `1.0.0`                     | Production‑ready stable release      |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,8 +3,8 @@
 > **Lifecycle Stages:** Pre‑Alpha → Alpha → Beta → Release
 >
 > This roadmap gives the purpose of each stage. The published version and changelog identify the current version.
-> Stage transitions follow the milestone criteria below, not fixed version numbers: every pre-1.0 release is a
-> `0.x` minor, and the Beta stage begins when the API freeze lands.
+> Stage transitions obey the milestone criteria below, not fixed version numbers. Each release before 1.0 is a
+> `0.x` minor version. The Beta stage starts when the API freeze is complete.
 
 ---
 


### PR DESCRIPTION
## Summary

Refreshes `docs/ROADMAP.md` and `docs/DESIGN.md` after the 2026-07-22 tracker grooming pass:

- **ROADMAP:** removes the stale hard-coded version bands (Alpha `0.1.x–0.8.x` vs the actual `0.22.0`). Stage transitions now follow milestone criteria: every pre-1.0 release is a `0.x` minor, and Beta begins when the API freeze lands.
- **DESIGN — animation:** flow-based over `Ticker` (#45/#46 rewritten, #47 closed). Effects produce `Flow<Component>`; a suspending sink presents frames; no driver interface or registry.
- **DESIGN — catalogue tooling:** the typed message catalogue moves from KSP to a pure `catalog-compiler` library with build/IDE/CLI frontends (#49/#51 rewritten); static style checks move to a detekt rule set (#54 rewritten), since KSP cannot see DSL expression bodies.
- **DESIGN — sidebars:** deferred to a possible `paper-ui` module (#323), recorded as a documented exception to the wrap-`net.kyori.*` rule.
- **DESIGN — Velocity:** natively Adventure; no audience adapter (#52 rewritten).

## Related Issues

Relates to #5, #45, #46, #47, #49, #51, #52, #54, #323.

## Scope

- [ ] README
- [x] `/docs/design/*`
- [ ] DSL usage examples
- [ ] Onboarding and setup guides

## Checklist

- [x] Verify that examples compile (no code examples changed)
- [x] Link the related issue, if applicable
- [x] Confirm that the content matches current API behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg2NBvBed5MtQidkuGKKWH
