### PR TITLE
feat(core): render virtual components against contexts

### DIFF
--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -60,7 +60,7 @@ Each package under `io.github.lmliam.kotventure.core` contains one feature:
 | `selector`                                        | `allPlayers { }`, `entities { }`, …, strict `parseSelector(...)` bridge                        |
 | `nbt`, `objectcomponent`                          | `nbt { }`, `nbtPath(...)`, block/entity/storage NBT components, `display(...)`                 |
 | `translatable`, `keybind`, `score`, `key`, `uuid` | the remaining component types and value helpers                                                |
-| `virtual`                                         | `virtual<C> { }` builds a component that a platform resolves from a render context at display time. |
+| `virtual`                                         | `virtual<C> { }` builds a component that a platform resolves from a render context; `Component.render(context, ...)` resolves matching nodes. |
 | `theme`                                           | `Theme` base class with `by style { }` properties, explicit `ThemeRegistry`                    |
 | `time`                                            | `ticks` and `Ticker` (`every`, `after`, `isCurrent`). Platforms adapt it.               |
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/Virtual.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/Virtual.kt
@@ -1,14 +1,16 @@
 package io.github.lmliam.kotventure.core.virtual
 
 import io.github.lmliam.kotventure.core.component.ComponentScope
+import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.VirtualComponent
+import kotlin.jvm.javaObjectType
 
 /**
  * Creates a [VirtualComponent] that resolves from a render context of type [C].
  *
  * The [build] block configures two appearances. A [VirtualScope.render] block builds the content that a platform shows
  * at display time. A [VirtualScope.fallback] sets the stand-in that a serialiser or a console shows when no platform
- * renders the component. The function only creates the component. The `core` module never calls the render block.
+ * renders the component. The function only creates the component. Use [Component.render] to render it in `core`.
  *
  * @sample io.github.lmliam.kotventure.core.virtual.virtualSample
  *
@@ -17,7 +19,7 @@ import net.kyori.adventure.text.VirtualComponent
  * @throws IllegalStateException when [build] sets no render block, or sets a write-once slot more than once.
  */
 public inline fun <reified C : Any> virtual(noinline build: VirtualScope<C>.() -> Unit): VirtualComponent =
-    buildVirtual(C::class.java, build)
+    buildVirtual(C::class.javaObjectType, build)
 
 /**
  * Creates a virtual component and appends it as the next child of this scope.
@@ -30,8 +32,27 @@ public inline fun <reified C : Any> virtual(noinline build: VirtualScope<C>.() -
  * @throws IllegalStateException when [build] sets no render block, or sets a write-once slot more than once.
  */
 public inline fun <reified C : Any> ComponentScope.virtual(noinline build: VirtualScope<C>.() -> Unit) {
-    append(buildVirtual(C::class.java, build))
+    append(buildVirtual(C::class.javaObjectType, build))
 }
+
+/**
+ * Renders virtual components with [context] and [additionalContexts].
+ *
+ * Contexts are checked in call order, and the first context accepted by each virtual renderer supplies its result.
+ * The operation recursively renders every component-bearing slot, including components introduced by a renderer. A
+ * virtual component with no matching context stays unchanged and can be rendered by a later call.
+ * A matching result replaces the complete virtual component, including its fallback style and children.
+ * Exceptions thrown by a virtual renderer propagate unchanged.
+ *
+ * @param context the first render context.
+ * @param additionalContexts the other render contexts, in selection order.
+ * @throws IllegalStateException when a virtual renderer returns `null`.
+ * @sample io.github.lmliam.kotventure.core.virtual.virtualRenderingSample
+ */
+public fun Component.render(
+    context: Any,
+    vararg additionalContexts: Any,
+): Component = VirtualTreeRenderer.render(this, VirtualRenderState(context, additionalContexts))
 
 @PublishedApi
 internal fun <C : Any> buildVirtual(

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/Virtual.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/Virtual.kt
@@ -52,7 +52,7 @@ public inline fun <reified C : Any> ComponentScope.virtual(noinline build: Virtu
 public fun Component.render(
     context: Any,
     vararg additionalContexts: Any,
-): Component = VirtualTreeRenderer.render(this, VirtualRenderState(context, additionalContexts))
+): Component = VirtualTreeRenderer.render(this, VirtualRenderState(context, *additionalContexts))
 
 @PublishedApi
 internal fun <C : Any> buildVirtual(

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderState.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderState.kt
@@ -4,11 +4,10 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.VirtualComponent
 
 internal class VirtualRenderState(
-    context: Any,
-    additionalContexts: Array<out Any>,
+    vararg contexts: Any,
 ) {
-    private val contexts: List<Any> = listOf(context, *additionalContexts)
-    private val activeComponents: MutableList<VirtualComponent> = mutableListOf()
+    private val contexts = contexts.asList()
+    private val activeComponents = ArrayDeque<VirtualComponent>()
 
     fun firstMatching(contextType: Class<*>): Any? = contexts.firstOrNull(contextType::isInstance)
 
@@ -17,11 +16,13 @@ internal class VirtualRenderState(
         render: () -> Component,
     ): Component {
         if (activeComponents.any { it === component }) return component
-        activeComponents += component
+        activeComponents.addLast(component)
 
         return try {
             render()
         } finally {
+            // Rendering nests strictly: a virtual component's render block always completes
+            // before an ancestor's does, so the popped entry must be this call's own component.
             check(activeComponents.removeLast() === component) {
                 "Virtual component rendering completed out of order."
             }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderState.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderState.kt
@@ -1,0 +1,30 @@
+package io.github.lmliam.kotventure.core.virtual
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.VirtualComponent
+
+internal class VirtualRenderState(
+    context: Any,
+    additionalContexts: Array<out Any>,
+) {
+    private val contexts: List<Any> = listOf(context, *additionalContexts)
+    private val activeComponents: MutableList<VirtualComponent> = mutableListOf()
+
+    fun firstMatching(contextType: Class<*>): Any? = contexts.firstOrNull(contextType::isInstance)
+
+    fun renderOnce(
+        component: VirtualComponent,
+        render: () -> Component,
+    ): Component {
+        if (activeComponents.any { it === component }) return component
+        activeComponents += component
+
+        return try {
+            render()
+        } finally {
+            check(activeComponents.removeLast() === component) {
+                "Virtual component rendering completed out of order."
+            }
+        }
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualTreeRenderer.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualTreeRenderer.kt
@@ -1,0 +1,138 @@
+package io.github.lmliam.kotventure.core.virtual
+
+import net.kyori.adventure.text.BlockNBTComponent
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.text.EntityNBTComponent
+import net.kyori.adventure.text.KeybindComponent
+import net.kyori.adventure.text.NBTComponent
+import net.kyori.adventure.text.ObjectComponent
+import net.kyori.adventure.text.ScoreComponent
+import net.kyori.adventure.text.SelectorComponent
+import net.kyori.adventure.text.StorageNBTComponent
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.TranslatableComponent
+import net.kyori.adventure.text.TranslationArgument
+import net.kyori.adventure.text.VirtualComponent
+import net.kyori.adventure.text.VirtualComponentRenderer
+import net.kyori.adventure.text.renderer.AbstractComponentRenderer
+
+internal object VirtualTreeRenderer : AbstractComponentRenderer<VirtualRenderState>() {
+    override fun render(
+        component: Component,
+        context: VirtualRenderState,
+    ): Component {
+        if (component !is VirtualComponent) return super.render(component, context)
+        return context.renderOnce(component) { super.render(component, context) }
+    }
+
+    override fun renderText(
+        component: TextComponent,
+        context: VirtualRenderState,
+    ): Component = renderNested(component, context)
+
+    override fun renderTranslatable(
+        component: TranslatableComponent,
+        context: VirtualRenderState,
+    ): Component {
+        val renderedArguments = component.arguments().map { renderArgument(it, context) }
+
+        return renderNested(component.arguments(renderedArguments), context)
+    }
+
+    override fun renderKeybind(
+        component: KeybindComponent,
+        context: VirtualRenderState,
+    ): Component = renderNested(component, context)
+
+    override fun renderScore(
+        component: ScoreComponent,
+        context: VirtualRenderState,
+    ): Component = renderNested(component, context)
+
+    override fun renderSelector(
+        component: SelectorComponent,
+        context: VirtualRenderState,
+    ): Component {
+        val separator = component.separator()
+        val rendered = if (separator == null) component else component.separator(render(separator, context))
+
+        return renderNested(rendered, context)
+    }
+
+    override fun renderBlockNbt(
+        component: BlockNBTComponent,
+        context: VirtualRenderState,
+    ): Component = renderNbt(component, context)
+
+    override fun renderEntityNbt(
+        component: EntityNBTComponent,
+        context: VirtualRenderState,
+    ): Component = renderNbt(component, context)
+
+    override fun renderStorageNbt(
+        component: StorageNBTComponent,
+        context: VirtualRenderState,
+    ): Component = renderNbt(component, context)
+
+    override fun renderObject(
+        component: ObjectComponent,
+        context: VirtualRenderState,
+    ): Component {
+        val fallback = component.fallback()
+        val rendered = if (fallback == null) component else component.fallback(render(fallback, context))
+
+        return renderNested(rendered, context)
+    }
+
+    override fun renderVirtual(
+        component: VirtualComponent,
+        context: VirtualRenderState,
+    ): Component {
+        val matchingContext = context.firstMatching(component.contextType()) ?: return component
+        val rendered = component.renderWith(matchingContext)
+
+        return if (rendered is VirtualComponent) render(rendered, context) else rendered
+    }
+
+    private fun renderArgument(
+        argument: TranslationArgument,
+        context: VirtualRenderState,
+    ): TranslationArgument {
+        val component = argument.value() as? Component ?: return argument
+        return TranslationArgument.component(render(component, context))
+    }
+
+    private fun <C : NBTComponent<C>> renderNbt(
+        component: C,
+        context: VirtualRenderState,
+    ): Component {
+        val separator = component.separator()
+        val rendered = if (separator == null) component else component.separator(render(separator, context))
+
+        return renderNested(rendered, context)
+    }
+
+    private fun renderNested(
+        component: Component,
+        context: VirtualRenderState,
+    ): Component {
+        val hoverEvent = component.hoverEvent()
+        val withRenderedHover =
+            if (hoverEvent == null) component else component.hoverEvent(hoverEvent.withRenderedValue(this, context))
+        val children = withRenderedHover.children()
+
+        return if (children.isEmpty()) {
+            withRenderedHover
+        } else {
+            withRenderedHover.children(children.map { render(it, context) })
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun VirtualComponent.renderWith(context: Any): Component {
+        val renderer = renderer() as VirtualComponentRenderer<Any>
+        val result: ComponentLike? = renderer.apply(context)
+        return checkNotNull(result) { "The virtual component renderer returned null." }.asComponent()
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualTreeRenderer.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualTreeRenderer.kt
@@ -121,7 +121,7 @@ internal object VirtualTreeRenderer : AbstractComponentRenderer<VirtualRenderSta
         nested: Component?,
         context: VirtualRenderState,
         replace: C.(ComponentLike) -> C,
-    ): C = nested?.let { replace(render(it, context)) } ?: this
+    ): C = nested?.let { replace(this@VirtualTreeRenderer.render(it, context)) } ?: this
 
     @Suppress("UNCHECKED_CAST")
     private fun VirtualComponent.renderWith(context: Any): Component {

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualTreeRenderer.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualTreeRenderer.kt
@@ -21,10 +21,12 @@ internal object VirtualTreeRenderer : AbstractComponentRenderer<VirtualRenderSta
     override fun render(
         component: Component,
         context: VirtualRenderState,
-    ): Component {
-        if (component !is VirtualComponent) return super.render(component, context)
-        return context.renderOnce(component) { super.render(component, context) }
-    }
+    ): Component =
+        if (component is VirtualComponent) {
+            context.renderOnce(component) { super.render(component, context) }
+        } else {
+            super.render(component, context)
+        }
 
     override fun renderText(
         component: TextComponent,
@@ -34,11 +36,7 @@ internal object VirtualTreeRenderer : AbstractComponentRenderer<VirtualRenderSta
     override fun renderTranslatable(
         component: TranslatableComponent,
         context: VirtualRenderState,
-    ): Component {
-        val renderedArguments = component.arguments().map { renderArgument(it, context) }
-
-        return renderNested(component.arguments(renderedArguments), context)
-    }
+    ): Component = renderNested(component.arguments(component.arguments().map { renderArgument(it, context) }), context)
 
     override fun renderKeybind(
         component: KeybindComponent,
@@ -53,12 +51,11 @@ internal object VirtualTreeRenderer : AbstractComponentRenderer<VirtualRenderSta
     override fun renderSelector(
         component: SelectorComponent,
         context: VirtualRenderState,
-    ): Component {
-        val separator = component.separator()
-        val rendered = if (separator == null) component else component.separator(render(separator, context))
-
-        return renderNested(rendered, context)
-    }
+    ): Component =
+        renderNested(
+            component.withRenderedNested(component.separator(), context, SelectorComponent::separator),
+            context,
+        )
 
     override fun renderBlockNbt(
         component: BlockNBTComponent,
@@ -78,12 +75,8 @@ internal object VirtualTreeRenderer : AbstractComponentRenderer<VirtualRenderSta
     override fun renderObject(
         component: ObjectComponent,
         context: VirtualRenderState,
-    ): Component {
-        val fallback = component.fallback()
-        val rendered = if (fallback == null) component else component.fallback(render(fallback, context))
-
-        return renderNested(rendered, context)
-    }
+    ): Component =
+        renderNested(component.withRenderedNested(component.fallback(), context, ObjectComponent::fallback), context)
 
     override fun renderVirtual(
         component: VirtualComponent,
@@ -106,12 +99,7 @@ internal object VirtualTreeRenderer : AbstractComponentRenderer<VirtualRenderSta
     private fun <C : NBTComponent<C>> renderNbt(
         component: C,
         context: VirtualRenderState,
-    ): Component {
-        val separator = component.separator()
-        val rendered = if (separator == null) component else component.separator(render(separator, context))
-
-        return renderNested(rendered, context)
-    }
+    ): Component = renderNested(component.withRenderedNested(component.separator(), context) { separator(it) }, context)
 
     private fun renderNested(
         component: Component,
@@ -119,7 +107,7 @@ internal object VirtualTreeRenderer : AbstractComponentRenderer<VirtualRenderSta
     ): Component {
         val hoverEvent = component.hoverEvent()
         val withRenderedHover =
-            if (hoverEvent == null) component else component.hoverEvent(hoverEvent.withRenderedValue(this, context))
+            hoverEvent?.let { component.hoverEvent(it.withRenderedValue(this, context)) } ?: component
         val children = withRenderedHover.children()
 
         return if (children.isEmpty()) {
@@ -129,10 +117,15 @@ internal object VirtualTreeRenderer : AbstractComponentRenderer<VirtualRenderSta
         }
     }
 
+    private fun <C : Component> C.withRenderedNested(
+        nested: Component?,
+        context: VirtualRenderState,
+        replace: C.(ComponentLike) -> C,
+    ): C = nested?.let { replace(render(it, context)) } ?: this
+
     @Suppress("UNCHECKED_CAST")
     private fun VirtualComponent.renderWith(context: Any): Component {
         val renderer = renderer() as VirtualComponentRenderer<Any>
-        val result: ComponentLike? = renderer.apply(context)
-        return checkNotNull(result) { "The virtual component renderer returned null." }.asComponent()
+        return checkNotNull(renderer.apply(context)) { "The virtual component renderer returned null." }.asComponent()
     }
 }

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualSamples.kt
@@ -1,8 +1,10 @@
 package io.github.lmliam.kotventure.core.virtual
 
 import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.component.component
 import io.github.lmliam.kotventure.core.text.text
 import java.util.Locale
+import java.util.UUID
 
 internal fun virtualSample() {
     val greeting =
@@ -25,4 +27,26 @@ internal fun virtualStyledFallbackSample() {
                 text(if (context.language == "fr") "Bonjour" else "Hello") { color(gold) }
             }
         }
+}
+
+internal fun virtualRenderingSample() {
+    val message =
+        component {
+            virtual<Locale> {
+                render {
+                    text(if (context.language == "fr") "Bonjour" else "Hello")
+                }
+            }
+            text(" Inspect") {
+                hover {
+                    text {
+                        virtual<UUID> {
+                            render { text(context.toString()) }
+                        }
+                    }
+                }
+            }
+        }
+
+    message.render(Locale.UK, UUID(0, 0))
 }

--- a/modules/core/src/test/java/io/github/lmliam/kotventure/core/virtual/NullVirtualComponentRenderer.java
+++ b/modules/core/src/test/java/io/github/lmliam/kotventure/core/virtual/NullVirtualComponentRenderer.java
@@ -1,0 +1,11 @@
+package io.github.lmliam.kotventure.core.virtual;
+
+import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.VirtualComponentRenderer;
+
+final class NullVirtualComponentRenderer implements VirtualComponentRenderer<Viewer> {
+  @Override
+  public ComponentLike apply(final Viewer context) {
+    return null;
+  }
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarHooksTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarHooksTest.kt
@@ -85,13 +85,13 @@ class TimedBossBarHooksTest :
                 ticker.advance(2.seconds)
 
                 events shouldContainExactly
-                    listOf(
-                        "name:1",
-                        "tick:1",
-                        "name:0",
-                        "tick:0",
-                        "finish",
-                    )
+                        listOf(
+                            "name:1",
+                            "tick:1",
+                            "name:0",
+                            "tick:0",
+                            "finish",
+                        )
                 observedProgress shouldBe listOf(0.5f, 0f)
                 timed.bar shouldHaveProgress BossBar.MIN_PROGRESS
             }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderingTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderingTest.kt
@@ -1,0 +1,255 @@
+package io.github.lmliam.kotventure.core.virtual
+
+import io.github.lmliam.kotventure.core.color.red
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.key.key
+import io.github.lmliam.kotventure.core.keybind.keybind
+import io.github.lmliam.kotventure.core.nbt.blockNbt
+import io.github.lmliam.kotventure.core.nbt.blockPos
+import io.github.lmliam.kotventure.core.nbt.entityNbt
+import io.github.lmliam.kotventure.core.nbt.nbtPath
+import io.github.lmliam.kotventure.core.nbt.storageNbt
+import io.github.lmliam.kotventure.core.objectcomponent.display
+import io.github.lmliam.kotventure.core.objectcomponent.sprite
+import io.github.lmliam.kotventure.core.score.score
+import io.github.lmliam.kotventure.core.selector.selector
+import io.github.lmliam.kotventure.core.selector.self
+import io.github.lmliam.kotventure.core.text.asSequence
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.core.translatable.translatable
+import io.github.lmliam.kotventure.test.text.shouldBeBlockNbtComponent
+import io.github.lmliam.kotventure.test.text.shouldBeEntityNbtComponent
+import io.github.lmliam.kotventure.test.text.shouldBeObjectComponent
+import io.github.lmliam.kotventure.test.text.shouldBeSelectorComponent
+import io.github.lmliam.kotventure.test.text.shouldBeStorageNbtComponent
+import io.github.lmliam.kotventure.test.text.shouldBeVirtualComponent
+import io.github.lmliam.kotventure.test.text.shouldContainText
+import io.github.lmliam.kotventure.test.text.shouldHaveArguments
+import io.github.lmliam.kotventure.test.text.shouldHaveChildren
+import io.github.lmliam.kotventure.test.text.shouldHaveContent
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TranslationArgument
+import net.kyori.adventure.text.VirtualComponent
+import net.kyori.adventure.text.VirtualComponentRenderer
+import net.kyori.adventure.text.event.HoverEvent
+import java.util.Locale
+import java.util.UUID
+
+class VirtualRenderingTest :
+    StringSpec(
+        {
+            "renders a root virtual component against a matching context" {
+                val message = virtual<Viewer> { render { text(context.name) } }
+
+                message.render(Viewer("Alex")) shouldBe renderedText("Alex")
+            }
+
+            "discards the complete fallback after a matching render" {
+                val message =
+                    virtual<Viewer> {
+                        fallback {
+                            color(red)
+                            text("fallback")
+                            text(" child")
+                        }
+                        render { text(context.name) }
+                    }
+
+                val rendered = message.render(Viewer("Alex"))
+
+                rendered shouldBe renderedText("Alex")
+                rendered shouldHaveContent "Alex"
+                rendered.shouldHaveChildren(Component.text("Alex"))
+            }
+
+            "uses an arbitrary component type from a renderer" {
+                val message =
+                    Component.virtual(
+                        Viewer::class.java,
+                        object : VirtualComponentRenderer<Viewer> {
+                            override fun apply(context: Viewer): Component = Component.score(context.name, "wins")
+                        },
+                    )
+
+                message.render(Viewer("Alex")) shouldBe Component.score("Alex", "wins")
+            }
+
+            "uses the first matching context" {
+                val message = virtual<Viewer> { render { text(context.name) } }
+
+                message.render(Viewer("Alex"), Viewer("Steve")) shouldBe renderedText("Alex")
+            }
+
+            "renders nodes for contexts of different types" {
+                val message =
+                    component {
+                        virtual<Viewer> { render { text(context.name) } }
+                        virtual<Locale> { render { text(context.language) } }
+                    }
+
+                val rendered = message.render(Viewer("Alex"), Locale.UK)
+
+                rendered.shouldHaveChildren(renderedText("Alex"), renderedText("en"))
+            }
+
+            "keeps unmatched virtual components for a later render" {
+                val message = virtual<Viewer> { render { text(context.name) } }
+
+                val unmatched = message.render(Locale.UK)
+
+                unmatched.shouldBeVirtualComponent()
+                unmatched.render(Viewer("Alex")) shouldBe renderedText("Alex")
+            }
+
+            "renders boxed primitive contexts" {
+                val message = virtual<Int> { render { text(context.toString()) } }
+
+                message.render(42) shouldBe renderedText("42")
+            }
+
+            "rejects a null result from an external renderer" {
+                val message =
+                    Component.virtual(
+                        Viewer::class.java,
+                        NullVirtualComponentRenderer(),
+                    )
+
+                shouldThrow<IllegalStateException> { message.render(Viewer("Alex")) }
+            }
+
+            "renders virtual components introduced by a renderer" {
+                val message =
+                    virtual<Viewer> {
+                        render {
+                            virtual<Locale> {
+                                render { text(context.language) }
+                            }
+                        }
+                    }
+
+                val rendered = message.render(Viewer("Alex"), Locale.UK)
+
+                rendered shouldContainText "en"
+                rendered.asSequence().any { it is VirtualComponent } shouldBe false
+            }
+
+            "renders a virtual component returned directly by an external renderer" {
+                val nested = virtual<Locale> { render { text(context.language) } }
+                val message =
+                    Component.virtual(
+                        Viewer::class.java,
+                        VirtualComponentRenderer<Viewer> { nested },
+                    )
+
+                message.render(Viewer("Alex"), Locale.UK) shouldBe renderedText("en")
+            }
+
+            "keeps a recursive external renderer finite" {
+                var message: VirtualComponent? = null
+                message =
+                    Component.virtual(
+                        Viewer::class.java,
+                        VirtualComponentRenderer<Viewer> { requireNotNull(message) },
+                    )
+
+                message.render(Viewer("Alex")) shouldBe message
+            }
+
+            "renders virtual children in every non-virtual renderer hook" {
+                val virtualChild = virtual<Viewer> { render { text(context.name) } }
+                val sources =
+                    listOf(
+                        text("text") { append(virtualChild) },
+                        translatable("translation.key") { append(virtualChild) },
+                        keybind("key.jump") { append(virtualChild) },
+                        score("Alex", "wins") { append(virtualChild) },
+                        selector(self()) { append(virtualChild) },
+                        blockNbt(blockPos(0, 64, 0), nbtPath("value")) { append(virtualChild) },
+                        entityNbt(self(), nbtPath("value")) { append(virtualChild) },
+                        storageNbt(key("kotventure", "messages"), nbtPath("value")) { append(virtualChild) },
+                        display(sprite(key("minecraft", "block/stone"))) { append(virtualChild) },
+                    )
+
+                sources.forEach { source ->
+                    val rendered = source.render(Viewer("Alex"))
+
+                    rendered::class shouldBe source::class
+                    rendered.shouldHaveChildren(renderedText("Alex"))
+                }
+            }
+
+            "renders virtual translatable arguments" {
+                val argument = virtual<Viewer> { render { text(context.name) } }
+                val message =
+                    translatable("translation.key") {
+                        arg(argument)
+                    }
+
+                val rendered = message.render(Viewer("Alex"))
+
+                rendered.shouldHaveArguments(TranslationArgument.component(renderedText("Alex")))
+            }
+
+            "renders virtual selector and NBT separators" {
+                val separator = virtual<Viewer> { render { text(context.name) } }
+                val selector = selector(self()) { separator(separator) }
+                val blockNbt = blockNbt(blockPos(0, 64, 0), nbtPath("value")) { separator(separator) }
+                val entityNbt = entityNbt(self(), nbtPath("value")) { separator(separator) }
+                val storageNbt = storageNbt(key("kotventure", "messages"), nbtPath("value")) { separator(separator) }
+
+                selector.render(Viewer("Alex")).shouldBeSelectorComponent().separator() shouldBe renderedText("Alex")
+                blockNbt.render(Viewer("Alex")).shouldBeBlockNbtComponent().separator() shouldBe renderedText("Alex")
+                entityNbt.render(Viewer("Alex")).shouldBeEntityNbtComponent().separator() shouldBe renderedText("Alex")
+                storageNbt.render(Viewer("Alex")).shouldBeStorageNbtComponent().separator() shouldBe
+                    renderedText("Alex")
+            }
+
+            "renders virtual hover text and entity names" {
+                val hoverText =
+                    text("Inspect") {
+                        hover {
+                            text {
+                                virtual<Viewer> { render { text(context.name) } }
+                            }
+                        }
+                    }
+                val hoverEntity =
+                    text("Entity") {
+                        hover {
+                            entity(key("minecraft", "player"), UUID(0, 0)) {
+                                virtual<Viewer> { render { text(context.name) } }
+                            }
+                        }
+                    }
+
+                val renderedHoverText = requireNotNull(hoverText.render(Viewer("Alex")).hoverEvent())
+                renderedHoverText.value() as Component shouldContainText "Alex"
+
+                val renderedHoverEntity = requireNotNull(hoverEntity.render(Viewer("Alex")).hoverEvent())
+                val entity = renderedHoverEntity.value() as? HoverEvent.ShowEntity
+                requireNotNull(requireNotNull(entity).name()) shouldContainText "Alex"
+            }
+
+            "renders virtual object fallbacks" {
+                val fallback = virtual<Viewer> { render { text(context.name) } }
+                val message =
+                    display(sprite(key("minecraft", "block/stone"))) {
+                        fallback(fallback)
+                    }
+
+                message.render(Viewer("Alex")).shouldBeObjectComponent().fallback() shouldBe renderedText("Alex")
+            }
+
+            "propagates exceptions from virtual renderers" {
+                val failure = IllegalArgumentException("stop")
+                val message = virtual<Viewer> { render { throw failure } }
+
+                shouldThrow<IllegalArgumentException> { message.render(Viewer("Alex")) } shouldBe failure
+            }
+        },
+    )
+
+private fun renderedText(value: String): Component = Component.text().append(Component.text(value)).build()

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderingTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderingTest.kt
@@ -27,6 +27,8 @@ import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveArguments
 import io.github.lmliam.kotventure.test.text.shouldHaveChildren
 import io.github.lmliam.kotventure.test.text.shouldHaveContent
+import io.github.lmliam.kotventure.test.text.shouldHaveHoverEntity
+import io.github.lmliam.kotventure.test.text.shouldHaveHoverText
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -69,10 +71,7 @@ class VirtualRenderingTest :
                 val message =
                     Component.virtual(
                         Viewer::class.java,
-                        object : VirtualComponentRenderer<Viewer> {
-                            override fun apply(context: Viewer): Component = Component.score(context.name, "wins")
-                        },
-                    )
+                    ) { context -> Component.score(context.name, "wins") }
 
                 message.render(Viewer("Alex")) shouldBe Component.score("Alex", "wins")
             }
@@ -141,8 +140,7 @@ class VirtualRenderingTest :
                 val message =
                     Component.virtual(
                         Viewer::class.java,
-                        VirtualComponentRenderer<Viewer> { nested },
-                    )
+                    ) { nested }
 
                 message.render(Viewer("Alex"), Locale.UK) shouldBe renderedText("en")
             }
@@ -152,8 +150,7 @@ class VirtualRenderingTest :
                 message =
                     Component.virtual(
                         Viewer::class.java,
-                        VirtualComponentRenderer<Viewer> { requireNotNull(message) },
-                    )
+                    ) { requireNotNull(message) }
 
                 message.render(Viewer("Alex")) shouldBe message
             }
@@ -162,16 +159,16 @@ class VirtualRenderingTest :
                 val virtualChild = virtual<Viewer> { render { text(context.name) } }
                 val sources =
                     listOf(
-                        text("text") { append(virtualChild) },
-                        translatable("translation.key") { append(virtualChild) },
-                        keybind("key.jump") { append(virtualChild) },
-                        score("Alex", "wins") { append(virtualChild) },
-                        selector(self()) { append(virtualChild) },
-                        blockNbt(blockPos(0, 64, 0), nbtPath("value")) { append(virtualChild) },
-                        entityNbt(self(), nbtPath("value")) { append(virtualChild) },
-                        storageNbt(key("kotventure", "messages"), nbtPath("value")) { append(virtualChild) },
-                        display(sprite(key("minecraft", "block/stone"))) { append(virtualChild) },
-                    )
+                        text("text"),
+                        translatable("translation.key"),
+                        keybind("key.jump"),
+                        score("Alex", "wins"),
+                        selector(self()),
+                        blockNbt(blockPos(0, 64, 0), nbtPath("value")),
+                        entityNbt(self(), nbtPath("value")),
+                        storageNbt(key("kotventure", "messages"), nbtPath("value")),
+                        display(sprite(key("minecraft", "block/stone"))),
+                    ).map { it.append(virtualChild) }
 
                 sources.forEach { source ->
                     val rendered = source.render(Viewer("Alex"))
@@ -199,12 +196,12 @@ class VirtualRenderingTest :
                 val blockNbt = blockNbt(blockPos(0, 64, 0), nbtPath("value")) { separator(separator) }
                 val entityNbt = entityNbt(self(), nbtPath("value")) { separator(separator) }
                 val storageNbt = storageNbt(key("kotventure", "messages"), nbtPath("value")) { separator(separator) }
+                val expectedSeparator = renderedText("Alex")
 
-                selector.render(Viewer("Alex")).shouldBeSelectorComponent().separator() shouldBe renderedText("Alex")
-                blockNbt.render(Viewer("Alex")).shouldBeBlockNbtComponent().separator() shouldBe renderedText("Alex")
-                entityNbt.render(Viewer("Alex")).shouldBeEntityNbtComponent().separator() shouldBe renderedText("Alex")
-                storageNbt.render(Viewer("Alex")).shouldBeStorageNbtComponent().separator() shouldBe
-                        renderedText("Alex")
+                selector.render(Viewer("Alex")).shouldBeSelectorComponent().separator() shouldBe expectedSeparator
+                blockNbt.render(Viewer("Alex")).shouldBeBlockNbtComponent().separator() shouldBe expectedSeparator
+                entityNbt.render(Viewer("Alex")).shouldBeEntityNbtComponent().separator() shouldBe expectedSeparator
+                storageNbt.render(Viewer("Alex")).shouldBeStorageNbtComponent().separator() shouldBe expectedSeparator
             }
 
             "renders virtual hover text and entity names" {
@@ -224,13 +221,18 @@ class VirtualRenderingTest :
                             }
                         }
                     }
+                val expectedName = Component.text().append(renderedText("Alex")).build()
 
-                val renderedHoverText = requireNotNull(hoverText.render(Viewer("Alex")).hoverEvent())
-                renderedHoverText.value() as Component shouldContainText "Alex"
-
-                val renderedHoverEntity = requireNotNull(hoverEntity.render(Viewer("Alex")).hoverEvent())
-                val entity = renderedHoverEntity.value() as? HoverEvent.ShowEntity
-                requireNotNull(requireNotNull(entity).name()) shouldContainText "Alex"
+                hoverText.render(Viewer("Alex")) shouldHaveHoverText expectedName
+                hoverEntity.render(Viewer("Alex")) shouldHaveHoverEntity
+                        HoverEvent.ShowEntity.showEntity(
+                            key(
+                                "minecraft",
+                                "player",
+                            ),
+                            UUID(0, 0),
+                            expectedName,
+                        )
             }
 
             "renders virtual object fallbacks" {

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderingTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderingTest.kt
@@ -204,7 +204,7 @@ class VirtualRenderingTest :
                 blockNbt.render(Viewer("Alex")).shouldBeBlockNbtComponent().separator() shouldBe renderedText("Alex")
                 entityNbt.render(Viewer("Alex")).shouldBeEntityNbtComponent().separator() shouldBe renderedText("Alex")
                 storageNbt.render(Viewer("Alex")).shouldBeStorageNbtComponent().separator() shouldBe
-                    renderedText("Alex")
+                        renderedText("Alex")
             }
 
             "renders virtual hover text and entity names" {


### PR DESCRIPTION
## Summary

- Add `Component.render(context, ...)` to resolve virtual components against ordered contexts.
- Render virtual nodes in children, translation arguments, separators, hover values, and object fallbacks.
- Keep unmatched nodes intact and support boxed primitive context types.

## Related Issues

Closes #332

## DSL Impact

Components can now resolve all matching virtual nodes before an audience or serializer receives the result.

```kotlin
val rendered = message.render(player, locale)
```

The first matching context supplies each result. A matching result replaces the complete fallback appearance.

## Rationale

Adventure does not resolve virtual components in `adventure-api`. This extension gives plugin authors one core-only operation that handles the complete component tree without a custom renderer.

## Testing

- Add Kotest coverage for ordered dispatch, fallback replacement, primitive contexts, composition, renderer failures, and recursion safety.
- Cover all nine Adventure component hooks and all special component-bearing slots.
- Verify compiled samples, Dokka links, formatting, the full test suite, vanilla conformance, and the 85% Kover gate with `./gradlew build`.

## Checklist

- [x] Link the related issue
- [x] Update the README and applicable `/docs` pages
- [x] Verify that examples build and run
