### PR TITLE
refactor(virtual): simplify virtual rendering scopes

### DIFF
--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/Virtual.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/Virtual.kt
@@ -8,31 +8,30 @@ import kotlin.jvm.javaObjectType
 /**
  * Creates a [VirtualComponent] that resolves from a render context of type [C].
  *
- * The [build] block configures two appearances. A [VirtualScope.render] block builds the content that a platform shows
- * at display time. A [VirtualScope.fallback] sets the stand-in that a serialiser or a console shows when no platform
- * renders the component. The function only creates the component. Use [Component.render] to render it in `core`.
+ * The [init] block configures two appearances. [VirtualScope.render] builds the content shown after rendering, while
+ * [VirtualScope.fallback] configures the static representation used before rendering. This function only constructs a
+ * component. Use [Component.render] to resolve it in `core`.
  *
  * @sample io.github.lmliam.kotventure.core.virtual.virtualSample
  *
  * @param C the render context type.
- * @param build configures the [VirtualScope.fallback] and [VirtualScope.render] slots.
- * @throws IllegalStateException when [build] sets no render block, or sets a write-once slot more than once.
+ * @param init configures the fallback and render slots.
+ * @throws IllegalStateException when [init] omits the render block or assigns a write-once slot more than once.
  */
-public inline fun <reified C : Any> virtual(noinline build: VirtualScope<C>.() -> Unit): VirtualComponent =
-    buildVirtual(C::class.javaObjectType, build)
+public inline fun <reified C : Any> virtual(noinline init: VirtualScope<C>.() -> Unit): VirtualComponent =
+    buildVirtualComponent(C::class.javaObjectType, init)
 
 /**
  * Creates a virtual component and appends it as the next child of this scope.
  *
- * The [build] block configures the same [VirtualScope.render] and [VirtualScope.fallback] slots as the top-level
- * [virtual] function.
+ * The [init] block configures the same [VirtualScope.render] and [VirtualScope.fallback] slots as [virtual].
  *
  * @param C the render context type.
- * @param build configures the [VirtualScope.fallback] and [VirtualScope.render] slots.
- * @throws IllegalStateException when [build] sets no render block, or sets a write-once slot more than once.
+ * @param init configures the fallback and render slots.
+ * @throws IllegalStateException when [init] omits the render block or assigns a write-once slot more than once.
  */
-public inline fun <reified C : Any> ComponentScope.virtual(noinline build: VirtualScope<C>.() -> Unit) {
-    append(buildVirtual(C::class.javaObjectType, build))
+public inline fun <reified C : Any> ComponentScope.virtual(noinline init: VirtualScope<C>.() -> Unit) {
+    append(buildVirtualComponent(C::class.javaObjectType, init))
 }
 
 /**
@@ -40,9 +39,9 @@ public inline fun <reified C : Any> ComponentScope.virtual(noinline build: Virtu
  *
  * Contexts are checked in call order, and the first context accepted by each virtual renderer supplies its result.
  * The operation recursively renders every component-bearing slot, including components introduced by a renderer. A
- * virtual component with no matching context stays unchanged and can be rendered by a later call.
- * A matching result replaces the complete virtual component, including its fallback style and children.
- * Exceptions thrown by a virtual renderer propagate unchanged.
+ * virtual component with no matching context stays unchanged and can be rendered by a later call. A matching result
+ * replaces the complete virtual component, including its fallback style and children. Exceptions thrown by a virtual
+ * renderer propagate unchanged.
  *
  * @param context the first render context.
  * @param additionalContexts the other render contexts, in selection order.
@@ -55,7 +54,7 @@ public fun Component.render(
 ): Component = VirtualTreeRenderer.render(this, VirtualRenderState(context, *additionalContexts))
 
 @PublishedApi
-internal fun <C : Any> buildVirtual(
+internal fun <C : Any> buildVirtualComponent(
     contextType: Class<C>,
-    build: VirtualScope<C>.() -> Unit,
-): VirtualComponent = VirtualBuilder(contextType).apply(build).build()
+    init: VirtualScope<C>.() -> Unit,
+): VirtualComponent = VirtualBuilder(contextType).apply(init).build()

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualBuilder.kt
@@ -8,46 +8,47 @@ import net.kyori.adventure.text.VirtualComponent
 import net.kyori.adventure.text.format.Style
 
 /**
- * Builds a [VirtualComponent] from the slots in [VirtualScope].
+ * Collects [VirtualScope] state and builds one [VirtualComponent].
  *
- * A render block is required.
- * The fallback has no content, style, or children when it is not set.
+ * The render block is required.
+ * An omitted fallback produces an empty fallback string with no style or children.
  *
  * @param C the render context type.
- * @property contextType the render context class that the component reports.
+ * @property contextType the context class exposed by the resulting virtual component
  */
 internal class VirtualBuilder<C : Any>(
     private val contextType: Class<C>,
 ) : VirtualScope<C> {
-    private var fallback: Fallback? by once()
-    private var render: (VirtualRenderScope<C>.() -> Unit)? by once()
+    private var fallback: VirtualFallback? by once()
+    private var renderBlock: VirtualRenderBlock<C>? by once { "'render' is already set." }
 
     override fun fallback(text: String) {
-        fallback = Fallback(text)
+        fallback = VirtualFallback(content = text)
     }
 
-    override fun fallback(build: ComponentScope.() -> Unit) {
-        val component = component(build)
-        fallback = Fallback(style = component.style(), children = component.children())
+    override fun fallback(init: ComponentScope.() -> Unit) {
+        fallback = buildVirtualFallback(init)
     }
 
-    override fun render(build: VirtualRenderScope<C>.() -> Unit) {
-        render = build
+    override fun render(init: VirtualRenderScope<C>.() -> Unit) {
+        renderBlock = init
     }
 
-    fun build(): VirtualComponent {
-        val render = checkNotNull(render) { "'render' is required" }
-        val resolvedFallback = fallback ?: Fallback()
-        val renderer = VirtualScopeRenderer(render, resolvedFallback.content)
+    internal fun build(): VirtualComponent {
+        val renderBlock = checkNotNull(renderBlock) { "'render' is not set." }
+        val fallback = fallback ?: VirtualFallback()
+        val renderer =
+            VirtualScopeRenderer(
+                renderBlock = renderBlock,
+                fallbackText = fallback.content,
+            )
 
         return Component
-            .virtual(contextType, renderer, resolvedFallback.style)
-            .children(resolvedFallback.children) as VirtualComponent
+            .virtual(contextType, renderer, fallback.style)
+            .withChildren(fallback.children)
     }
-
-    private data class Fallback(
-        val content: String = "",
-        val style: Style = Style.empty(),
-        val children: List<Component> = emptyList(),
-    )
 }
+
+// Adventure preserves the virtual subtype, but the Java API exposes Component as the return type
+private fun VirtualComponent.withChildren(children: List<Component>): VirtualComponent =
+    if (children.isEmpty()) this else children(children) as VirtualComponent

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualFallback.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualFallback.kt
@@ -1,0 +1,24 @@
+package io.github.lmliam.kotventure.core.virtual
+
+import io.github.lmliam.kotventure.core.component.ComponentScope
+import io.github.lmliam.kotventure.core.component.component
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.Style
+
+/**
+ * An immutable snapshot of a virtual component's fallback text, style, and children.
+ */
+internal data class VirtualFallback(
+    val content: String = "",
+    val style: Style = Style.empty(),
+    val children: List<Component> = emptyList(),
+)
+
+internal fun buildVirtualFallback(init: ComponentScope.() -> Unit): VirtualFallback {
+    val component = component(init)
+
+    return VirtualFallback(
+        style = component.style(),
+        children = component.children(),
+    )
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderScope.kt
@@ -2,13 +2,14 @@ package io.github.lmliam.kotventure.core.virtual
 
 import io.github.lmliam.kotventure.core.component.ComponentScope
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.Component
 
 /**
- * Builds the content of a virtual component from a render [context] of type [C].
+ * Builds virtual-component content from a render [context] of type [C].
  *
- * The platform supplies the [context] and calls the render block at display time. The block can run more than once, and
- * it runs one time for each render. The scope inherits the component surface from [ComponentScope], so it accepts the
- * same style calls and child components as a `component { }` block.
+ * Adventure or [Component.render] supplies [context] when it resolves the virtual component. A render block can run
+ * more than once and receives a new scope for each invocation. The scope exposes the same style and child-component
+ * operations as a `component { }` block.
  *
  * @param C the render context type, for example the viewing player.
  * @sample io.github.lmliam.kotventure.core.virtual.virtualSample
@@ -16,7 +17,9 @@ import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
 @KotventureDslMarker
 public interface VirtualRenderScope<C : Any> : ComponentScope {
     /**
-     * The render context that the platform supplies at display time.
+     * The context supplied for the current render.
      */
     public val context: C
 }
+
+internal typealias VirtualRenderBlock<C> = VirtualRenderScope<C>.() -> Unit

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualScope.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualScope.kt
@@ -2,14 +2,15 @@ package io.github.lmliam.kotventure.core.virtual
 
 import io.github.lmliam.kotventure.core.component.ComponentScope
 import io.github.lmliam.kotventure.core.dsl.KotventureDslMarker
+import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.VirtualComponent
 
 /**
- * Configures the two appearances of a [VirtualComponent].
+ * Configures the fallback and rendered appearances of a [VirtualComponent].
  *
- * A virtual component has two forms. The [render] block builds the content that a platform shows at display time. The
- * [fallback] is the stand-in that a serialiser or a console shows when no platform renders the component. Set a style
- * or add children on the [fallback] block, not on this scope. This scope only holds the [fallback] and [render] slots.
+ * The [render] block builds dynamic content from a render context. The [fallback] is the static representation used
+ * before a renderer resolves the component, such as during serialisation or console output. Static style and children
+ * belong in the fallback block; this scope itself exposes only the two appearance slots.
  *
  * @sample io.github.lmliam.kotventure.core.virtual.virtualSample
  *
@@ -18,36 +19,36 @@ import net.kyori.adventure.text.VirtualComponent
 @KotventureDslMarker
 public interface VirtualScope<C : Any> {
     /**
-     * Sets the plain-text stand-in shown when no platform renders the component.
+     * Sets the plain-text fallback used before the component is rendered.
      *
-     * This form and the [fallback] block form share one write-once slot.
+     * This form and the block form of [fallback] share one write-once slot.
      *
-     * @param text the stand-in text.
-     * @throws IllegalStateException when a fallback is already set in this block.
+     * @param text the fallback text.
+     * @throws IllegalStateException when this block already set a fallback.
      */
     public fun fallback(text: String)
 
     /**
-     * Builds a styled stand-in shown when no platform renders the component.
+     * Builds the styled fallback used before the component is rendered.
      *
-     * The [build] block sets the style and children of the stand-in. This form and the [fallback] text form share one
-     * write-once slot.
+     * The block configures the fallback's static style and children. This form and the text form of [fallback] share
+     * one write-once slot.
      *
      * @sample io.github.lmliam.kotventure.core.virtual.virtualStyledFallbackSample
      *
-     * @param build styles the stand-in and appends any children.
-     * @throws IllegalStateException when a fallback is already set in this block.
+     * @param init styles the fallback and appends its children.
+     * @throws IllegalStateException when this block already set a fallback.
      */
-    public fun fallback(build: ComponentScope.() -> Unit)
+    public fun fallback(init: ComponentScope.() -> Unit)
 
     /**
-     * Sets the block that builds the rendered content from the render context.
+     * Sets the block that builds content from the current render context.
      *
-     * The platform calls [build] at display time with the current context, for example the viewing player. The block
-     * can run more than once. The `core` module never calls it.
+     * Adventure or [Component.render] invokes [init] when it resolves the component. The block can run more
+     * than once and receives a new [VirtualRenderScope] for each invocation.
      *
-     * @param build builds the rendered content from the [VirtualRenderScope.context].
-     * @throws IllegalStateException when a render block is already set in this block.
+     * @param init builds content from [VirtualRenderScope.context].
+     * @throws IllegalStateException when this block already set the render block.
      */
-    public fun render(build: VirtualRenderScope<C>.() -> Unit)
+    public fun render(init: VirtualRenderScope<C>.() -> Unit)
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualScopeRenderer.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualScopeRenderer.kt
@@ -6,20 +6,18 @@ import net.kyori.adventure.text.VirtualComponentRenderer
 /**
  * Adapts a [VirtualRenderScope] block to Adventure's [VirtualComponentRenderer].
  *
- * The type is a `data class` on purpose. Two renderers are equal when they hold the same [render] block and the same
- * [fallback]. Adventure compares the renderer as part of virtual component equality, so this equality lets a test
- * compare a DSL component with a raw `net.kyori` component.
+ * This type is a data class because Adventure includes the renderer in virtual-component equality. Two instances are
+ * equal when they hold the same render block and fallback text.
  *
  * @param C the render context type.
- * @property render the block that builds the component content from the context.
- * @property fallback the text that a serialiser shows when no platform renders the component.
+ * @property renderBlock builds the rendered component from a context.
+ * @property fallbackText the text used when the component is serialised before rendering.
  */
-@PublishedApi
 internal data class VirtualScopeRenderer<C : Any>(
-    val render: VirtualRenderScope<C>.() -> Unit,
-    val fallback: String,
+    val renderBlock: VirtualRenderBlock<C>,
+    val fallbackText: String,
 ) : VirtualComponentRenderer<C> {
-    override fun apply(context: C): ComponentLike = VirtualRenderBuilder(context).apply(render).build()
+    override fun apply(context: C): ComponentLike = VirtualRenderBuilder(context).apply(renderBlock).build()
 
-    override fun fallbackString(): String = fallback
+    override fun fallbackString(): String = fallbackText
 }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualDslTest.kt
@@ -33,7 +33,11 @@ class VirtualDslTest :
                         fallback("player")
                         render(body)
                     }
-                val raw = Component.virtual(Viewer::class.java, VirtualScopeRenderer(body, "player"))
+                val raw =
+                    Component.virtual(
+                        Viewer::class.java,
+                        VirtualScopeRenderer(renderBlock = body, fallbackText = "player"),
+                    )
 
                 dsl shouldBe raw
             }
@@ -52,8 +56,11 @@ class VirtualDslTest :
                     }
                 val raw =
                     Component
-                        .virtual(Viewer::class.java, VirtualScopeRenderer(body, ""), Style.style(NamedTextColor.GOLD))
-                        .children(
+                        .virtual(
+                            Viewer::class.java,
+                            VirtualScopeRenderer(renderBlock = body, fallbackText = ""),
+                            Style.style(NamedTextColor.GOLD),
+                        ).children(
                             listOf(
                                 Component.text("player"),
                                 Component.text(" (online)").color(NamedTextColor.GRAY),

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderingTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/virtual/VirtualRenderingTest.kt
@@ -26,6 +26,7 @@ import io.github.lmliam.kotventure.test.text.shouldBeVirtualComponent
 import io.github.lmliam.kotventure.test.text.shouldContainText
 import io.github.lmliam.kotventure.test.text.shouldHaveArguments
 import io.github.lmliam.kotventure.test.text.shouldHaveChildren
+import io.github.lmliam.kotventure.test.text.shouldHaveColor
 import io.github.lmliam.kotventure.test.text.shouldHaveContent
 import io.github.lmliam.kotventure.test.text.shouldHaveHoverEntity
 import io.github.lmliam.kotventure.test.text.shouldHaveHoverText
@@ -100,6 +101,24 @@ class VirtualRenderingTest :
                 val unmatched = message.render(Locale.UK)
 
                 unmatched.shouldBeVirtualComponent()
+                unmatched.render(Viewer("Alex")) shouldBe renderedText("Alex")
+            }
+
+            "keeps styled fallback children when the context is unmatched" {
+                val message =
+                    virtual<Viewer> {
+                        fallback {
+                            color(red)
+                            text("fallback")
+                            text(" child")
+                        }
+                        render { text(context.name) }
+                    }
+
+                val unmatched = message.render(Locale.UK).shouldBeVirtualComponent()
+
+                unmatched shouldHaveColor red
+                unmatched.shouldHaveChildren(Component.text("fallback"), Component.text(" child"))
                 unmatched.render(Viewer("Alex")) shouldBe renderedText("Alex")
             }
 


### PR DESCRIPTION
## Summary

Simplify virtual rendering scopes and their builder flow.

## Scope

- Refine the virtual builder and renderer scope implementation.
- Keep the VirtualDslTest and VirtualRenderingTest coverage with the rendering changes.

## Rationale

Virtual rendering is an independent core layer above the utility changes and below the lifecycle and selector work.

## Testing

- `./gradlew :core:test --tests 'io.github.lmliam.kotventure.core.virtual.VirtualDslTest' --tests 'io.github.lmliam.kotventure.core.virtual.VirtualRenderingTest'`
- `./gradlew :core:spotlessCheck`

## Stack

This PR is part of the stacked replacement for #344.

- Depends on: [#345](https://github.com/LMLiam/Kotventure/pull/345)
- Followed by: [#347](https://github.com/LMLiam/Kotventure/pull/347)