### PR TITLE
feat(core): style the virtual component wrapper

### DIFF
--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/Virtual.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/Virtual.kt
@@ -1,41 +1,40 @@
 package io.github.lmliam.kotventure.core.virtual
 
 import io.github.lmliam.kotventure.core.component.ComponentScope
-import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.VirtualComponent
 
 /**
  * Creates a [VirtualComponent] that resolves from a render context of type [C].
  *
- * The platform calls [render] at display time with the current context, for example the viewing player. The block can
- * run more than once. The function only creates the component. The `core` module never calls the renderer.
- *
- * A serialiser shows [fallback] when no platform renders the component, for example on a console or in stored data.
+ * The [build] block configures two appearances. A [VirtualScope.render] block builds the content that a platform shows
+ * at display time. A [VirtualScope.fallback] sets the stand-in that a serialiser or a console shows when no platform
+ * renders the component. The function only creates the component. The `core` module never calls the render block.
  *
  * @sample io.github.lmliam.kotventure.core.virtual.virtualSample
  *
  * @param C the render context type.
- * @param fallback the text to show when no platform renders the component.
- * @param render builds the component content from the [VirtualRenderScope.context].
+ * @param build configures the [VirtualScope.fallback] and [VirtualScope.render] slots.
+ * @throws IllegalStateException when [build] sets no render block, or sets a write-once slot more than once.
  */
-public inline fun <reified C : Any> virtual(
-    fallback: String = "",
-    noinline render: VirtualRenderScope<C>.() -> Unit,
-): VirtualComponent = Component.virtual(C::class.java, VirtualScopeRenderer(render, fallback))
+public inline fun <reified C : Any> virtual(noinline build: VirtualScope<C>.() -> Unit): VirtualComponent =
+    buildVirtual(C::class.java, build)
 
 /**
  * Creates a virtual component and appends it as the next child of this scope.
  *
- * The platform calls [render] at display time with the current context of type [C]. A serialiser shows [fallback] when
- * no platform renders the component.
+ * The [build] block configures the same [VirtualScope.render] and [VirtualScope.fallback] slots as the top-level
+ * [virtual] function.
  *
  * @param C the render context type.
- * @param fallback the text to show when no platform renders the component.
- * @param render builds the child content from the [VirtualRenderScope.context].
+ * @param build configures the [VirtualScope.fallback] and [VirtualScope.render] slots.
+ * @throws IllegalStateException when [build] sets no render block, or sets a write-once slot more than once.
  */
-public inline fun <reified C : Any> ComponentScope.virtual(
-    fallback: String = "",
-    noinline render: VirtualRenderScope<C>.() -> Unit,
-) {
-    append(Component.virtual(C::class.java, VirtualScopeRenderer(render, fallback)))
+public inline fun <reified C : Any> ComponentScope.virtual(noinline build: VirtualScope<C>.() -> Unit) {
+    append(buildVirtual(C::class.java, build))
 }
+
+@PublishedApi
+internal fun <C : Any> buildVirtual(
+    contextType: Class<C>,
+    build: VirtualScope<C>.() -> Unit,
+): VirtualComponent = VirtualBuilder(contextType).apply(build).build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualBuilder.kt
@@ -1,34 +1,34 @@
 package io.github.lmliam.kotventure.core.virtual
 
-import io.github.lmliam.kotventure.core.component.ComponentBuilder
 import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
 import io.github.lmliam.kotventure.core.dsl.once
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.VirtualComponent
 import net.kyori.adventure.text.format.Style
 
 /**
- * Collects the [VirtualScope] slots and builds the Adventure [VirtualComponent].
+ * Builds a [VirtualComponent] from the slots in [VirtualScope].
  *
- * The builder holds a write-once fallback and a write-once render block. The [build] step requires the render block,
- * so a block without a render call fails fast.
+ * A render block is required.
+ * The fallback has no content, style, or children when it is not set.
  *
  * @param C the render context type.
- * @property contextType the reified render context class that the component reports.
+ * @property contextType the render context class that the component reports.
  */
 internal class VirtualBuilder<C : Any>(
     private val contextType: Class<C>,
 ) : VirtualScope<C> {
-    private var fallback: ResolvedFallback? by once()
+    private var fallback: Fallback? by once()
     private var render: (VirtualRenderScope<C>.() -> Unit)? by once()
 
     override fun fallback(text: String) {
-        fallback = ResolvedFallback(text, Style.empty(), emptyList())
+        fallback = Fallback(text)
     }
 
     override fun fallback(build: ComponentScope.() -> Unit) {
-        val stand = ComponentBuilder(Component.text()).apply(build).build()
-        fallback = ResolvedFallback("", stand.style(), stand.children())
+        val component = component(build)
+        fallback = Fallback(style = component.style(), children = component.children())
     }
 
     override fun render(build: VirtualRenderScope<C>.() -> Unit) {
@@ -36,18 +36,18 @@ internal class VirtualBuilder<C : Any>(
     }
 
     fun build(): VirtualComponent {
-        val body = checkNotNull(render) { "a render block is required" }
-        val stand = fallback ?: ResolvedFallback("", Style.empty(), emptyList())
-        val renderer = VirtualScopeRenderer(body, stand.string)
-        return Component.virtual(contextType, renderer, stand.style).children(stand.children) as VirtualComponent
+        val render = checkNotNull(render) { "'render' is required" }
+        val resolvedFallback = fallback ?: Fallback()
+        val renderer = VirtualScopeRenderer(render, resolvedFallback.content)
+
+        return Component
+            .virtual(contextType, renderer, resolvedFallback.style)
+            .children(resolvedFallback.children) as VirtualComponent
     }
 
-    /**
-     * The resolved fallback: the plain-text stand-in and the style and children of the virtual node.
-     */
-    private data class ResolvedFallback(
-        val string: String,
-        val style: Style,
-        val children: List<Component>,
+    private data class Fallback(
+        val content: String = "",
+        val style: Style = Style.empty(),
+        val children: List<Component> = emptyList(),
     )
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualBuilder.kt
@@ -1,0 +1,53 @@
+package io.github.lmliam.kotventure.core.virtual
+
+import io.github.lmliam.kotventure.core.component.ComponentBuilder
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.once
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.VirtualComponent
+import net.kyori.adventure.text.format.Style
+
+/**
+ * Collects the [VirtualScope] slots and builds the Adventure [VirtualComponent].
+ *
+ * The builder holds a write-once fallback and a write-once render block. The [build] step requires the render block,
+ * so a block without a render call fails fast.
+ *
+ * @param C the render context type.
+ * @property contextType the reified render context class that the component reports.
+ */
+internal class VirtualBuilder<C : Any>(
+    private val contextType: Class<C>,
+) : VirtualScope<C> {
+    private var fallback: ResolvedFallback? by once()
+    private var render: (VirtualRenderScope<C>.() -> Unit)? by once()
+
+    override fun fallback(text: String) {
+        fallback = ResolvedFallback(text, Style.empty(), emptyList())
+    }
+
+    override fun fallback(build: ComponentScope.() -> Unit) {
+        val stand = ComponentBuilder(Component.text()).apply(build).build()
+        fallback = ResolvedFallback("", stand.style(), stand.children())
+    }
+
+    override fun render(build: VirtualRenderScope<C>.() -> Unit) {
+        render = build
+    }
+
+    fun build(): VirtualComponent {
+        val body = checkNotNull(render) { "a render block is required" }
+        val stand = fallback ?: ResolvedFallback("", Style.empty(), emptyList())
+        val renderer = VirtualScopeRenderer(body, stand.string)
+        return Component.virtual(contextType, renderer, stand.style).children(stand.children) as VirtualComponent
+    }
+
+    /**
+     * The resolved fallback: the plain-text stand-in and the style and children of the virtual node.
+     */
+    private data class ResolvedFallback(
+        val string: String,
+        val style: Style,
+        val children: List<Component>,
+    )
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualScope.kt
@@ -1,0 +1,53 @@
+package io.github.lmliam.kotventure.core.virtual
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.VirtualComponent
+
+/**
+ * Configures the two appearances of a [VirtualComponent].
+ *
+ * A virtual component has two forms. The [render] block builds the content that a platform shows at display time. The
+ * [fallback] is the stand-in that a serialiser or a console shows when no platform renders the component. Set a style
+ * or add children on the [fallback] block, not on this scope. This scope only holds the [fallback] and [render] slots.
+ *
+ * @sample io.github.lmliam.kotventure.core.virtual.virtualSample
+ *
+ * @param C the render context type, for example the viewing player.
+ */
+@KotventureDslMarker
+public interface VirtualScope<C : Any> {
+    /**
+     * Sets the plain-text stand-in shown when no platform renders the component.
+     *
+     * This form and the [fallback] block form share one write-once slot.
+     *
+     * @param text the stand-in text.
+     * @throws IllegalStateException when a fallback is already set in this block.
+     */
+    public fun fallback(text: String)
+
+    /**
+     * Builds a styled stand-in shown when no platform renders the component.
+     *
+     * The [build] block sets the style and children of the stand-in. This form and the [fallback] text form share one
+     * write-once slot.
+     *
+     * @sample io.github.lmliam.kotventure.core.virtual.virtualStyledFallbackSample
+     *
+     * @param build styles the stand-in and appends any children.
+     * @throws IllegalStateException when a fallback is already set in this block.
+     */
+    public fun fallback(build: ComponentScope.() -> Unit)
+
+    /**
+     * Sets the block that builds the rendered content from the render context.
+     *
+     * The platform calls [build] at display time with the current context, for example the viewing player. The block
+     * can run more than once. The `core` module never calls it.
+     *
+     * @param build builds the rendered content from the [VirtualRenderScope.context].
+     * @throws IllegalStateException when a render block is already set in this block.
+     */
+    public fun render(build: VirtualRenderScope<C>.() -> Unit)
+}

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualSamples.kt
@@ -1,11 +1,28 @@
 package io.github.lmliam.kotventure.core.virtual
 
+import io.github.lmliam.kotventure.core.color.gold
 import io.github.lmliam.kotventure.core.text.text
 import java.util.Locale
 
 internal fun virtualSample() {
     val greeting =
-        virtual<Locale>(fallback = "Hello") {
-            text(if (context.language == "fr") "Bonjour" else "Hello")
+        virtual<Locale> {
+            fallback("Hello")
+            render {
+                text(if (context.language == "fr") "Bonjour" else "Hello")
+            }
+        }
+}
+
+internal fun virtualStyledFallbackSample() {
+    val greeting =
+        virtual<Locale> {
+            fallback {
+                color(gold)
+                text("Hello")
+            }
+            render {
+                text(if (context.language == "fr") "Bonjour" else "Hello") { color(gold) }
+            }
         }
 }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualDslTest.kt
@@ -1,39 +1,115 @@
 package io.github.lmliam.kotventure.core.virtual
 
+import io.github.lmliam.kotventure.core.color.gold
 import io.github.lmliam.kotventure.core.component.component
 import io.github.lmliam.kotventure.core.text.text
 import io.github.lmliam.kotventure.test.text.childAt
 import io.github.lmliam.kotventure.test.text.shouldBeVirtualComponent
 import io.github.lmliam.kotventure.test.text.shouldHaveChildCount
+import io.github.lmliam.kotventure.test.text.shouldHaveChildren
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldHaveContextType
 import io.github.lmliam.kotventure.test.text.shouldHaveFallbackString
+import io.github.lmliam.kotventure.test.text.shouldHaveNoChildren
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.VirtualComponent
 import net.kyori.adventure.text.VirtualComponentRenderer
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.Style
 
 @Suppress("UNCHECKED_CAST")
 class VirtualDslTest :
     StringSpec(
         {
             "equals the raw net.kyori construction" {
-                val render: VirtualRenderScope<Viewer>.() -> Unit = { text(context.name) }
+                val body: VirtualRenderScope<Viewer>.() -> Unit = { text(context.name) }
 
-                val dsl = virtual<Viewer>(fallback = "player", render = render)
-                val raw = Component.virtual(Viewer::class.java, VirtualScopeRenderer(render, "player"))
+                val dsl =
+                    virtual<Viewer> {
+                        fallback("player")
+                        render(body)
+                    }
+                val raw = Component.virtual(Viewer::class.java, VirtualScopeRenderer(body, "player"))
 
                 dsl shouldBe raw
             }
 
+            "sets a static style and children on the fallback that equal the raw construction" {
+                val body: VirtualRenderScope<Viewer>.() -> Unit = { text(context.name) }
+
+                val dsl =
+                    virtual<Viewer> {
+                        fallback {
+                            color(gold)
+                            text("player")
+                        }
+                        render(body)
+                    }
+                val raw =
+                    Component
+                        .virtual(Viewer::class.java, VirtualScopeRenderer(body, ""), Style.style(NamedTextColor.GOLD))
+                        .children(listOf(Component.text("player"))) as VirtualComponent
+
+                dsl shouldBe raw
+                dsl.shouldHaveColor(NamedTextColor.GOLD)
+                dsl.shouldHaveChildren(Component.text("player"))
+            }
+
+            "defaults the fallback to empty content and no children" {
+                val component = virtual<Viewer> { render { text(context.name) } }
+
+                component shouldHaveFallbackString ""
+                component.content() shouldBe ""
+                component.shouldHaveNoChildren()
+            }
+
+            "throws when no render block is set" {
+                shouldThrow<IllegalStateException> {
+                    virtual<Viewer> { fallback("player") }
+                }
+            }
+
+            "throws when the render block is set twice" {
+                shouldThrow<IllegalStateException> {
+                    virtual<Viewer> {
+                        render { text(context.name) }
+                        render { text(context.name) }
+                    }
+                }
+            }
+
+            "throws when the fallback text is set twice" {
+                shouldThrow<IllegalStateException> {
+                    virtual<Viewer> {
+                        fallback("first")
+                        fallback("second")
+                        render { text(context.name) }
+                    }
+                }
+            }
+
+            "throws when the fallback text and block forms are mixed" {
+                shouldThrow<IllegalStateException> {
+                    virtual<Viewer> {
+                        fallback("first")
+                        fallback { text("second") }
+                        render { text(context.name) }
+                    }
+                }
+            }
+
             "exposes the reified context type" {
-                val component = virtual<Viewer> { text(context.name) }
+                val component = virtual<Viewer> { render { text(context.name) } }
 
                 component.contextType() shouldBe Viewer::class.java
                 component.shouldHaveContextType<Viewer>()
             }
 
             "renders content from the supplied context" {
-                val component = virtual<Viewer> { text(context.name) }
+                val component = virtual<Viewer> { render { text(context.name) } }
                 val renderer = component.renderer() as VirtualComponentRenderer<Viewer>
 
                 val alex = renderer.apply(Viewer("Alex")).asComponent()
@@ -44,24 +120,24 @@ class VirtualDslTest :
             }
 
             "uses the fallback string as serialised content" {
-                val component = virtual<Viewer>(fallback = "player") { text(context.name) }
+                val component =
+                    virtual<Viewer> {
+                        fallback("player")
+                        render { text(context.name) }
+                    }
 
                 component shouldHaveFallbackString "player"
                 component.content() shouldBe "player"
-            }
-
-            "defaults the fallback to an empty string" {
-                val component = virtual<Viewer> { text(context.name) }
-
-                component shouldHaveFallbackString ""
-                component.content() shouldBe ""
             }
 
             "appends a virtual component inside component { }" {
                 val message =
                     component {
                         text("Welcome, ")
-                        virtual<Viewer>(fallback = "player") { text(context.name) }
+                        virtual<Viewer> {
+                            fallback("player")
+                            render { text(context.name) }
+                        }
                     }
 
                 message shouldHaveChildCount 2
@@ -75,8 +151,10 @@ class VirtualDslTest :
 
                 val component =
                     virtual<Viewer> {
-                        renders++
-                        text(context.name)
+                        render {
+                            renders++
+                            text(context.name)
+                        }
                     }
                 renders shouldBe 0
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualDslTest.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.kotventure.core.virtual
 
 import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.color.gray
 import io.github.lmliam.kotventure.core.component.component
 import io.github.lmliam.kotventure.core.text.text
 import io.github.lmliam.kotventure.test.text.childAt
@@ -45,17 +46,26 @@ class VirtualDslTest :
                         fallback {
                             color(gold)
                             text("player")
+                            text(" (online)") { color(gray) }
                         }
                         render(body)
                     }
                 val raw =
                     Component
                         .virtual(Viewer::class.java, VirtualScopeRenderer(body, ""), Style.style(NamedTextColor.GOLD))
-                        .children(listOf(Component.text("player"))) as VirtualComponent
+                        .children(
+                            listOf(
+                                Component.text("player"),
+                                Component.text(" (online)").color(NamedTextColor.GRAY),
+                            ),
+                        ) as VirtualComponent
 
                 dsl shouldBe raw
                 dsl.shouldHaveColor(NamedTextColor.GOLD)
-                dsl.shouldHaveChildren(Component.text("player"))
+                dsl.shouldHaveChildren(
+                    Component.text("player"),
+                    Component.text(" (online)").color(NamedTextColor.GRAY),
+                )
             }
 
             "defaults the fallback to empty content and no children" {


### PR DESCRIPTION
## Summary

The virtual DSL now sets a static style and static children on the virtual component itself, not
only on the render output. The entry point becomes a `VirtualScope` block with two named
appearances: `render { }` (dynamic, has `context`) and `fallback` (the stand-in when no platform
renders the component).

## Related Issues

Closes #330

## DSL Impact

- New `VirtualScope<C>` with three slots: `fallback(text)`, `fallback { }` (styled stand-in), and
  the required `render { }`. Both `fallback` forms share one write-once slot; `render` is write-once
  and required.
- `virtual<C> { }` and `ComponentScope.virtual<C> { }` now take the `VirtualScope` block. This
  **replaces** the #318 `virtual<C>(fallback) { render }` signature (pre-1.0, no back-compat).

```kotlin
virtual<Player> {
    fallback { color(gold); text("player") }   // styled stand-in (style + children)
    render { text(context.name) }              // dynamic body
}
```

## Rationale

Adventure's `VirtualComponent extends TextComponent`, so it carries its own `Style` and children.
Those have a **verified** effect only in the unrendered / serialized form (`ComponentFlattenerImpl`
flattens the node as `text(fallback)` + style + children; the renderer is skipped). Whether they
survive Paper's live render is undocumented NMS behaviour (the empirical test is parked in #57), so
the DSL models the two appearances explicitly instead of a single ambiguous node surface. This
delivers #330's static style + children as a styled `fallback`, and keeps the top-level scope to two
honest slots. A suffix that must show live goes in `render`.

## Testing

`VirtualDslTest` rewritten to the new API and extended:

- `dsl == raw net.kyori` for render-only and for a styled fallback (style + children).
- Default fallback is empty content with no children.
- Missing `render`, duplicate `render`, duplicate `fallback`, and mixed `fallback` forms each throw
  `IllegalStateException` (behaviour asserted, not message text).
- Context type, lazy rendering, and the `component { }` append overload.
- Dogfoods the `test` matchers (`shouldBeVirtualComponent`, `shouldHaveColor`, `shouldHaveChildren`,
  `shouldHaveFallbackString`, …).

## Checklist

- [x] Link the related issue
- [x] Update the README and applicable `/docs` pages (no prose section exists for the virtual DSL;
      KDoc + `@sample` updated, README shape line still accurate)
- [x] Verify that examples build and run (`./gradlew build` green; samples compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184Z5UREkJesX51QxGQC27A
