### PR TITLE
feat(core): add the text replacement DSL

### DIFF
--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -61,6 +61,7 @@ Each package under `io.github.lmliam.kotventure.core` contains one feature:
 | `nbt`, `objectcomponent`                          | `nbt { }`, `nbtPath(...)`, block/entity/storage NBT components, `display(...)`                 |
 | `translatable`, `keybind`, `score`, `key`, `uuid` | the remaining component types and value helpers                                                |
 | `virtual`                                         | `virtual<C> { }` builds a component that a platform resolves from a render context; `Component.render(context, ...)` resolves matching nodes. |
+| `replacement`                                     | `Component.replace(literal) { }` / `Component.replace(Regex) { }` — literal and regex matchers, matched-text modification (`modify { }`), arbitrary component replacement (`replacement { }`), limits (`once`, `times`, `condition`), and removal (`remove`). |
 | `theme`                                           | `Theme` base class with `by style { }` properties, explicit `ThemeRegistry`                    |
 | `time`                                            | `ticks` and `Ticker` (`every`, `after`, `isCurrent`). Platforms adapt it.               |
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ConditionScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ConditionScope.kt
@@ -1,0 +1,31 @@
+package io.github.lmliam.kotventure.core.replacement
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+
+/**
+ * Decides the outcome for one match inside a [ReplaceScope.condition] block.
+ *
+ * Return one of the scoped constants [replace], [skip], or [stop] from the block.
+ *
+ * @sample io.github.lmliam.kotventure.core.replacement.replaceConditionSample
+ */
+@KotventureDslMarker
+public interface ConditionScope {
+    /** The snapshotted current match. */
+    public val match: TextMatch
+
+    /** The number of matches found so far, including this one. */
+    public val matchCount: Int
+
+    /** The number of matches already replaced before this one. */
+    public val replacementCount: Int
+
+    /** Replaces this match. */
+    public val replace: MatchAction
+
+    /** Skips this match. The pass keeps searching for later matches. */
+    public val skip: MatchAction
+
+    /** Stops the pass. The operation does not change the remaining children. */
+    public val stop: MatchAction
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ConditionState.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ConditionState.kt
@@ -1,0 +1,11 @@
+package io.github.lmliam.kotventure.core.replacement
+
+internal class ConditionState(
+    override val match: TextMatch,
+    override val matchCount: Int,
+    override val replacementCount: Int,
+) : ConditionScope {
+    override val replace: MatchAction get() = MatchAction.REPLACE
+    override val skip: MatchAction get() = MatchAction.SKIP
+    override val stop: MatchAction get() = MatchAction.STOP
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/MatchAction.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/MatchAction.kt
@@ -1,0 +1,22 @@
+package io.github.lmliam.kotventure.core.replacement
+
+import net.kyori.adventure.text.PatternReplacementResult
+
+/**
+ * The outcome for one match inside a [ReplaceScope.condition] block.
+ *
+ * A block returns this value. Access it through the scoped constants [ConditionScope.replace],
+ * [ConditionScope.skip], and [ConditionScope.stop]. Do not construct an entry directly.
+ */
+public enum class MatchAction(
+    internal val result: PatternReplacementResult,
+) {
+    /** Replaces the current match. */
+    REPLACE(PatternReplacementResult.REPLACE),
+
+    /** Skips the current match. The pass keeps searching for later matches. */
+    SKIP(PatternReplacementResult.CONTINUE),
+
+    /** Stops the pass. The operation does not change the remaining children. */
+    STOP(PatternReplacementResult.STOP),
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ModifyBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ModifyBuilder.kt
@@ -1,0 +1,13 @@
+package io.github.lmliam.kotventure.core.replacement
+
+import io.github.lmliam.kotventure.core.text.TextBuilder
+import io.github.lmliam.kotventure.core.text.TextScope
+import net.kyori.adventure.text.Component
+
+internal class ModifyBuilder(
+    private val text: TextBuilder,
+    override val match: TextMatch,
+) : ModifyScope,
+    TextScope by text {
+    fun build(): Component = text.build()
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ModifyScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ModifyScope.kt
@@ -1,0 +1,19 @@
+package io.github.lmliam.kotventure.core.replacement
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.core.text.TextScope
+
+/**
+ * Modifies the matched text inside a [ReplaceScope.modify] block.
+ *
+ * This scope starts with the [TextScope] content, style, and children of a text component that Adventure
+ * pre-populates from [match]. Change [TextScope.content] to keep only part of the match, apply a style, or append
+ * children. Leave the content unchanged to keep the matched text as-is.
+ *
+ * @sample io.github.lmliam.kotventure.core.replacement.replaceModifySample
+ */
+@KotventureDslMarker
+public interface ModifyScope : TextScope {
+    /** The snapshotted match that this block modifies. */
+    public val match: TextMatch
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/Replace.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/Replace.kt
@@ -1,0 +1,50 @@
+package io.github.lmliam.kotventure.core.replacement
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TextReplacementConfig
+import java.util.regex.Pattern
+
+/**
+ * Replaces each match of [literal] inside this component, and returns the changed component.
+ *
+ * [literal] is a literal string. It is not a regular expression, unlike Adventure's own `match(String)` method on
+ * `TextReplacementConfig.Builder`. [init] configures the replacement action, the match limit, and the hover-event
+ * behaviour.
+ *
+ * This function only builds a new component. It does not change this component.
+ *
+ * @sample io.github.lmliam.kotventure.core.replacement.replaceLiteralSample
+ *
+ * @param literal the literal text to find.
+ * @param init configures the replacement action, the match limit, and the hover-event behaviour.
+ * @throws IllegalStateException when [init] sets a write-once slot twice, or sets no replacement action.
+ * @throws IllegalArgumentException when [init] calls `times` with a count below `1`.
+ */
+public fun Component.replace(
+    literal: String,
+    init: ReplaceScope.() -> Unit,
+): Component = replaceText(buildReplacement(Pattern.compile(literal, Pattern.LITERAL), init))
+
+/**
+ * Replaces each match of [pattern] inside this component, and returns the changed component.
+ *
+ * [init] configures the replacement action, the match limit, and the hover-event behaviour.
+ *
+ * This function only builds a new component. It does not change this component.
+ *
+ * @sample io.github.lmliam.kotventure.core.replacement.replaceModifySample
+ *
+ * @param pattern the regular expression to find.
+ * @param init configures the replacement action, the match limit, and the hover-event behaviour.
+ * @throws IllegalStateException when [init] sets a write-once slot twice, or sets no replacement action.
+ * @throws IllegalArgumentException when [init] calls `times` with a count below `1`.
+ */
+public fun Component.replace(
+    pattern: Regex,
+    init: ReplaceScope.() -> Unit,
+): Component = replaceText(buildReplacement(pattern.toPattern(), init))
+
+internal fun buildReplacement(
+    pattern: Pattern,
+    init: ReplaceScope.() -> Unit,
+): TextReplacementConfig = ReplaceBuilder(pattern).apply(init).build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ReplaceBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ReplaceBuilder.kt
@@ -1,0 +1,89 @@
+package io.github.lmliam.kotventure.core.replacement
+
+import io.github.lmliam.kotventure.core.dsl.once
+import io.github.lmliam.kotventure.core.text.TextBuilder
+import io.github.lmliam.kotventure.core.text.TextScope
+import io.github.lmliam.kotventure.core.text.text
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.TextReplacementConfig
+import java.util.function.BiFunction
+import java.util.regex.MatchResult
+import java.util.regex.Pattern
+
+internal class ReplaceBuilder(
+    private val pattern: Pattern,
+) : ReplaceScope {
+    private val namedGroups: Map<String, Int> = pattern.namedGroups()
+
+    private var replacementFactory: ((MatchResult, TextComponent.Builder) -> ComponentLike?)? by
+        once { "The replacement action is already set by 'modify', 'replacement', or 'remove'." }
+    private var conditionApplier: ((TextReplacementConfig.Builder) -> Unit)? by
+        once { "The match condition is already set by 'once', 'times', or 'condition'." }
+    private var insideHoverEvents: Boolean? by once { "'insideHoverEvents' is already set." }
+
+    override fun replacement(
+        value: String,
+        init: TextScope.() -> Unit,
+    ) {
+        replacement(text(value, init))
+    }
+
+    override fun <T : ComponentLike> replacement(component: T) {
+        val prepared = component.asComponent()
+        replacementFactory = { _, _ -> prepared }
+    }
+
+    override fun replacement(build: ReplacementScope.() -> ComponentLike?) {
+        replacementFactory = { result, _ -> ReplacementState(TextMatch(result, namedGroups)).build() }
+    }
+
+    override fun modify(build: ModifyScope.() -> Unit) {
+        replacementFactory = { result, builder ->
+            ModifyBuilder(TextBuilder(builder), TextMatch(result, namedGroups)).apply(build).build()
+        }
+    }
+
+    override fun remove() {
+        replacementFactory = { _, _ -> null }
+    }
+
+    override fun once() {
+        conditionApplier = { it.once() }
+    }
+
+    override fun times(count: Int) {
+        require(count > 0) { "'times' must be positive, was $count." }
+        conditionApplier = { it.times(count) }
+    }
+
+    override fun condition(predicate: ConditionScope.() -> MatchAction) {
+        conditionApplier = { builder ->
+            builder.condition { result, matchCount, replaced ->
+                ConditionState(TextMatch(result, namedGroups), matchCount, replaced).predicate().result
+            }
+        }
+    }
+
+    override fun insideHoverEvents(replace: Boolean) {
+        insideHoverEvents = replace
+    }
+
+    fun build(): TextReplacementConfig {
+        val factory =
+            checkNotNull(replacementFactory) {
+                "A replacement action is required: use 'modify', 'replacement', or 'remove'."
+            }
+
+        val configBuilder = TextReplacementConfig.builder().match(pattern)
+        val replacementFunction =
+            BiFunction<MatchResult, TextComponent.Builder, ComponentLike?> { result, builder ->
+                factory(result, builder)
+            }
+        configBuilder.replacement(replacementFunction)
+        conditionApplier?.invoke(configBuilder)
+        insideHoverEvents?.let(configBuilder::replaceInsideHoverEvents)
+
+        return configBuilder.build()
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ReplaceBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ReplaceBuilder.kt
@@ -7,19 +7,24 @@ import io.github.lmliam.kotventure.core.text.text
 import net.kyori.adventure.text.ComponentLike
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.TextReplacementConfig
-import java.util.function.BiFunction
 import java.util.regex.MatchResult
 import java.util.regex.Pattern
+
+private typealias ReplacementFactory = (MatchResult, TextComponent.Builder) -> ComponentLike?
+
+private typealias ConditionApplier = TextReplacementConfig.Builder.() -> Unit
 
 internal class ReplaceBuilder(
     private val pattern: Pattern,
 ) : ReplaceScope {
     private val namedGroups: Map<String, Int> = pattern.namedGroups()
 
-    private var replacementFactory: ((MatchResult, TextComponent.Builder) -> ComponentLike?)? by
-        once { "The replacement action is already set by 'modify', 'replacement', or 'remove'." }
-    private var conditionApplier: ((TextReplacementConfig.Builder) -> Unit)? by
-        once { "The match condition is already set by 'once', 'times', or 'condition'." }
+    private var replacementFactory: ReplacementFactory? by
+    once { "The replacement action is already set by 'modify', 'replacement', or 'remove'." }
+
+    private var conditionApplier: ConditionApplier? by
+    once { "The match condition is already set by 'once', 'times', or 'condition'." }
+
     private var insideHoverEvents: Boolean? by once { "'insideHoverEvents' is already set." }
 
     override fun replacement(
@@ -29,18 +34,23 @@ internal class ReplaceBuilder(
         replacement(text(value, init))
     }
 
-    override fun <T : ComponentLike> replacement(component: T) {
+    override fun replacement(component: ComponentLike) {
         val prepared = component.asComponent()
         replacementFactory = { _, _ -> prepared }
     }
 
-    override fun replacement(build: ReplacementScope.() -> ComponentLike?) {
-        replacementFactory = { result, _ -> ReplacementState(TextMatch(result, namedGroups)).build() }
+    override fun replacement(init: ReplacementScope.() -> ComponentLike?) {
+        replacementFactory = { result, _ ->
+            ReplacementState(result.snapshot()).init()
+        }
     }
 
-    override fun modify(build: ModifyScope.() -> Unit) {
+    override fun modify(init: ModifyScope.() -> Unit) {
         replacementFactory = { result, builder ->
-            ModifyBuilder(TextBuilder(builder), TextMatch(result, namedGroups)).apply(build).build()
+            ModifyBuilder(
+                text = TextBuilder(builder),
+                match = result.snapshot(),
+            ).apply(init).build()
         }
     }
 
@@ -49,41 +59,49 @@ internal class ReplaceBuilder(
     }
 
     override fun once() {
-        conditionApplier = { it.once() }
+        conditionApplier = { this.once() }
     }
 
     override fun times(count: Int) {
-        require(count > 0) { "'times' must be positive, was $count." }
-        conditionApplier = { it.times(count) }
+        require(count > 0) {
+            "'times' must be positive, was $count."
+        }
+
+        conditionApplier = { this.times(count) }
     }
 
     override fun condition(predicate: ConditionScope.() -> MatchAction) {
-        conditionApplier = { builder ->
-            builder.condition { result, matchCount, replaced ->
-                ConditionState(TextMatch(result, namedGroups), matchCount, replaced).predicate().result
+        conditionApplier = {
+            this.condition { result, matchCount, replacementCount ->
+                ConditionState(
+                    match = result.snapshot(),
+                    matchCount = matchCount,
+                    replacementCount = replacementCount,
+                ).predicate().result
             }
         }
     }
 
-    override fun insideHoverEvents(replace: Boolean) {
-        insideHoverEvents = replace
+    override fun insideHoverEvents(enabled: Boolean) {
+        insideHoverEvents = enabled
     }
 
     fun build(): TextReplacementConfig {
-        val factory =
+        val replacement =
             checkNotNull(replacementFactory) {
                 "A replacement action is required: use 'modify', 'replacement', or 'remove'."
             }
 
         val configBuilder = TextReplacementConfig.builder().match(pattern)
-        val replacementFunction =
-            BiFunction<MatchResult, TextComponent.Builder, ComponentLike?> { result, builder ->
-                factory(result, builder)
-            }
-        configBuilder.replacement(replacementFunction)
+
+        configBuilder.replacement { result, textBuilder ->
+            replacement(result, textBuilder)
+        }
         conditionApplier?.invoke(configBuilder)
         insideHoverEvents?.let(configBuilder::replaceInsideHoverEvents)
 
         return configBuilder.build()
     }
+
+    private fun MatchResult.snapshot(): TextMatch = TextMatch(this, namedGroups)
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ReplaceScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ReplaceScope.kt
@@ -1,0 +1,110 @@
+package io.github.lmliam.kotventure.core.replacement
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import io.github.lmliam.kotventure.core.text.TextScope
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Configures one [Component.replace] call.
+ *
+ * Choose exactly one replacement action: [modify], one form of [replacement], or [remove]. Choose at most one
+ * match limit: [once], [times], or [condition]. [insideHoverEvents] is independent of both. Each slot is
+ * write-once.
+ *
+ * @sample io.github.lmliam.kotventure.core.replacement.replaceLiteralSample
+ */
+@KotventureDslMarker
+public interface ReplaceScope {
+    /**
+     * Sets the replacement to a text component with literal [value], configured by [init].
+     *
+     * This is the short form for a fixed text replacement. Use [modify] to keep the matched text and only change
+     * its style or children. Use the [replacement] block form to compute a different replacement for each match.
+     * Kotventure builds the replacement one time. It does not rebuild the value for each match.
+     *
+     * @throws IllegalStateException when a replacement action is already set in this block.
+     */
+    public fun replacement(
+        value: String,
+        init: TextScope.() -> Unit = {},
+    )
+
+    /**
+     * Sets the replacement to [component] for every match.
+     *
+     * Kotventure stores [component] one time. It does not rebuild the value for each match.
+     *
+     * @sample io.github.lmliam.kotventure.core.replacement.replaceComponentSample
+     *
+     * @throws IllegalStateException when a replacement action is already set in this block.
+     */
+    public fun <T : ComponentLike> replacement(component: T)
+
+    /**
+     * Sets the replacement to the result of [build], computed for each accepted match.
+     *
+     * [build] receives the snapshotted match through [ReplacementScope.match]. It returns any component, or the
+     * scoped [ReplacementScope.remove] to delete this match.
+     *
+     * @throws IllegalStateException when a replacement action is already set in this block.
+     */
+    public fun replacement(build: ReplacementScope.() -> ComponentLike?)
+
+    /**
+     * Modifies the matched text through [build].
+     *
+     * [build] starts with a text component that Adventure pre-populates from the match. The block can change the
+     * content, the style, and the children of that component without retyping the matched text. The snapshotted
+     * match is available as [ModifyScope.match].
+     *
+     * @throws IllegalStateException when a replacement action is already set in this block.
+     */
+    public fun modify(build: ModifyScope.() -> Unit)
+
+    /**
+     * Deletes every accepted match.
+     *
+     * @throws IllegalStateException when a replacement action is already set in this block.
+     */
+    public fun remove()
+
+    /**
+     * Replaces only the first match.
+     *
+     * This form and [times] and [condition] share one write-once slot.
+     *
+     * @throws IllegalStateException when a match limit is already set in this block.
+     */
+    public fun once()
+
+    /**
+     * Replaces only the first [count] matches.
+     *
+     * This form and [once] and [condition] share one write-once slot.
+     *
+     * @sample io.github.lmliam.kotventure.core.replacement.replaceLimitSample
+     *
+     * @throws IllegalArgumentException when [count] is below `1`.
+     * @throws IllegalStateException when a match limit is already set in this block.
+     */
+    public fun times(count: Int)
+
+    /**
+     * Decides the outcome for each match through [predicate].
+     *
+     * This form and [once] and [times] share one write-once slot.
+     *
+     * @throws IllegalStateException when a match limit is already set in this block.
+     */
+    public fun condition(predicate: ConditionScope.() -> MatchAction)
+
+    /**
+     * Sets whether a replacement also changes text inside hover events.
+     *
+     * Adventure applies this setting with a default of `true`.
+     *
+     * @throws IllegalStateException when this slot is already set in this block.
+     */
+    public fun insideHoverEvents(replace: Boolean)
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ReplaceScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ReplaceScope.kt
@@ -6,24 +6,26 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentLike
 
 /**
- * Configures one [Component.replace] call.
+ * Configures one [Component.replace] operation.
  *
- * Choose exactly one replacement action: [modify], one form of [replacement], or [remove]. Choose at most one
- * match limit: [once], [times], or [condition]. [insideHoverEvents] is independent of both. Each slot is
- * write-once.
+ * Set exactly one replacement action: [modify], one form of [replacement], or [remove].
+ * Set at most one match policy: [once], [times], or [condition].
+ * [insideHoverEvents] is independent of those slots.
+ * Every slot is write-once.
  *
  * @sample io.github.lmliam.kotventure.core.replacement.replaceLiteralSample
  */
 @KotventureDslMarker
 public interface ReplaceScope {
     /**
-     * Sets the replacement to a text component with literal [value], configured by [init].
+     * Replaces every accepted match with a text component containing [value] and
+     * configured by [init].
      *
-     * This is the short form for a fixed text replacement. Use [modify] to keep the matched text and only change
-     * its style or children. Use the [replacement] block form to compute a different replacement for each match.
-     * Kotventure builds the replacement one time. It does not rebuild the value for each match.
+     * The replacement is built once.
+     * Use [modify] to retain and edit the matched text, or the receiver-block
+     * form of [replacement] to calculate a different component for each accepted match.
      *
-     * @throws IllegalStateException when a replacement action is already set in this block.
+     * @throws IllegalStateException when this block already contains a replacement action.
      */
     public fun replacement(
         value: String,
@@ -31,80 +33,90 @@ public interface ReplaceScope {
     )
 
     /**
-     * Sets the replacement to [component] for every match.
+     * Replaces every accepted match with [component].
      *
-     * Kotventure stores [component] one time. It does not rebuild the value for each match.
+     * Kotventure converts and stores the component once rather than rebuilding it for
+    each match.
      *
      * @sample io.github.lmliam.kotventure.core.replacement.replaceComponentSample
      *
-     * @throws IllegalStateException when a replacement action is already set in this block.
+     * @throws IllegalStateException when this block already contains a replacement
+    action.
      */
-    public fun <T : ComponentLike> replacement(component: T)
+    public fun replacement(component: ComponentLike)
 
     /**
-     * Sets the replacement to the result of [build], computed for each accepted match.
+     * Replaces each accepted match with the component returned by [init].
      *
-     * [build] receives the snapshotted match through [ReplacementScope.match]. It returns any component, or the
-     * scoped [ReplacementScope.remove] to delete this match.
+     * [init] is evaluated separately for every accepted match. Its receiver exposes the
+    snapshotted match through
+     * [ReplacementScope.match]. Return any [ComponentLike], or return
+    [ReplacementScope.remove] to delete only the
+     * current match.
      *
-     * @throws IllegalStateException when a replacement action is already set in this block.
+     * @throws IllegalStateException when this block already contains a replacement
+    action.
      */
-    public fun replacement(build: ReplacementScope.() -> ComponentLike?)
+    public fun replacement(init: ReplacementScope.() -> ComponentLike?)
 
     /**
-     * Modifies the matched text through [build].
+     * Modifies each accepted match through [init].
      *
-     * [build] starts with a text component that Adventure pre-populates from the match. The block can change the
-     * content, the style, and the children of that component without retyping the matched text. The snapshotted
-     * match is available as [ModifyScope.match].
+     * Adventure supplies a text-component builder pre-populated with the matched text.
+    [init] can change its content,
+     * style, and children without reconstructing the match. The snapshotted match is
+    available through
+     * [ModifyScope.match].
      *
-     * @throws IllegalStateException when a replacement action is already set in this block.
+     * @throws IllegalStateException when this block already contains a replacement
+    action.
      */
-    public fun modify(build: ModifyScope.() -> Unit)
+    public fun modify(init: ModifyScope.() -> Unit)
 
     /**
      * Deletes every accepted match.
      *
-     * @throws IllegalStateException when a replacement action is already set in this block.
+     * @throws IllegalStateException when this block already contains a replacement
+    action.
      */
     public fun remove()
 
     /**
      * Replaces only the first match.
      *
-     * This form and [times] and [condition] share one write-once slot.
+     * This function shares one write-once match-policy slot with [times] and [condition].
      *
-     * @throws IllegalStateException when a match limit is already set in this block.
+     * @throws IllegalStateException when this block already contains a match policy.
      */
     public fun once()
 
     /**
      * Replaces only the first [count] matches.
      *
-     * This form and [once] and [condition] share one write-once slot.
+     * This function shares one write-once match-policy slot with [once] and [condition].
      *
      * @sample io.github.lmliam.kotventure.core.replacement.replaceLimitSample
      *
-     * @throws IllegalArgumentException when [count] is below `1`.
-     * @throws IllegalStateException when a match limit is already set in this block.
+     * @throws IllegalArgumentException when [count] is less than `1`.
+     * @throws IllegalStateException when this block already contains a match policy.
      */
     public fun times(count: Int)
 
     /**
-     * Decides the outcome for each match through [predicate].
+     * Uses [predicate] to decide the outcome of each match.
      *
-     * This form and [once] and [times] share one write-once slot.
+     * This function shares one write-once match-policy slot with [once] and [times].
      *
-     * @throws IllegalStateException when a match limit is already set in this block.
+     * @throws IllegalStateException when this block already contains a match policy.
      */
     public fun condition(predicate: ConditionScope.() -> MatchAction)
 
     /**
-     * Sets whether a replacement also changes text inside hover events.
+     * Sets whether replacement also searches text inside hover events.
      *
-     * Adventure applies this setting with a default of `true`.
+     * Adventure enables this behaviour by default.
      *
-     * @throws IllegalStateException when this slot is already set in this block.
+     * @throws IllegalStateException when this setting is already present in the block.
      */
-    public fun insideHoverEvents(replace: Boolean)
+    public fun insideHoverEvents(enabled: Boolean)
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ReplacementScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ReplacementScope.kt
@@ -1,0 +1,20 @@
+package io.github.lmliam.kotventure.core.replacement
+
+import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.ComponentLike
+
+/**
+ * Computes the replacement for one accepted match inside a [ReplaceScope.replacement] block.
+ *
+ * The block returns any [ComponentLike] computed from [match], or the scoped [remove] to delete this match.
+ *
+ * @sample io.github.lmliam.kotventure.core.replacement.replaceRemoveSample
+ */
+@KotventureDslMarker
+public interface ReplacementScope {
+    /** The snapshotted match that this block replaces. */
+    public val match: TextMatch
+
+    /** Deletes this match. Return this value from the block instead of a component. */
+    public val remove: ComponentLike?
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ReplacementState.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/ReplacementState.kt
@@ -1,0 +1,9 @@
+package io.github.lmliam.kotventure.core.replacement
+
+import net.kyori.adventure.text.ComponentLike
+
+internal class ReplacementState(
+    override val match: TextMatch,
+) : ReplacementScope {
+    override val remove: ComponentLike? = null
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/TextMatch.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/replacement/TextMatch.kt
@@ -1,0 +1,50 @@
+package io.github.lmliam.kotventure.core.replacement
+
+import java.util.regex.MatchResult
+
+/**
+ * A snapshot of one pattern match found inside the content of a text component.
+ *
+ * Adventure supplies a live `java.util.regex.MatchResult` during a replacement or condition callback. That result
+ * is only valid during the callback. `TextMatch` copies every exposed value, so it stays valid after the callback
+ * returns.
+ *
+ * [range] is an index range inside the content of the text component that holds the match. It is not an index
+ * into the whole message.
+ *
+ * @sample io.github.lmliam.kotventure.core.replacement.replaceModifySample
+ */
+public class TextMatch internal constructor(
+    result: MatchResult,
+    private val namedGroups: Map<String, Int>,
+) {
+    /** The complete matched text. */
+    public val value: String = result.group()
+
+    /** The index range of [value] inside the content of the text component that holds the match. */
+    public val range: IntRange = result.start() until result.end()
+
+    /**
+     * The captured text for each group in the pattern, indexed from `0`.
+     *
+     * Index `0` is the complete match. An optional group that did not take part in the match is `null`.
+     */
+    public val groups: List<String?> = List(result.groupCount() + 1) { index -> result.group(index) }
+
+    /**
+     * Returns the captured text for the group at [index].
+     *
+     * @throws IndexOutOfBoundsException when [index] is not a group in the match.
+     */
+    public operator fun get(index: Int): String? = groups[index]
+
+    /**
+     * Returns the captured text for the group named [name].
+     *
+     * @throws IllegalArgumentException when the pattern has no group named [name].
+     */
+    public operator fun get(name: String): String? {
+        val index = requireNotNull(namedGroups[name]) { "The pattern has no group named '$name'." }
+        return groups[index]
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/text/TextBuilder.kt
@@ -9,8 +9,9 @@ import net.kyori.adventure.text.format.TextColor
 import io.github.lmliam.kotventure.core.color.gradient as colorGradient
 import io.github.lmliam.kotventure.core.color.gradientText as gradientComponent
 
-internal class TextBuilder :
-    ComponentBuilder<TextComponent, TextComponent.Builder>(Component.text()),
+internal class TextBuilder(
+    builder: TextComponent.Builder = Component.text(),
+) : ComponentBuilder<TextComponent, TextComponent.Builder>(builder),
     TextScope {
     private var content: String? by once()
     private var gradient: ColorGradient? by once()

--- a/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/replacement/ReplacementSamples.kt
+++ b/modules/core/src/samples/kotlin/io/github/lmliam/kotventure/core/replacement/ReplacementSamples.kt
@@ -1,0 +1,67 @@
+package io.github.lmliam.kotventure.core.replacement
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.color.red
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.core.translatable.translatable
+
+internal fun replaceLiteralSample() {
+    val message = text("Welcome, %player%!")
+    val greeting = message.replace("%player%") { replacement("Alex") { color(gold) } }
+}
+
+internal fun replaceModifySample() {
+    val line = text("user: alex#42")
+    val tagged =
+        line.replace(Regex("""(?<user>\w+)#(\d+)""")) {
+            modify {
+                content(match["user"].orEmpty())
+                insertion(match[2].orEmpty())
+                color(gold)
+            }
+        }
+}
+
+internal fun replaceComponentSample() {
+    val badge = text("VIP") { color(gold) }
+    val message = text("Welcome, %badge%!")
+    val decorated = message.replace("%badge%") { replacement(badge) }
+}
+
+internal fun replaceLimitSample() {
+    val message = text("%tip% %tip% %tip%")
+    val firstOnly =
+        message.replace("%tip%") {
+            once()
+            replacement("tip")
+        }
+    val threeOfThem =
+        message.replace("%tip%") {
+            times(3)
+            replacement("tip")
+        }
+}
+
+internal fun replaceConditionSample() {
+    val chat = text("visit https://example.com or example.net")
+    val linked =
+        chat.replace(Regex("""\S+\.\S+""")) {
+            condition { if (match.value.startsWith("https://")) replace else skip }
+            modify {
+                val url = match.value
+                color(red)
+                click { openUrl(url) }
+            }
+        }
+}
+
+internal fun replaceRemoveSample() {
+    val line = text("role: %role%")
+    val roles =
+        line.replace(Regex("""role: (\w+)""")) {
+            replacement {
+                val role = match[1].orEmpty()
+                if (role == "hidden") remove else translatable("role.$role")
+            }
+        }
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/replacement/ReplaceDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/replacement/ReplaceDslTest.kt
@@ -1,0 +1,555 @@
+package io.github.lmliam.kotventure.core.replacement
+
+import io.github.lmliam.kotventure.core.color.gold
+import io.github.lmliam.kotventure.core.component.component
+import io.github.lmliam.kotventure.core.text.text
+import io.github.lmliam.kotventure.core.translatable.translatable
+import io.github.lmliam.kotventure.test.compilation.assertDoesNotCompile
+import io.github.lmliam.kotventure.test.text.childAt
+import io.github.lmliam.kotventure.test.text.shouldHaveArguments
+import io.github.lmliam.kotventure.test.text.shouldHaveContent
+import io.github.lmliam.kotventure.test.text.shouldHaveHoverText
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.ComponentLike
+import net.kyori.adventure.text.TextReplacementConfig
+import net.kyori.adventure.text.TranslationArgument
+import net.kyori.adventure.text.event.HoverEvent
+import net.kyori.adventure.text.format.NamedTextColor
+import java.util.regex.Pattern
+
+class ReplaceDslTest :
+    StringSpec(
+        {
+            "literal replacement equals the raw matchLiteral and ComponentLike construction" {
+                val message = Component.text("Hello %player%!")
+                val replacementComponent = Component.text("Alex").color(NamedTextColor.GOLD)
+
+                val dsl = message.replace("%player%") { replacement("Alex") { color(gold) } }
+                val raw =
+                    message.replaceText(
+                        TextReplacementConfig
+                            .builder()
+                            .matchLiteral("%player%")
+                            .replacement(replacementComponent as ComponentLike)
+                            .build(),
+                    )
+
+                dsl shouldBe raw
+            }
+
+            "regex replacement equals the raw match(Pattern) and ComponentLike construction" {
+                val message = Component.text("Value: 123")
+                val replacementComponent = Component.text("NUM")
+
+                val dsl = message.replace(Regex("""\d+""")) { replacement("NUM") }
+                val raw =
+                    message.replaceText(
+                        TextReplacementConfig
+                            .builder()
+                            .match(Pattern.compile("""\d+"""))
+                            .replacement(replacementComponent as ComponentLike)
+                            .build(),
+                    )
+
+                dsl shouldBe raw
+            }
+
+            "a literal matcher is not parsed as a regular expression" {
+                val message = Component.text("cost: 1+1")
+
+                val literal = message.replace("1+1") { replacement("2") }
+                literal shouldHaveContent "cost: 2"
+
+                val asRegex = message.replace(Regex("1+1")) { replacement("2") }
+                asRegex shouldHaveContent "cost: 1+1"
+            }
+
+            "modify keeps the pre-populated matched text and adds a colour" {
+                val message = Component.text("Hello world")
+
+                val dsl = message.replace("world") { modify { color(NamedTextColor.RED) } }
+                val raw =
+                    message.replaceText(
+                        TextReplacementConfig
+                            .builder()
+                            .matchLiteral("world")
+                            .replacement { builder -> builder.color(NamedTextColor.RED) }
+                            .build(),
+                    )
+
+                dsl shouldBe raw
+                dsl shouldHaveContent "Hello world"
+            }
+
+            "content inside modify overwrites the pre-populated text" {
+                val message = Component.text("Hello world")
+
+                val dsl = message.replace("world") { modify { content("Kotlin") } }
+                val raw =
+                    message.replaceText(
+                        TextReplacementConfig
+                            .builder()
+                            .matchLiteral("world")
+                            .replacement { builder -> builder.content("Kotlin") }
+                            .build(),
+                    )
+
+                dsl shouldBe raw
+                dsl shouldHaveContent "Hello Kotlin"
+            }
+
+            "replacement(component) swaps in a prepared component for every match" {
+                val message = Component.text("Hello world")
+                val badge = Component.text("Kotlin").color(NamedTextColor.GOLD)
+
+                val dsl = message.replace("world") { replacement(badge) }
+                val raw =
+                    message.replaceText(
+                        TextReplacementConfig
+                            .builder()
+                            .matchLiteral("world")
+                            .replacement(badge as ComponentLike)
+                            .build(),
+                    )
+
+                dsl shouldBe raw
+            }
+
+            "a replacement block computes a translatable component directly from the match" {
+                val message = Component.text("Hello role:admin")
+
+                val dsl =
+                    message.replace(Regex("""role:(\w+)""")) {
+                        replacement { translatable("role.${match[1]}") }
+                    }
+                val raw =
+                    message.replaceText(
+                        TextReplacementConfig
+                            .builder()
+                            .match(Pattern.compile("""role:(\w+)"""))
+                            .replacement { result, _ -> Component.translatable("role.${result.group(1)}") }
+                            .build(),
+                    )
+
+                dsl shouldBe raw
+            }
+
+            "a replacement block's scoped remove deletes only the matching branch" {
+                val message = Component.text("keep:a drop:b keep:c")
+
+                val dsl =
+                    message.replace(Regex("""(keep|drop):(\w)""")) {
+                        replacement {
+                            if (match[1] == "drop") remove else Component.text(match[2].orEmpty())
+                        }
+                    }
+                val raw =
+                    message.replaceText(
+                        TextReplacementConfig
+                            .builder()
+                            .match(Pattern.compile("""(keep|drop):(\w)"""))
+                            .replacement { result, _ ->
+                                if (result.group(1) == "drop") null else Component.text(result.group(2))
+                            }.build(),
+                    )
+
+                dsl shouldBe raw
+                dsl shouldHaveContent "a  c"
+            }
+
+            "groups expose indexed and named captured text, with value and range" {
+                lateinit var captured: TextMatch
+                val content = "user: alex#42"
+                val message = Component.text(content)
+
+                message.replace(Regex("""(?<user>\w+)#(?<num>\d+)(?<extra>-x)?""")) {
+                    replacement {
+                        captured = match
+                        Component.empty()
+                    }
+                }
+
+                val start = content.indexOf("alex#42")
+                captured.value shouldBe "alex#42"
+                captured.range shouldBe (start until (start + "alex#42".length))
+                captured.groups shouldBe listOf("alex#42", "alex", "42", null)
+                captured[0] shouldBe "alex#42"
+                captured[1] shouldBe "alex"
+                captured["user"] shouldBe "alex"
+                captured["num"] shouldBe "42"
+                captured["extra"] shouldBe null
+            }
+
+            "an invalid group index or an unknown group name throws" {
+                lateinit var captured: TextMatch
+                Component.text("value").replace(Regex("value")) {
+                    replacement {
+                        captured = match
+                        Component.empty()
+                    }
+                }
+
+                shouldThrow<IndexOutOfBoundsException> { captured[5] }
+                shouldThrow<IllegalArgumentException> { captured["missing"] }
+            }
+
+            "once and times equal the raw builder methods" {
+                val message = Component.text("a a a")
+
+                val dslOnce =
+                    message.replace("a") {
+                        once()
+                        replacement("b")
+                    }
+                val rawOnce =
+                    message.replaceText(
+                        TextReplacementConfig
+                            .builder()
+                            .matchLiteral("a")
+                            .once()
+                            .replacement("b")
+                            .build(),
+                    )
+                dslOnce shouldBe rawOnce
+
+                val dslTimes =
+                    message.replace("a") {
+                        times(2)
+                        replacement("b")
+                    }
+                val rawTimes =
+                    message.replaceText(
+                        TextReplacementConfig
+                            .builder()
+                            .matchLiteral("a")
+                            .times(2)
+                            .replacement("b")
+                            .build(),
+                    )
+                dslTimes shouldBe rawTimes
+            }
+
+            "times rejects a non-positive count" {
+                shouldThrow<IllegalArgumentException> {
+                    Component.text("a").replace("a") {
+                        times(0)
+                        replacement("b")
+                    }
+                }
+                shouldThrow<IllegalArgumentException> {
+                    Component.text("a").replace("a") {
+                        times(-1)
+                        replacement("b")
+                    }
+                }
+            }
+
+            "a rejected times count leaves the match-limit slot free for a later valid call" {
+                val message = Component.text("a a a")
+
+                val dsl =
+                    message.replace("a") {
+                        shouldThrow<IllegalArgumentException> { times(0) }
+                        times(2)
+                        replacement("b")
+                    }
+                val raw =
+                    message.replaceText(
+                        TextReplacementConfig
+                            .builder()
+                            .matchLiteral("a")
+                            .times(2)
+                            .replacement("b")
+                            .build(),
+                    )
+
+                dsl shouldBe raw
+            }
+
+            "condition selects skip for every match, leaving the component unchanged" {
+                val message =
+                    component {
+                        text("a1 ")
+                        text("a2 ")
+                        text("a3")
+                    }
+
+                val dsl =
+                    message.replace(Regex("""a\d""")) {
+                        condition { skip }
+                        replacement("X")
+                    }
+
+                dsl shouldBe message
+            }
+
+            "condition selects replace for every match" {
+                val message =
+                    component {
+                        text("a1 ")
+                        text("a2 ")
+                        text("a3")
+                    }
+
+                val dsl =
+                    message.replace(Regex("""a\d""")) {
+                        condition { replace }
+                        replacement("X")
+                    }
+
+                dsl shouldHaveContent "X X X"
+            }
+
+            "condition can replace an early match and stop before a later one, based on matchCount" {
+                val message =
+                    component {
+                        text("a1 ")
+                        text("a2 ")
+                        text("a3")
+                    }
+
+                val dsl =
+                    message.replace(Regex("""a\d""")) {
+                        condition { if (matchCount == 1) replace else stop }
+                        replacement("X")
+                    }
+
+                dsl shouldHaveContent "X a2 a3"
+            }
+
+            "condition counts skipped matches in matchCount but not in replacementCount" {
+                val message = Component.text("a1 a2 a3 a4")
+
+                val dsl =
+                    message.replace(Regex("""a\d""")) {
+                        condition {
+                            when {
+                                matchCount == 1 -> skip
+                                replacementCount < 2 -> replace
+                                else -> stop
+                            }
+                        }
+                        replacement("X")
+                    }
+
+                dsl shouldHaveContent "a1 X X a4"
+            }
+
+            "remove deletes a whole-component match and a partial match" {
+                val whole = Component.text("secret")
+                whole.replace("secret") { remove() } shouldBe Component.empty()
+
+                val partial = Component.text("keep secret please")
+                partial.replace("secret") { remove() } shouldHaveContent "keep  please"
+            }
+
+            "insideHoverEvents controls whether hover text is rewritten" {
+                val message = Component.text("info").hoverEvent(HoverEvent.showText(Component.text("secret")))
+
+                val rewritten = message.replace("secret") { replacement("public") }
+                rewritten shouldHaveHoverText Component.text("public")
+
+                val untouched =
+                    message.replace("secret") {
+                        replacement("public")
+                        insideHoverEvents(false)
+                    }
+                untouched shouldHaveHoverText Component.text("secret")
+            }
+
+            "rewrites matches inside children and inside translatable arguments" {
+                val message =
+                    component {
+                        text("Hello %name%, ")
+                        translatable("greeting.detail") {
+                            arg(Component.text("%name%"))
+                        }
+                    }
+
+                val dsl = message.replace("%name%") { replacement("Alex") }
+
+                dsl shouldHaveContent "Hello Alex, "
+                dsl.childAt(1).shouldHaveArguments(TranslationArgument.component(Component.text("Alex")))
+            }
+
+            "a component with no match is returned unchanged" {
+                val message = Component.text("nothing to see here")
+
+                val dsl = message.replace("missing") { replacement("found") }
+
+                dsl shouldBe message
+            }
+
+            "two modify calls throw" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        modify { }
+                        modify { }
+                    }
+                }
+            }
+
+            "modify followed by replacement(value) throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        modify { }
+                        replacement("y")
+                    }
+                }
+            }
+
+            "modify followed by replacement(component) throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        modify { }
+                        replacement(Component.text("y"))
+                    }
+                }
+            }
+
+            "modify followed by replacement(block) throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        modify { }
+                        replacement { remove }
+                    }
+                }
+            }
+
+            "modify followed by remove throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        modify { }
+                        remove()
+                    }
+                }
+            }
+
+            "two replacement calls throw" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        replacement("y")
+                        replacement("z")
+                    }
+                }
+            }
+
+            "replacement followed by remove throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        replacement("y")
+                        remove()
+                    }
+                }
+            }
+
+            "once followed by times throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        once()
+                        times(2)
+                        replacement("y")
+                    }
+                }
+            }
+
+            "once followed by condition throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        once()
+                        condition { replace }
+                        replacement("y")
+                    }
+                }
+            }
+
+            "times followed by condition throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        times(1)
+                        condition { replace }
+                        replacement("y")
+                    }
+                }
+            }
+
+            "two insideHoverEvents calls throw" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        insideHoverEvents(false)
+                        insideHoverEvents(true)
+                        replacement("y")
+                    }
+                }
+            }
+
+            "a missing replacement action throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") { once() }
+                }
+            }
+
+            "outer ReplaceScope members do not resolve inside modify" {
+                assertDoesNotCompile(
+                    fileName = "ModifyScopeLeakTest.kt",
+                    source =
+                        """
+                        import io.github.lmliam.kotventure.core.replacement.replace
+                        import net.kyori.adventure.text.Component
+
+                        fun shouldNotCompile() {
+                            Component.text("x").replace("x") {
+                                modify {
+                                    once()
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    "cannot be called in this context with an implicit receiver",
+                )
+            }
+
+            "outer ReplaceScope members do not resolve inside a replacement block" {
+                assertDoesNotCompile(
+                    fileName = "ReplacementScopeLeakTest.kt",
+                    source =
+                        """
+                        import io.github.lmliam.kotventure.core.replacement.replace
+                        import net.kyori.adventure.text.Component
+
+                        fun shouldNotCompile() {
+                            Component.text("x").replace("x") {
+                                replacement {
+                                    once()
+                                    remove
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    "cannot be called in this context with an implicit receiver",
+                )
+            }
+
+            "a replacement block that only styles the match does not compile" {
+                assertDoesNotCompile(
+                    fileName = "ReplacementBlockTypeTest.kt",
+                    source =
+                        """
+                        import io.github.lmliam.kotventure.core.color.red
+                        import io.github.lmliam.kotventure.core.replacement.replace
+                        import net.kyori.adventure.text.Component
+
+                        fun shouldNotCompile() {
+                            Component.text("x").replace("x") {
+                                replacement { color(red) }
+                            }
+                        }
+                        """.trimIndent(),
+                    "Unresolved reference 'color'",
+                )
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/replacement/ReplaceDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/replacement/ReplaceDslTest.kt
@@ -428,6 +428,42 @@ class ReplaceDslTest :
                 }
             }
 
+            "replacement(value) followed by modify throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        replacement("y")
+                        modify { }
+                    }
+                }
+            }
+
+            "replacement(component) followed by modify throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        replacement(Component.text("y"))
+                        modify { }
+                    }
+                }
+            }
+
+            "replacement(block) followed by modify throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        replacement { remove }
+                        modify { }
+                    }
+                }
+            }
+
+            "remove followed by modify throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        remove()
+                        modify { }
+                    }
+                }
+            }
+
             "two replacement calls throw" {
                 shouldThrow<IllegalStateException> {
                     Component.text("x").replace("x") {
@@ -446,11 +482,39 @@ class ReplaceDslTest :
                 }
             }
 
+            "remove followed by replacement throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        remove()
+                        replacement("y")
+                    }
+                }
+            }
+
+            "two remove calls throw" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        remove()
+                        remove()
+                    }
+                }
+            }
+
             "once followed by times throws" {
                 shouldThrow<IllegalStateException> {
                     Component.text("x").replace("x") {
                         once()
                         times(2)
+                        replacement("y")
+                    }
+                }
+            }
+
+            "times followed by once throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        times(2)
+                        once()
                         replacement("y")
                     }
                 }
@@ -466,11 +530,51 @@ class ReplaceDslTest :
                 }
             }
 
+            "condition followed by once throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        condition { replace }
+                        once()
+                        replacement("y")
+                    }
+                }
+            }
+
             "times followed by condition throws" {
                 shouldThrow<IllegalStateException> {
                     Component.text("x").replace("x") {
                         times(1)
                         condition { replace }
+                        replacement("y")
+                    }
+                }
+            }
+
+            "condition followed by times throws" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        condition { replace }
+                        times(1)
+                        replacement("y")
+                    }
+                }
+            }
+
+            "two times calls throw" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        times(1)
+                        times(2)
+                        replacement("y")
+                    }
+                }
+            }
+
+            "two condition calls throw" {
+                shouldThrow<IllegalStateException> {
+                    Component.text("x").replace("x") {
+                        condition { replace }
+                        condition { skip }
                         replacement("y")
                     }
                 }


### PR DESCRIPTION
## Summary

Adds a DSL for Adventure's text replacement. `Component.replace` finds a literal or a regular expression inside a component tree and rewrites each match. The new `core.replacement` package wraps `TextReplacementConfig`.

## Related Issues

Closes #319

## DSL Impact

New public API in `io.github.lmliam.kotventure.core.replacement`:

```kotlin
// literal placeholder, styled replacement
message.replace("%player%") { replacement(name) { color(gold) } }

// keep the matched text, change only its style
log.replace(Regex("ERROR")) { modify { color(red); bold() } }

// compute any component from the match, or delete this match
line.replace(rolePattern) {
    replacement {
        val role = match["role"].orEmpty()
        if (role == "hidden") remove else translatable("role.$role")
    }
}

// limits and per-match decisions
chat.replace(urlPattern) {
    condition { if (match.value.startsWith("https://")) replace else skip }
    modify { color(aqua) }
}
```

- `Component.replace(literal: String) { }` and `Component.replace(pattern: Regex) { }`. A `String` is a literal and a `Regex` is a regular expression, the same convention as `kotlin.text.String.replace`. Adventure's own `match(String)` compiles the string as a regular expression, so the KDoc states the difference.
- `ReplaceScope` holds two write-once slots. The replacement action comes from `modify`, one of three `replacement` forms, or `remove`. The match limit comes from `once`, `times`, or `condition`. `insideHoverEvents` is independent.
- `modify { }` starts with the text that Adventure pre-populates from the match, so a caller can style a match without retyping it. `replacement { }` returns any component computed from the match, or the scoped `remove`.
- `TextMatch` is an immutable snapshot of one match. Adventure supplies the live `Matcher`, which is only valid during the callback.
- `MatchAction` and the scoped constants `replace`, `skip`, and `stop` on `ConditionScope` follow the `SelectorSort` idiom.

The entry point is `replace`, not `replaceText`, because `replaceText` is already a `Component` member: a bare `replaceText { }` lambda resolves to Adventure's Java `Consumer<TextReplacementConfig.Builder>` through SAM conversion.

`TextBuilder` gains a constructor parameter with a default value, so `modify { }` can wrap Adventure's pre-populated builder. Every current call site is unchanged.

## Rationale

Placeholder substitution in an already-built component is one of the most common operations in a plugin. Adventure supports it through a Java builder with four `replacement` overloads, a nullable return that means "delete", and a limit field that three different methods write. The DSL makes each of those explicit, rejects a duplicate slot with `IllegalStateException`, and keeps the matched text available as a snapshot instead of a live `Matcher`.

## Testing

`ReplaceDslTest` adds 36 Kotest cases:

- Literal and regular expression replacement each equal the same operation built with a raw `TextReplacementConfig`.
- A literal matcher is not parsed as a regular expression.
- `modify` keeps the pre-populated text; `content` overwrites it.
- `replacement(component)`, the `replacement { }` block, and the scoped `remove`.
- `TextMatch` values, ranges, indexed groups, named groups, and an absent optional group. An invalid index throws `IndexOutOfBoundsException` and an unknown name throws `IllegalArgumentException`.
- `once` and `times` equal the raw builder methods. `times(0)` and `times(-1)` throw, and a rejected count leaves the slot free.
- `condition` for `skip`, `replace`, and `stop`, including the difference between `matchCount` and `replacementCount`.
- `remove` for a whole-component match and a partial match.
- `insideHoverEvents` in both states.
- Matches inside children and inside translatable arguments.
- Every duplicate slot combination throws `IllegalStateException`, and a missing replacement action throws.
- Compile-fail tests for `@DslMarker` leaks and for a `replacement { }` block that only styles the match.

`core` line coverage is 93.2%, above the 85% gate. The `replacement` package is at 98.4%.

## Checklist

- [x] Link the related issue
- [x] Update the README and applicable `/docs` pages
- [x] Verify that examples build and run
