### PR TITLE
refactor(core): simplify utility APIs and theme lookup

### DIFF
--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/BoundChatBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/audience/BoundChatBuilder.kt
@@ -28,8 +28,9 @@ internal open class BoundChatBuilder : BoundChatScope {
         target = component.asComponent()
     }
 
-    internal fun buildBound(): ChatType.Bound {
-        val name = checkNotNull(name) { "'name' is not set." }
-        return (type ?: ChatType.CHAT).bind(name, target)
-    }
+    internal fun buildBound(): ChatType.Bound =
+        (type ?: ChatType.CHAT).bind(
+            checkNotNull(name) { "'name' is not set." },
+            target,
+        )
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Color.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Color.kt
@@ -4,7 +4,14 @@ import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.util.HSVLike
 import org.jetbrains.annotations.Range
 
-private val hexColorPattern: Regex = Regex("#[0-9A-Fa-f]{6}")
+private const val MIN_COLOR_CHANNEL: Int = 0
+private const val MAX_COLOR_CHANNEL: Int = 255
+private const val MIN_UNIT_FLOAT: Float = 0f
+private const val MAX_UNIT_FLOAT: Float = 1f
+
+private val ColorChannelRange: IntRange = MIN_COLOR_CHANNEL..MAX_COLOR_CHANNEL
+private val UnitFloatRange: ClosedFloatingPointRange<Float> = MIN_UNIT_FLOAT..MAX_UNIT_FLOAT
+private val HexColorPattern: Regex = Regex("#[0-9a-f]{6}", RegexOption.IGNORE_CASE)
 
 /**
  * Creates a [TextColor] from an exact `#RRGGBB` hex string.
@@ -15,12 +22,12 @@ private val hexColorPattern: Regex = Regex("#[0-9A-Fa-f]{6}")
  * @throws IllegalArgumentException when [value] is not exactly `#RRGGBB`.
  */
 public fun hex(value: String): TextColor {
-    require(hexColorPattern.matches(value)) {
+    require(HexColorPattern.matches(value)) {
         "Hex colors must use the exact #RRGGBB format, but was <$value>."
     }
-    return requireNotNull(TextColor.fromHexString(value)) {
-        "Adventure could not create a TextColor from <$value>."
-    }
+
+    return TextColor.fromHexString(value)
+        ?: error("Adventure could not create a TextColor from validated hex color <$value>.")
 }
 
 /**
@@ -39,6 +46,7 @@ public fun rgb(
     requireColorChannel("red", red)
     requireColorChannel("green", green)
     requireColorChannel("blue", blue)
+
     return TextColor.color(red, green, blue)
 }
 
@@ -48,16 +56,17 @@ public fun rgb(
  * @param hue the hue, `0f..1f`.
  * @param saturation the saturation, `0f..1f`.
  * @param value the brightness value, `0f..1f`.
- * @throws IllegalArgumentException when any component is outside `0f..1f`.
+ * @throws IllegalArgumentException when any component is not finite or is outside `0f..1f`.
  */
 public fun hsv(
     hue: Float,
     saturation: Float,
     value: Float,
 ): TextColor {
-    requireHsvComponent("hue", hue)
-    requireHsvComponent("saturation", saturation)
-    requireHsvComponent("value", value)
+    requireFiniteUnitFloat("hue", hue)
+    requireFiniteUnitFloat("saturation", saturation)
+    requireFiniteUnitFloat("value", value)
+
     return TextColor.color(HSVLike.hsvLike(hue, saturation, value))
 }
 
@@ -78,6 +87,7 @@ public fun interpolate(
     require(progress.isFinite()) {
         "progress must be finite, but was <$progress>."
     }
+
     return TextColor.lerp(progress, start, end)
 }
 
@@ -85,16 +95,19 @@ private fun requireColorChannel(
     name: String,
     value: Int,
 ) {
-    require(value in 0..255) {
-        "$name must be in the 0..255 range, but was <$value>."
+    require(value in ColorChannelRange) {
+        "$name must be in the $MIN_COLOR_CHANNEL..$MAX_COLOR_CHANNEL range, but was <$value>."
     }
 }
 
-private fun requireHsvComponent(
+private fun requireFiniteUnitFloat(
     name: String,
     value: Float,
 ) {
-    require(value in 0f..1f) {
-        "$name must be in the 0f..1f range, but was <$value>."
+    require(value.isFinite()) {
+        "$name must be finite, but was <$value>."
+    }
+    require(value in UnitFloatRange) {
+        "$name must be in the ${MIN_UNIT_FLOAT}..${MAX_UNIT_FLOAT} range, but was <$value>."
     }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Color.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Color.kt
@@ -10,7 +10,7 @@ private const val MIN_UNIT_FLOAT: Float = 0f
 private const val MAX_UNIT_FLOAT: Float = 1f
 
 private val ColorChannelRange: IntRange = MIN_COLOR_CHANNEL..MAX_COLOR_CHANNEL
-private val UnitFloatRange: ClosedFloatingPointRange<Float> = MIN_UNIT_FLOAT..MAX_UNIT_FLOAT
+private val ZeroToOneRange: ClosedFloatingPointRange<Float> = MIN_UNIT_FLOAT..MAX_UNIT_FLOAT
 private val HexColorPattern: Regex = Regex("#[0-9a-f]{6}", RegexOption.IGNORE_CASE)
 
 /**
@@ -63,9 +63,9 @@ public fun hsv(
     saturation: Float,
     value: Float,
 ): TextColor {
-    requireFiniteUnitFloat("hue", hue)
-    requireFiniteUnitFloat("saturation", saturation)
-    requireFiniteUnitFloat("value", value)
+    requireNormalisedHsvComponent(hue)
+    requireNormalisedHsvComponent(saturation)
+    requireNormalisedHsvComponent(value)
 
     return TextColor.color(HSVLike.hsvLike(hue, saturation, value))
 }
@@ -100,14 +100,11 @@ private fun requireColorChannel(
     }
 }
 
-private fun requireFiniteUnitFloat(
-    name: String,
-    value: Float,
-) {
+private fun requireNormalisedHsvComponent(value: Float) {
     require(value.isFinite()) {
-        "$name must be finite, but was <$value>."
+        "HSV component must be finite, but was <$value>."
     }
-    require(value in UnitFloatRange) {
-        "$name must be in the ${MIN_UNIT_FLOAT}..${MAX_UNIT_FLOAT} range, but was <$value>."
+    require(value in ZeroToOneRange) {
+        "HSV component must be in the ${MIN_UNIT_FLOAT}..${MAX_UNIT_FLOAT} range, but was <$value>."
     }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
@@ -5,6 +5,7 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.TextColor
 import kotlin.math.floor
 import kotlin.math.min
+import kotlin.streams.asSequence
 
 /**
  * An immutable colour gradient with an ordered list of two or more [TextColor] stops.
@@ -18,12 +19,7 @@ public class ColorGradient internal constructor(
     stops: Iterable<TextColor>,
 ) {
     /** An immutable copy of the colour stops in interpolation order. */
-    public val stops: List<TextColor> =
-        stops.toList().also { copiedStops ->
-            require(copiedStops.size >= 2) {
-                "A color gradient requires at least 2 stops."
-            }
-        }
+    public val stops: List<TextColor> = stops.toGradientStops()
 
     /**
      * Returns the interpolated colour at [progress].
@@ -36,11 +32,19 @@ public class ColorGradient internal constructor(
         require(progress.isFinite()) {
             "Gradient progress must be finite, but was <$progress>."
         }
-        val clampedProgress = progress.coerceIn(0f, 1f)
-        val scaledProgress = clampedProgress * (stops.size - 1)
-        val segmentIndex = min(floor(scaledProgress).toInt(), stops.lastIndex - 1)
-        val segmentProgress = scaledProgress - segmentIndex
-        return interpolate(segmentProgress, stops[segmentIndex], stops[segmentIndex + 1])
+
+        val scaledProgress = progress.coerceIn(0f, 1f) * stops.lastIndex
+        val startIndex =
+            floor(scaledProgress)
+                .toInt()
+                .coerceAtMost(stops.lastIndex - 1)
+        val segmentProgress = scaledProgress - startIndex
+
+        return interpolate(
+            progress = segmentProgress,
+            start = stops[startIndex],
+            end = stops[startIndex + 1],
+        )
     }
 }
 
@@ -90,28 +94,29 @@ public fun gradientText(
     value: String,
     gradient: ColorGradient,
 ): Component {
-    val children = gradientTextChildren(value, gradient)
-    if (children.isEmpty()) {
-        return emptyComponent()
+    if (value.isEmpty()) return emptyComponent()
+
+    val codePoints = value.toCodePointStrings()
+    val lastIndex = codePoints.lastIndex.toFloat()
+    val builder = Component.text()
+
+    codePoints.forEachIndexed { index, text ->
+        val progress = if (codePoints.size == 1) 0f else index / lastIndex
+        builder.append(Component.text(text).color(gradient.colorAt(progress)))
     }
 
-    val builder = Component.text()
-    children.forEach { child -> builder.append(child) }
     return builder.build()
 }
 
-private fun gradientTextChildren(
-    value: String,
-    gradient: ColorGradient,
-): List<Component> {
-    val codePoints = value.toCodePointStrings()
-    return codePoints.mapIndexed { index, text ->
-        val progress = if (codePoints.size == 1) 0f else index.toFloat() / codePoints.lastIndex.toFloat()
-        Component.text(text).color(gradient.colorAt(progress))
+private fun Iterable<TextColor>.toGradientStops(): List<TextColor> =
+    toList().also { stops ->
+        require(stops.size >= 2) {
+            "A color gradient requires at least 2 stops."
+        }
     }
-}
 
 private fun String.toCodePointStrings(): List<String> =
     codePoints()
-        .toArray()
+        .asSequence()
         .map { codePoint -> String(Character.toChars(codePoint)) }
+        .toList()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/color/Gradient.kt
@@ -1,6 +1,8 @@
 package io.github.lmliam.kotventure.core.color
 
+import io.github.lmliam.kotventure.core.component.component
 import io.github.lmliam.kotventure.core.component.emptyComponent
+import io.github.lmliam.kotventure.core.text.text
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.TextColor
 import kotlin.math.floor
@@ -19,7 +21,7 @@ public class ColorGradient internal constructor(
     stops: Iterable<TextColor>,
 ) {
     /** An immutable copy of the colour stops in interpolation order. */
-    public val stops: List<TextColor> = stops.toGradientStops()
+    public val stops: List<TextColor> = copyAndValidateStops(stops)
 
     /**
      * Returns the interpolated colour at [progress].
@@ -98,19 +100,19 @@ public fun gradientText(
 
     val codePoints = value.toCodePointStrings()
     val lastIndex = codePoints.lastIndex.toFloat()
-    val builder = Component.text()
-
-    codePoints.forEachIndexed { index, text ->
-        val progress = if (codePoints.size == 1) 0f else index / lastIndex
-        builder.append(Component.text(text).color(gradient.colorAt(progress)))
+    return component {
+        codePoints.forEachIndexed { index, codePoint ->
+            val progress = if (codePoints.size == 1) 0f else index / lastIndex
+            text(codePoint) {
+                color(gradient.colorAt(progress))
+            }
+        }
     }
-
-    return builder.build()
 }
 
-private fun Iterable<TextColor>.toGradientStops(): List<TextColor> =
-    toList().also { stops ->
-        require(stops.size >= 2) {
+private fun copyAndValidateStops(stops: Iterable<TextColor>): List<TextColor> =
+    stops.toList().also { copiedStops ->
+        require(copiedStops.size >= 2) {
             "A color gradient requires at least 2 stops."
         }
     }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistry.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistry.kt
@@ -17,12 +17,19 @@ import kotlin.concurrent.withLock
  */
 public class ThemeRegistry {
     private val lock = ReentrantLock()
-    private val providers: MutableMap<String, ThemeProvider> = mutableMapOf()
+    private val providers = mutableMapOf<String, ThemeProvider>()
     private var defaultProvider: ThemeProvider? = null
+
+    /**
+     * This registry's default theme provider, or `null` when none exists.
+     */
+    public val defaultTheme: ThemeProvider?
+        get() = lock.withLock { defaultProvider }
 
     /**
      * Registers [provider], optionally marking it as this registry's default theme.
      *
+     * @return [provider]
      * @throws IllegalArgumentException when the provider name is blank, already registered, or
      * when [default] is true and this registry already has a default theme.
      */
@@ -30,19 +37,24 @@ public class ThemeRegistry {
         provider: T,
         default: Boolean = false,
     ): T {
-        val providerName = requireProviderName(provider)
+        val providerName = provider.requireName()
+
         lock.withLock {
             require(providerName !in providers) {
                 "Theme provider '$providerName' is already registered."
             }
-            require(!default || defaultProvider == null) {
-                "Default theme provider '${checkNotNull(defaultProvider).name}' is already registered."
+
+            val currentDefault = defaultProvider
+            require(!default || currentDefault == null) {
+                "Default theme provider '${currentDefault?.name}' is already registered."
             }
+
             providers[providerName] = provider
             if (default) {
                 defaultProvider = provider
             }
         }
+
         return provider
     }
 
@@ -50,9 +62,9 @@ public class ThemeRegistry {
      * Registers [provider], replacing any existing provider with the same name.
      *
      * Use this for hot-reload: a second registration of the same name is intentional. When
-     * [default] is `true`, [provider] becomes the sole default (any previous default is cleared).
-     * When [default] is `false`, replacement of the current default with the same name clears the default. A different
-     * theme that is already the default does not change.
+     * [default] is `true`, [provider] becomes the sole default. When [default] is `false`,
+     * replacement of the current default clears the default. A different theme that is already
+     * the default does not change.
      *
      * @return [provider]
      * @throws IllegalArgumentException when the provider name is blank.
@@ -61,14 +73,17 @@ public class ThemeRegistry {
         provider: T,
         default: Boolean = false,
     ): T {
-        val providerName = requireProviderName(provider)
+        val providerName = provider.requireName()
+
         lock.withLock {
             val previous = providers.put(providerName, provider)
+
             when {
                 default -> defaultProvider = provider
-                previous != null && defaultProvider === previous -> defaultProvider = null
+                previous === defaultProvider -> defaultProvider = null
             }
         }
+
         return provider
     }
 
@@ -84,12 +99,9 @@ public class ThemeRegistry {
      */
     public fun <T : ThemeProvider> unregister(provider: T): T? =
         lock.withLock {
-            val current = providers[provider.name]
-            if (current !== provider) {
-                return@withLock null
-            }
-            removeRegistered(provider.name, provider)
             provider
+                .takeIf { providers[provider.name] === provider }
+                ?.also { removeRegistered(provider.name) }
         }
 
     /**
@@ -104,41 +116,36 @@ public class ThemeRegistry {
      */
     public fun unregister(name: String): ThemeProvider? =
         lock.withLock {
-            val removed = providers[name] ?: return@withLock null
-            removeRegistered(name, removed)
-            removed
+            removeRegistered(name)
         }
 
     /**
      * Returns the theme provider registered as [name], or `null` when none exists.
      */
-    public fun theme(name: String): ThemeProvider? =
+    public operator fun get(name: String): ThemeProvider? =
         lock.withLock {
             providers[name]
         }
 
     /**
-     * Returns this registry's default theme provider, or `null` when none
-     * exists.
+     * Returns the theme provider registered as [name], or `null` when none exists.
      */
-    public fun defaultTheme(): ThemeProvider? =
-        lock.withLock {
-            defaultProvider
+    public fun theme(name: String): ThemeProvider? = get(name)
+
+    /**
+     * Returns this registry's default theme provider, or `null` when none exists.
+     */
+    public fun defaultTheme(): ThemeProvider? = defaultTheme
+
+    private fun removeRegistered(name: String): ThemeProvider? =
+        providers.remove(name)?.also { removed ->
+            if (defaultProvider === removed) {
+                defaultProvider = null
+            }
         }
 
-    private fun removeRegistered(
-        name: String,
-        removed: ThemeProvider,
-    ) {
-        providers.remove(name)
-        if (defaultProvider === removed) {
-            defaultProvider = null
+    private fun ThemeProvider.requireName(): String =
+        name.also {
+            require(it.isNotBlank()) { "Theme provider name must not be blank." }
         }
-    }
-
-    private fun requireProviderName(provider: ThemeProvider): String {
-        val providerName = provider.name
-        require(providerName.isNotBlank()) { "Theme provider name must not be blank." }
-        return providerName
-    }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistry.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistry.kt
@@ -38,7 +38,7 @@ public class ThemeRegistry {
         provider: T,
         default: Boolean = false,
     ): T {
-        val providerName = provider.requireName()
+        val providerName = requireThemeName(provider.name)
 
         lock.withLock {
             require(providerName !in providers) {
@@ -74,7 +74,7 @@ public class ThemeRegistry {
         provider: T,
         default: Boolean = false,
     ): T {
-        val providerName = provider.requireName()
+        val providerName = requireThemeName(provider.name)
 
         lock.withLock {
             val previous = providers.put(providerName, provider)
@@ -100,7 +100,7 @@ public class ThemeRegistry {
      * @throws IllegalArgumentException when the provider name is blank.
      */
     public fun <T : ThemeProvider> unregister(provider: T): T? {
-        val providerName = provider.requireName()
+        val providerName = requireThemeName(provider.name)
 
         return lock.withLock {
             provider
@@ -121,7 +121,7 @@ public class ThemeRegistry {
      * @throws IllegalArgumentException when [name] is blank.
      */
     public fun unregister(name: String): ThemeProvider? {
-        val themeName = name.requireName()
+        val themeName = requireThemeName(name)
 
         return lock.withLock {
             removeRegistered(themeName)
@@ -134,7 +134,7 @@ public class ThemeRegistry {
      * @throws IllegalArgumentException when [name] is blank.
      */
     public operator fun get(name: String): ThemeProvider? {
-        val themeName = name.requireName()
+        val themeName = requireThemeName(name)
 
         return lock.withLock {
             providers[themeName]
@@ -160,10 +160,8 @@ public class ThemeRegistry {
             }
         }
 
-    private fun ThemeProvider.requireName(): String = name.requireName()
-
-    private fun String.requireName(): String =
-        also {
-            require(it.isNotBlank()) { "Theme provider name must not be blank." }
+    private fun requireThemeName(name: String): String =
+        name.also {
+            require(it.isNotBlank()) { "Theme name must not be blank." }
         }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistry.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/theme/ThemeRegistry.kt
@@ -30,8 +30,9 @@ public class ThemeRegistry {
      * Registers [provider], optionally marking it as this registry's default theme.
      *
      * @return [provider]
-     * @throws IllegalArgumentException when the provider name is blank, already registered, or
-     * when [default] is true and this registry already has a default theme.
+     * @throws IllegalArgumentException when the provider name is blank or already registered.
+     * @throws IllegalStateException when [default] is true and this registry already has a default
+     * theme.
      */
     public fun <T : ThemeProvider> register(
         provider: T,
@@ -45,7 +46,7 @@ public class ThemeRegistry {
             }
 
             val currentDefault = defaultProvider
-            require(!default || currentDefault == null) {
+            check(!default || currentDefault == null) {
                 "Default theme provider '${currentDefault?.name}' is already registered."
             }
 
@@ -96,13 +97,17 @@ public class ThemeRegistry {
      * When the removed provider was the default theme, the default is cleared.
      *
      * @return [provider] when it was removed, or null when it is not the registered instance.
+     * @throws IllegalArgumentException when the provider name is blank.
      */
-    public fun <T : ThemeProvider> unregister(provider: T): T? =
-        lock.withLock {
+    public fun <T : ThemeProvider> unregister(provider: T): T? {
+        val providerName = provider.requireName()
+
+        return lock.withLock {
             provider
-                .takeIf { providers[provider.name] === provider }
-                ?.also { removeRegistered(provider.name) }
+                .takeIf { providers[providerName] === provider }
+                ?.also { removeRegistered(providerName) }
         }
+    }
 
     /**
      * Removes the theme registered as [name].
@@ -113,22 +118,33 @@ public class ThemeRegistry {
      * When the removed provider was the default theme, the default is cleared.
      *
      * @return the removed provider, or null when [name] was not registered.
+     * @throws IllegalArgumentException when [name] is blank.
      */
-    public fun unregister(name: String): ThemeProvider? =
-        lock.withLock {
-            removeRegistered(name)
+    public fun unregister(name: String): ThemeProvider? {
+        val themeName = name.requireName()
+
+        return lock.withLock {
+            removeRegistered(themeName)
         }
+    }
 
     /**
      * Returns the theme provider registered as [name], or `null` when none exists.
+     *
+     * @throws IllegalArgumentException when [name] is blank.
      */
-    public operator fun get(name: String): ThemeProvider? =
-        lock.withLock {
-            providers[name]
+    public operator fun get(name: String): ThemeProvider? {
+        val themeName = name.requireName()
+
+        return lock.withLock {
+            providers[themeName]
         }
+    }
 
     /**
      * Returns the theme provider registered as [name], or `null` when none exists.
+     *
+     * @throws IllegalArgumentException when [name] is blank.
      */
     public fun theme(name: String): ThemeProvider? = get(name)
 
@@ -144,8 +160,10 @@ public class ThemeRegistry {
             }
         }
 
-    private fun ThemeProvider.requireName(): String =
-        name.also {
+    private fun ThemeProvider.requireName(): String = name.requireName()
+
+    private fun String.requireName(): String =
+        also {
             require(it.isNotBlank()) { "Theme provider name must not be blank." }
         }
 }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/color/ColorDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/color/ColorDslTest.kt
@@ -52,6 +52,23 @@ class ColorDslTest :
                 }
             }
 
+            "rejects non-finite HSV components and interpolation progress" {
+                listOf(Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY).forEach { value ->
+                    shouldThrow<IllegalArgumentException> {
+                        hsv(value, 0f, 0f)
+                    }
+                    shouldThrow<IllegalArgumentException> {
+                        hsv(0f, value, 0f)
+                    }
+                    shouldThrow<IllegalArgumentException> {
+                        hsv(0f, 0f, value)
+                    }
+                    shouldThrow<IllegalArgumentException> {
+                        interpolate(value, NamedTextColor.BLACK, NamedTextColor.WHITE)
+                    }
+                }
+            }
+
             "delegates interpolation to Adventure TextColor lerp behavior" {
                 interpolate(0f, NamedTextColor.BLACK, NamedTextColor.WHITE) shouldBe NamedTextColor.BLACK
                 interpolate(0.5f, NamedTextColor.BLACK, NamedTextColor.WHITE).asHexString() shouldBe "#808080"

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeLookupTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeLookupTest.kt
@@ -22,13 +22,26 @@ class ThemeLookupTest :
                 ThemeRegistry().theme("missing").shouldBeNull()
             }
 
+            "resolves registered themes through operator lookup" {
+                val registry = ThemeRegistry()
+                val provider = TestThemeProvider("brand")
+
+                registry.register(provider)
+
+                registry["brand"] shouldBe provider
+            }
+
+            "returns null for unknown names through operator lookup" {
+                ThemeRegistry()["missing"].shouldBeNull()
+            }
+
             "resolves the registered default theme" {
                 val registry = ThemeRegistry()
                 val provider = TestThemeProvider("server")
 
                 registry.register(provider, default = true)
 
-                registry.defaultTheme shouldBe provider
+                registry.defaultTheme() shouldBe provider
             }
 
             "returns null when no default theme is registered" {
@@ -60,8 +73,31 @@ class ThemeLookupTest :
 
                 registry.register(TestThemeProvider("brand"), default = true)
 
-                shouldThrow<IllegalArgumentException> {
+                shouldThrow<IllegalStateException> {
                     registry.register(TestThemeProvider("server"), default = true)
+                }
+            }
+
+            "rejects blank provider names when unregistering by object" {
+                shouldThrow<IllegalArgumentException> {
+                    ThemeRegistry().unregister(TestThemeProvider(" "))
+                }
+            }
+
+            "rejects blank theme names when unregistering by name" {
+                shouldThrow<IllegalArgumentException> {
+                    ThemeRegistry().unregister(" ")
+                }
+            }
+
+            "rejects blank theme names through lookup accessors" {
+                val registry = ThemeRegistry()
+
+                shouldThrow<IllegalArgumentException> {
+                    registry[" "]
+                }
+                shouldThrow<IllegalArgumentException> {
+                    registry.theme(" ")
                 }
             }
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeLookupTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/theme/ThemeLookupTest.kt
@@ -28,7 +28,7 @@ class ThemeLookupTest :
 
                 registry.register(provider, default = true)
 
-                registry.defaultTheme() shouldBe provider
+                registry.defaultTheme shouldBe provider
             }
 
             "returns null when no default theme is registered" {
@@ -36,7 +36,7 @@ class ThemeLookupTest :
 
                 registry.register(TestThemeProvider("brand"))
 
-                registry.defaultTheme().shouldBeNull()
+                registry.defaultTheme.shouldBeNull()
             }
 
             "rejects blank provider names" {
@@ -112,7 +112,7 @@ class ThemeLookupTest :
                 registry.register(provider, default = true)
 
                 registry.unregister(provider) shouldBe provider
-                registry.defaultTheme().shouldBeNull()
+                registry.defaultTheme.shouldBeNull()
             }
 
             "unregister by name clears the default when the default theme is removed" {
@@ -122,7 +122,7 @@ class ThemeLookupTest :
                 registry.register(provider, default = true)
 
                 registry.unregister("brand") shouldBe provider
-                registry.defaultTheme().shouldBeNull()
+                registry.defaultTheme.shouldBeNull()
             }
 
             "unregister leaves another default intact when removing a non-default theme" {
@@ -134,7 +134,7 @@ class ThemeLookupTest :
                 registry.register(server)
 
                 registry.unregister(server) shouldBe server
-                registry.defaultTheme() shouldBe brand
+                registry.defaultTheme shouldBe brand
             }
 
             "replace swaps a theme under the same name" {
@@ -165,7 +165,7 @@ class ThemeLookupTest :
                 registry.register(brand, default = true)
                 registry.replace(server, default = true)
 
-                registry.defaultTheme() shouldBe server
+                registry.defaultTheme shouldBe server
                 registry.theme("brand") shouldBe brand
             }
 
@@ -178,7 +178,7 @@ class ThemeLookupTest :
                 registry.replace(reloaded)
 
                 registry.theme("brand") shouldBe reloaded
-                registry.defaultTheme().shouldBeNull()
+                registry.defaultTheme.shouldBeNull()
             }
 
             "replace without default leaves a different default theme intact" {
@@ -192,7 +192,7 @@ class ThemeLookupTest :
                 registry.replace(serverReload)
 
                 registry.theme("server") shouldBe serverReload
-                registry.defaultTheme() shouldBe brand
+                registry.defaultTheme shouldBe brand
             }
 
             "replace rejects blank provider names" {
@@ -210,7 +210,7 @@ class ThemeLookupTest :
                 registry.replace(reloaded, default = true)
 
                 registry.theme("brand") shouldBe reloaded
-                registry.defaultTheme() shouldBe reloaded
+                registry.defaultTheme shouldBe reloaded
             }
         },
     )


### PR DESCRIPTION
## Summary

Simplify foundational core utility APIs and theme lookup.

## Scope

- Simplify BoundChatBuilder and the colour and gradient DSL.
- Refine ThemeRegistry lookup behaviour.
- Keep the related ColorDslTest and ThemeLookupTest coverage with the production changes.

## Rationale

This is the lowest-level core refactor. Later layers can build on the reduced utility API without mixing in rendering, lifecycle, or parser behaviour.

## Testing

- `./gradlew :core:test --tests 'io.github.lmliam.kotventure.core.color.ColorDslTest' --tests 'io.github.lmliam.kotventure.core.theme.ThemeLookupTest'`
- `./gradlew :core:spotlessCheck`

## Stack

This PR is part of the stacked replacement for #344.

- Depends on: `master`
- Followed by: [#346](https://github.com/LMLiam/Kotventure/pull/346)