### PR TITLE
fix(bossbar): harden timed lifecycle shutdown

### DIFF
--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBar.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBar.kt
@@ -75,6 +75,3 @@ public class TimedBossBar internal constructor(
      */
     public fun hide(audience: Audience): Unit = runtime.hide(audience)
 }
-
-private fun TimedBossBarConfig.buildInitialBar(): BossBar =
-    BossBar.bossBar(name(over), progress.from, appearance.color, appearance.overlay, appearance.flags)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarBuilder.kt
@@ -5,6 +5,7 @@ import io.github.lmliam.kotventure.core.bossbar.BossBarAppearanceScope
 import io.github.lmliam.kotventure.core.component.ComponentScope
 import io.github.lmliam.kotventure.core.component.component
 import io.github.lmliam.kotventure.core.dsl.once
+import io.github.lmliam.kotventure.core.dsl.positive
 import io.github.lmliam.kotventure.core.time.Ticker
 import io.github.lmliam.kotventure.core.time.ticks
 import net.kyori.adventure.audience.Audience
@@ -12,6 +13,12 @@ import net.kyori.adventure.bossbar.BossBar
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentLike
 import kotlin.time.Duration
+
+private typealias TimedNameRenderer = (Duration) -> Component
+private typealias TickHandler = TimedBossBar.(remaining: Duration) -> Unit
+private typealias LifecycleHandler = TimedBossBar.() -> Unit
+
+private val DefaultTickInterval: Duration = 1.ticks
 
 /**
  * Validates [TimedBossBarScope] state and starts a [TimedBossBar] for one initial viewer.
@@ -22,14 +29,14 @@ internal class TimedBossBarBuilder(
     private val appearance: BossBarAppearanceBuilder = BossBarAppearanceBuilder(),
 ) : TimedBossBarScope,
     BossBarAppearanceScope by appearance {
-    private var name: ((Duration) -> Component)? by once()
+    private var name: TimedNameRenderer? by once()
 
     // The appearance scope owns `progress` as an overlay name, so this slot uses the endpoint name.
     private var progressEndpoints: TimedBossBarProgress? by once { "'progress' is already set." }
     private var every: Duration? by once()
-    private var onTick: (TimedBossBar.(Duration) -> Unit)? by once()
-    private var onFinish: (TimedBossBar.() -> Unit)? by once()
-    private var onCancel: (TimedBossBar.() -> Unit)? by once()
+    private var onTick: TickHandler? by once()
+    private var onFinish: LifecycleHandler? by once()
+    private var onCancel: LifecycleHandler? by once()
 
     override fun name(init: ComponentScope.() -> Unit): Unit = name(component(init))
 
@@ -49,18 +56,20 @@ internal class TimedBossBarBuilder(
     }
 
     override fun every(interval: Duration) {
-        every = interval.requirePositive(label = "every")
+        require(interval.isFinite()) { "'every' must be finite, was $interval" }
+        require(interval.isPositive()) { "'every' must be positive, was $interval" }
+        every = interval
     }
 
-    override fun onTick(handler: TimedBossBar.(remaining: Duration) -> Unit) {
+    override fun onTick(handler: TickHandler) {
         onTick = handler
     }
 
-    override fun onFinish(handler: TimedBossBar.() -> Unit) {
+    override fun onFinish(handler: LifecycleHandler) {
         onFinish = handler
     }
 
-    override fun onCancel(handler: TimedBossBar.() -> Unit) {
+    override fun onCancel(handler: LifecycleHandler) {
         onCancel = handler
     }
 
@@ -68,20 +77,24 @@ internal class TimedBossBarBuilder(
         over: Duration,
         ticker: Ticker,
         initialViewer: Audience,
-    ): TimedBossBar = TimedBossBar(ticker, toConfig(over), initialViewer)
+    ): TimedBossBar = TimedBossBar(ticker, over.toConfig(), initialViewer)
 
-    private fun toConfig(over: Duration): TimedBossBarConfig {
-        val lifetime = over.requirePositive(label = "over")
-        val interval = every ?: 1.ticks
+    private fun Duration.toConfig(): TimedBossBarConfig {
+        val lifetime =
+            also {
+                require(isFinite()) { "'over' must be finite, was $this" }
+                require(isPositive()) { "'over' must be positive, was $this" }
+            }
+        val interval = every ?: DefaultTickInterval
+
         // A cadence longer than the lifetime would make the first update late.
         require(interval <= lifetime) {
             "'every' ($interval) must not exceed 'over' ($lifetime)."
         }
+
         return TimedBossBarConfig(
             name = checkNotNull(name) { "'name' is not set." },
-            progress =
-                progressEndpoints
-                    ?: TimedBossBarProgress(from = BossBar.MAX_PROGRESS, to = BossBar.MIN_PROGRESS),
+            progress = progressEndpoints ?: TimedBossBarProgress.Countdown,
             appearance = appearance.build(),
             every = interval,
             over = lifetime,
@@ -91,8 +104,3 @@ internal class TimedBossBarBuilder(
         )
     }
 }
-
-private fun Duration.requirePositive(label: String): Duration =
-    also {
-        require(isPositive()) { "'$label' must be positive, got $this." }
-    }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarConfig.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarConfig.kt
@@ -1,6 +1,7 @@
 package io.github.lmliam.kotventure.core.bossbar.timed
 
 import io.github.lmliam.kotventure.core.bossbar.BossBarAppearance
+import net.kyori.adventure.bossbar.BossBar
 import net.kyori.adventure.text.Component
 import kotlin.time.Duration
 
@@ -19,4 +20,7 @@ internal data class TimedBossBarConfig(
     val onTick: (TimedBossBar.(Duration) -> Unit)?,
     val onFinish: (TimedBossBar.() -> Unit)?,
     val onCancel: (TimedBossBar.() -> Unit)?,
-)
+) {
+    fun buildInitialBar(): BossBar =
+        BossBar.bossBar(name(over), progress.from, appearance.color, appearance.overlay, appearance.flags)
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarProgress.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarProgress.kt
@@ -29,4 +29,9 @@ internal data class TimedBossBarProgress(
         val elapsedFraction = 1.0 - (remaining / over)
         return from + ((to - from) * elapsedFraction).toFloat()
     }
+
+    companion object {
+        val Countdown: TimedBossBarProgress =
+            TimedBossBarProgress(from = BossBar.MAX_PROGRESS, to = BossBar.MIN_PROGRESS)
+    }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarRuntime.kt
@@ -37,32 +37,35 @@ internal class TimedBossBarRuntime(
     private var tickGeneration: Int = 0
 
     val remaining: Duration
-        get() = lock.withLock { remainingTime }
+        get() = locked { remainingTime }
 
     val isRunning: Boolean
-        get() = lock.withLock { running }
+        get() = locked { running }
 
     val isPaused: Boolean
-        get() = lock.withLock { paused }
+        get() = locked { paused }
 
     fun start(initialViewer: Audience) {
         show(initialViewer)
-        startTicking()
+        locked {
+            if (running) startTicking()
+        }
     }
 
     fun pause() {
         val toCancel =
-            lock.withLock {
+            locked {
                 check(running) { "Cannot pause a finished or cancelled TimedBossBar." }
                 check(!paused) { "TimedBossBar is already paused." }
                 detachTask().also { paused = true }
             }
+
         toCancel?.cancel()
     }
 
     fun resume() {
         // Schedule under the lock so that cancellation cannot create a replacement task.
-        lock.withLock {
+        locked {
             check(running) { "Cannot resume a finished or cancelled TimedBossBar." }
             check(paused) { "TimedBossBar is not paused." }
             paused = false
@@ -71,13 +74,13 @@ internal class TimedBossBarRuntime(
     }
 
     fun cancel() {
-        val shutdown = lock.withLock { if (running) markStopped() else null } ?: return
+        val shutdown = locked { if (running) markStopped() else null } ?: return
         finaliseShutdown(shutdown, config.onCancel)
     }
 
     fun show(audience: Audience) {
         val accepted =
-            lock.withLock {
+            locked {
                 if (!running) {
                     false
                 } else {
@@ -85,41 +88,56 @@ internal class TimedBossBarRuntime(
                     true
                 }
             }
+
         if (!accepted) return
 
         audience.showBossBar(bar)
 
         // A concurrent termination can occur after tracking but before the show operation completes.
-        val stillTracked = lock.withLock { running && audience in viewers }
+        val stillTracked = locked { running && audience in viewers }
         if (!stillTracked) {
             audience.hideBossBar(bar)
         }
     }
 
     fun hide(audience: Audience) {
-        lock.withLock { viewers.remove(audience) }
+        locked { viewers.remove(audience) }
         audience.hideBossBar(bar)
     }
 
     /**
      * Cancels the detached task, attempts to hide every snapshotted viewer, and then invokes [hook].
      *
-     * Viewer failures do not stop later hide attempts. The function keeps the first failure and suppresses later
-     * failures. The `finally` block guarantees that the terminal hook runs.
+     * Viewer failures do not stop later hide attempts. Terminal hooks always run. If multiple shutdown steps fail, the
+     * first failure is thrown and later failures are attached as suppressed exceptions.
      */
     private fun finaliseShutdown(
         shutdown: TimedBossBarShutdown,
         hook: (TimedBossBar.() -> Unit)?,
     ) {
-        shutdown.task?.cancel()
-        try {
-            viewers.hideAll(bar, shutdown.viewers)
-        } finally {
-            hook?.invoke(owner)
-        }
+        var failure: Throwable? = null
+
+        failure =
+            failure.collectFailure {
+                shutdown.task?.cancel()
+            }
+        failure =
+            failure.collectFailure {
+                viewers.hideAll(bar, shutdown.viewers)
+            }
+        failure =
+            failure.collectFailure {
+                hook?.invoke(owner)
+            }
+
+        failure?.let { throw it }
     }
 
     private fun startTicking() {
+        check(lock.isHeldByCurrentThread) {
+            "TimedBossBar ticking must start while the runtime lock is held."
+        }
+
         val generation = tickGeneration
         task = ticker.every(config.every) { onTick(generation) }
     }
@@ -131,7 +149,8 @@ internal class TimedBossBarRuntime(
 
     private fun onTick(generation: Int) {
         // Mark natural completion before the hook so concurrent cancellation cannot replace it.
-        val outcome = lock.withLock { advanceOrNull(generation) } ?: return
+        val outcome = locked { advanceOrNull(generation) } ?: return
+
         try {
             config.onTick?.invoke(owner, outcome.remaining)
         } finally {
@@ -147,9 +166,11 @@ internal class TimedBossBarRuntime(
      */
     private fun advanceOrNull(generation: Int): TickOutcome? {
         if (!running || paused || generation != tickGeneration) return null
+
         remainingTime = (remainingTime - config.every).coerceAtLeast(Duration.ZERO)
         bar.progress(config.progress.at(remaining = remainingTime, over = config.over))
         updateNameIfChanged(remainingTime)
+
         val shutdown = if (remainingTime == Duration.ZERO) markStopped() else null
         return TickOutcome(remaining = remainingTime, shutdown = shutdown)
     }
@@ -167,13 +188,25 @@ internal class TimedBossBarRuntime(
     private fun markStopped(): TimedBossBarShutdown {
         running = false
         paused = false
+
         return TimedBossBarShutdown(
             task = detachTask(),
             viewers = viewers.snapshotAndClear(),
         )
     }
 
-    /** Tick state that carries shutdown work only for natural completion. */
+    private inline fun <T> locked(action: () -> T): T = lock.withLock(action)
+
+    private inline fun Throwable?.collectFailure(action: () -> Unit): Throwable? {
+        try {
+            action()
+        } catch (failure: Throwable) {
+            return this?.apply { addSuppressed(failure) } ?: failure
+        }
+
+        return this
+    }
+
     private data class TickOutcome(
         val remaining: Duration,
         val shutdown: TimedBossBarShutdown?,

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarViewers.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarViewers.kt
@@ -11,8 +11,7 @@ import java.util.IdentityHashMap
  * This class is not thread-safe. [TimedBossBarRuntime] serialises access with its state lock.
  */
 internal class TimedBossBarViewers {
-    private val viewers: MutableSet<Audience> =
-        Collections.newSetFromMap(IdentityHashMap())
+    private val viewers = Collections.newSetFromMap<Audience>(IdentityHashMap())
 
     fun add(audience: Audience): Boolean = viewers.add(audience)
 
@@ -37,18 +36,15 @@ internal class TimedBossBarViewers {
         bar: BossBar,
         audiences: List<Audience>,
     ) {
-        var firstError: Throwable? = null
+        var failure: Throwable? = null
         for (audience in audiences) {
             try {
                 audience.hideBossBar(bar)
             } catch (error: Throwable) {
-                if (firstError == null) {
-                    firstError = error
-                } else {
-                    firstError.addSuppressed(error)
-                }
+                failure = failure?.apply { addSuppressed(error) } ?: error
             }
         }
-        firstError?.let { throw it }
+
+        failure?.let { throw it }
     }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/time/Ticker.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/time/Ticker.kt
@@ -21,9 +21,18 @@ public interface Ticker {
     public val isCurrent: Boolean
 
     /**
-     * Schedules [action] after each [interval].
+     * Schedules [action] at each [interval].
      *
-     * The first invocation occurs after one interval.
+     * The first invocation occurs after one complete [interval].
+     * This function returns before it invokes [action].
+     * An implementation must not invoke [action] during this function call.
+     *
+     * The returned task controls the scheduled invocations.
+     * Cancellation prevents future invocations.
+     * Cancellation does not have to interrupt an invocation that is already running.
+     *
+     * [interval] must be positive.
+     * An implementation must reject [interval] when its precision is unsupported.
      *
      * @throws IllegalArgumentException when [interval] is not positive or its precision is unsupported.
      */

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarDslTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarDslTest.kt
@@ -46,6 +46,23 @@ class TimedBossBarDslTest :
                 }
             }
 
+            "rejects infinite durations" {
+                val ticker = ManualTicker()
+                val audience = TimedBossBarRecordingAudience()
+
+                shouldThrow<IllegalArgumentException> {
+                    timedBossBar(ticker, audience, Duration.INFINITE) {
+                        name { text("Bad") }
+                    }
+                }
+                shouldThrow<IllegalArgumentException> {
+                    timedBossBar(ticker, audience, Duration.INFINITE) {
+                        name { text("Bad") }
+                        every(Duration.INFINITE)
+                    }
+                }
+            }
+
             "rejects out-of-range progress endpoints" {
                 val ticker = ManualTicker()
                 val audience = TimedBossBarRecordingAudience()

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarLifecycleTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/bossbar/timed/TimedBossBarLifecycleTest.kt
@@ -2,6 +2,8 @@ package io.github.lmliam.kotventure.core.bossbar.timed
 
 import io.github.lmliam.kotventure.core.text.text
 import io.github.lmliam.kotventure.core.time.StaleCallbackTicker
+import io.github.lmliam.kotventure.core.time.Ticker
+import io.github.lmliam.kotventure.core.time.TickerTask
 import io.github.lmliam.kotventure.test.bossbar.shouldHaveProgress
 import io.github.lmliam.kotventure.test.time.ManualTicker
 import io.kotest.assertions.throwables.shouldThrow
@@ -9,6 +11,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.floats.plusOrMinus
 import io.kotest.matchers.shouldBe
+import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.bossbar.BossBar
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -192,5 +195,142 @@ class TimedBossBarLifecycleTest :
 
                 shouldThrow<IllegalStateException> { timed.pause() }
             }
+
+            "runs every shutdown step and preserves the first failure" {
+                val cancellationFailure = IllegalStateException("cancel")
+                val firstHideFailure = IllegalStateException("first hide")
+                val secondHideFailure = IllegalStateException("second hide")
+                val hookFailure = IllegalStateException("hook")
+                val firstViewer = FailingHideAudience(firstHideFailure)
+                val secondViewer = FailingHideAudience(secondHideFailure)
+
+                val timed =
+                    timedBossBar(
+                        CancellationFailingTicker(cancellationFailure),
+                        firstViewer,
+                        1.seconds,
+                    ) {
+                        name { text("Failure") }
+                        onCancel { throw hookFailure }
+                    }
+                timed.show(secondViewer)
+
+                val thrown = shouldThrow<IllegalStateException> { timed.cancel() }
+
+                thrown shouldBe cancellationFailure
+                val hideFailures = setOf(firstHideFailure, secondHideFailure)
+                val topLevelHideFailures = thrown.suppressed.filter { it in hideFailures }
+                topLevelHideFailures.size shouldBe 1
+                val topLevelHideFailure = topLevelHideFailures.single()
+                topLevelHideFailure.suppressed.toSet() shouldBe hideFailures - setOf(topLevelHideFailure)
+                thrown.suppressed.filter { it !== topLevelHideFailure }.toSet() shouldBe setOf(hookFailure)
+                firstViewer.hideCalls shouldBe 1
+                secondViewer.hideCalls shouldBe 1
+                timed.isRunning shouldBe false
+            }
+
+            "natural completion runs every shutdown step and preserves the first failure" {
+                val cancellationFailure = IllegalStateException("cancel")
+                val firstViewerFailure = IllegalStateException("first hide")
+                val secondViewerFailure = IllegalStateException("second hide")
+                val finishFailure = IllegalStateException("finish")
+                val hideOrder = mutableListOf<Throwable>()
+                val firstViewer = FailingHideAudience(firstViewerFailure) { hideOrder += firstViewerFailure }
+                val secondViewer = FailingHideAudience(secondViewerFailure) { hideOrder += secondViewerFailure }
+                var finishCalls = 0
+                var cancelCalls = 0
+                val ticker = CancellationFailingTicker(cancellationFailure)
+
+                val timed =
+                    timedBossBar(
+                        ticker,
+                        firstViewer,
+                        1.seconds,
+                    ) {
+                        name { text("Natural failure") }
+                        every(1.seconds)
+                        onFinish {
+                            finishCalls++
+                            throw finishFailure
+                        }
+                        onCancel { cancelCalls++ }
+                    }
+                timed.show(secondViewer)
+
+                val thrown = shouldThrow<IllegalStateException> { ticker.run() }
+
+                thrown shouldBe cancellationFailure
+                hideOrder.size shouldBe 2
+                hideOrder.toSet() shouldBe setOf(firstViewerFailure, secondViewerFailure)
+                val firstHideFailure = hideOrder[0]
+                val secondHideFailure = hideOrder[1]
+                thrown.suppressed.toList() shouldBe listOf(firstHideFailure, finishFailure)
+                firstHideFailure.suppressed.toList() shouldBe listOf(secondHideFailure)
+                secondHideFailure.suppressed.toList() shouldBe emptyList()
+                finishFailure.suppressed.toList() shouldBe emptyList()
+                ticker.cancelCalls shouldBe 1
+                cancelCalls shouldBe 0
+                finishCalls shouldBe 1
+                firstViewer.hideCalls shouldBe 1
+                secondViewer.hideCalls shouldBe 1
+                timed.isRunning shouldBe false
+                timed.isPaused shouldBe false
+                timed.remaining shouldBe Duration.ZERO
+
+                ticker.run()
+                timed.cancel()
+
+                ticker.cancelCalls shouldBe 1
+                cancelCalls shouldBe 0
+                finishCalls shouldBe 1
+                firstViewer.hideCalls shouldBe 1
+                secondViewer.hideCalls shouldBe 1
+            }
         },
     )
+
+private class CancellationFailingTicker(
+    private val failure: Throwable,
+) : Ticker {
+    override val isCurrent: Boolean = true
+    private var scheduledAction: (() -> Unit)? = null
+    var cancelCalls: Int = 0
+        private set
+
+    override fun every(
+        interval: Duration,
+        action: () -> Unit,
+    ): TickerTask {
+        scheduledAction = action
+        return object : TickerTask {
+            override fun cancel() {
+                cancelCalls++
+                throw failure
+            }
+        }
+    }
+
+    fun run() {
+        checkNotNull(scheduledAction) { "The test ticker has no scheduled action." }.invoke()
+    }
+
+    override fun after(
+        delay: Duration,
+        action: () -> Unit,
+    ): TickerTask = error("The test ticker does not support one-time tasks.")
+}
+
+private class FailingHideAudience(
+    private val failure: Throwable,
+    private val onHide: () -> Unit = {},
+) : Audience {
+    var hideCalls: Int = 0
+
+    override fun showBossBar(bar: BossBar) = Unit
+
+    override fun hideBossBar(bar: BossBar) {
+        hideCalls++
+        onHide()
+        throw failure
+    }
+}

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/time/ManualTickerTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/time/ManualTickerTest.kt
@@ -21,6 +21,41 @@ class ManualTickerTest :
                 count shouldBe 2
             }
 
+            "returns an every task before its first action" {
+                val ticker = ManualTicker()
+                val events = mutableListOf<String>()
+
+                events += "before"
+                val task =
+                    ticker.every(1.seconds) {
+                        events += "callback"
+                    }
+                events += "after"
+
+                events shouldBe listOf("before", "after")
+
+                ticker.advance(999.milliseconds)
+                events shouldBe listOf("before", "after")
+
+                ticker.advance(1.milliseconds)
+                events shouldBe listOf("before", "after", "callback")
+
+                ticker.advance(1.seconds)
+                events shouldBe listOf("before", "after", "callback", "callback")
+
+                task.cancel()
+            }
+
+            "cancelling an every task before its first interval prevents its action" {
+                val ticker = ManualTicker()
+                var count = 0
+
+                ticker.every(1.seconds) { count++ }.cancel()
+                ticker.advance(1.seconds)
+
+                count shouldBe 0
+            }
+
             "preserves phase when advancing past multiple intervals" {
                 val ticker = ManualTicker()
                 val fires = mutableListOf<Int>()


### PR DESCRIPTION
## Summary

Harden timed boss-bar lifecycle shutdown and deferred scheduling behaviour.

## Scope

- Refine timed boss-bar lifecycle and shutdown handling.
- Keep the natural-completion shutdown regression test with the implementation.
- Keep the Ticker.every deferred-invocation contract, its ASD-STE100 KDoc, and related tests in this scheduling layer.

## Rationale

These are correctness fixes for timed lifecycle ownership and scheduling. They must land before selector and MiniMessage changes that build on the core APIs.

## Testing

- `./gradlew :core:test --tests 'io.github.lmliam.kotventure.core.bossbar.timed.*' --tests 'io.github.lmliam.kotventure.core.time.ManualTickerTest'`
- `./gradlew :core:spotlessCheck`

## Stack

This PR is part of the stacked replacement for #344.

- Depends on: [#346](https://github.com/LMLiam/Kotventure/pull/346)
- Followed by: [#348](https://github.com/LMLiam/Kotventure/pull/348)