### PR TITLE
refactor(selector): simplify model and builder state

### DIFF
--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentConversion.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentConversion.kt
@@ -19,23 +19,29 @@ import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Team
 import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Type
 import java.util.Map.entry
 
+private const val ENTITY_TYPE_TAG_PREFIX: String = "#"
+
 /**
  * Converts validated builder state to typed arguments in canonical order.
  */
 internal fun EntitySelectorBuilder.selectorArguments(): List<EntitySelectorArgument> =
     buildList {
-        addAll(typeFilters.arguments(::typeArgument))
-        addAll(nameFilters.arguments(::Name))
+        addArguments(typeFilters, ::typeArgument)
+        addArguments(nameFilters, ::Name)
+
         SelectorCoordinate.entries.forEach { coordinate ->
             coordinates[coordinate]?.let { add(Coordinate(coordinate, it)) }
         }
+
         distance?.let { add(Range(SelectorRangeArgument.DISTANCE, it)) }
         pitch?.let { add(Range(SelectorRangeArgument.X_ROTATION, it)) }
         yaw?.let { add(Range(SelectorRangeArgument.Y_ROTATION, it)) }
         level?.let { add(Level(it)) }
+
         scores?.let { scores ->
             add(Scores(scores.map { (objective, range) -> SelectorScoreRequirement(objective, range) }))
         }
+
         advancements?.let { advancements ->
             add(
                 Advancements(
@@ -45,24 +51,35 @@ internal fun EntitySelectorBuilder.selectorArguments(): List<EntitySelectorArgum
                 ),
             )
         }
-        addAll(gamemodeFilters.arguments(::GameMode))
-        addAll(teamFilters.arguments(::teamArgument))
+
+        addArguments(gamemodeFilters, ::GameMode)
+        addArguments(teamFilters, ::teamArgument)
+
         limit?.let { add(Limit(it)) }
         sort?.let { add(Sort(it)) }
-        addAll(tagFilters.arguments(::tagArgument))
-        addAll(nbtFilters.arguments(::nbtArgument))
-        addAll(predicateFilters.arguments(::predicateArgument))
+
+        addArguments(tagFilters, ::tagArgument)
+        addArguments(nbtFilters, ::nbtArgument)
+        addArguments(predicateFilters, ::predicateArgument)
     }
 
 /**
- * Converts this filter group with [toArgument] and keeps entry polarity and order.
+ * Converts [filters] with [toArgument] and keeps entry polarity and order.
  */
-private fun <T> SelectorFilterGroup<T>.arguments(
+private inline fun <T> MutableList<EntitySelectorArgument>.addArguments(
+    filters: SelectorFilterGroup<T>,
     toArgument: (value: T, isNegated: Boolean) -> EntitySelectorArgument,
-): List<EntitySelectorArgument> =
-    entries.map {
-        toArgument(it.value, it.polarity == SelectorFilterPolarity.NEGATIVE)
+) {
+    filters.entries.forEach { entry ->
+        add(toArgument(entry.value, entry.isNegated))
     }
+}
+
+/**
+ * Returns whether this filter entry has negative polarity.
+ */
+private val SelectorFilterEntry<*>.isNegated: Boolean
+    get() = polarity == SelectorFilterPolarity.NEGATIVE
 
 /**
  * Converts a type or type-tag string to a [Type] argument.
@@ -72,15 +89,16 @@ private fun <T> SelectorFilterGroup<T>.arguments(
 private fun typeArgument(
     value: String,
     isNegated: Boolean,
-): Type {
-    val target =
-        if (value.isEntityTypeTag()) {
-            SelectorEntityType.Tag(key(value.removePrefix("#")))
-        } else {
-            SelectorEntityType.Direct(key(value))
-        }
-    return Type(target, isNegated)
-}
+): Type =
+    Type(
+        target =
+            if (value.isEntityTypeTag()) {
+                SelectorEntityType.Tag(key(value.removePrefix(ENTITY_TYPE_TAG_PREFIX)))
+            } else {
+                SelectorEntityType.Direct(key(value))
+            },
+        isNegated = isNegated,
+    )
 
 /**
  * Converts a predicate ID to a [Predicate] argument.
@@ -131,4 +149,4 @@ private fun AdvancementCondition.progress(): SelectorAdvancementProgress =
 /**
  * Returns whether this string starts with the entity-type-tag prefix.
  */
-private fun String.isEntityTypeTag(): Boolean = startsWith("#")
+private fun String.isEntityTypeTag(): Boolean = startsWith(ENTITY_TYPE_TAG_PREFIX)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentNames.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentNames.kt
@@ -1,24 +1,39 @@
 package io.github.lmliam.kotventure.core.selector
 
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Advancements
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Coordinate
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.GameMode
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Level
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Limit
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Name
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Nbt
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Predicate
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Range
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Scores
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Sort
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Tag
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Team
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Type
+
 /**
  * Returns the keyword of this argument, or null when its argument type owns the name.
  */
 internal val EntitySelectorArgument.keyword: SelectorArgumentKeyword?
     get() =
         when (this) {
-            is EntitySelectorArgument.Coordinate, is EntitySelectorArgument.Range -> null
-            is EntitySelectorArgument.Level -> SelectorArgumentKeyword.LEVEL
-            is EntitySelectorArgument.Limit -> SelectorArgumentKeyword.LIMIT
-            is EntitySelectorArgument.Sort -> SelectorArgumentKeyword.SORT
-            is EntitySelectorArgument.GameMode -> SelectorArgumentKeyword.GAMEMODE
-            is EntitySelectorArgument.Name -> SelectorArgumentKeyword.NAME
-            is EntitySelectorArgument.Type -> SelectorArgumentKeyword.TYPE
-            is EntitySelectorArgument.Tag -> SelectorArgumentKeyword.TAG
-            is EntitySelectorArgument.Team -> SelectorArgumentKeyword.TEAM
-            is EntitySelectorArgument.Nbt -> SelectorArgumentKeyword.NBT
-            is EntitySelectorArgument.Scores -> SelectorArgumentKeyword.SCORES
-            is EntitySelectorArgument.Predicate -> SelectorArgumentKeyword.PREDICATE
-            is EntitySelectorArgument.Advancements -> SelectorArgumentKeyword.ADVANCEMENTS
+            is Coordinate, is Range -> null
+            is Level -> SelectorArgumentKeyword.LEVEL
+            is Limit -> SelectorArgumentKeyword.LIMIT
+            is Sort -> SelectorArgumentKeyword.SORT
+            is GameMode -> SelectorArgumentKeyword.GAMEMODE
+            is Name -> SelectorArgumentKeyword.NAME
+            is Type -> SelectorArgumentKeyword.TYPE
+            is Tag -> SelectorArgumentKeyword.TAG
+            is Team -> SelectorArgumentKeyword.TEAM
+            is Nbt -> SelectorArgumentKeyword.NBT
+            is Scores -> SelectorArgumentKeyword.SCORES
+            is Predicate -> SelectorArgumentKeyword.PREDICATE
+            is Advancements -> SelectorArgumentKeyword.ADVANCEMENTS
         }
 
 /**
@@ -29,9 +44,9 @@ internal val EntitySelectorArgument.keyword: SelectorArgumentKeyword?
 internal val EntitySelectorArgument.argumentName: String
     get() =
         when (this) {
-            is EntitySelectorArgument.Coordinate -> coordinate.argumentName
-            is EntitySelectorArgument.Range -> argument.argumentName
-            else -> checkNotNull(keyword) { "Keyword arguments always declare a keyword" }.sourceName
+            is Coordinate -> coordinate.argumentName
+            is Range -> argument.argumentName
+            else -> keyword?.sourceName ?: error("Keyword arguments always declare a keyword")
         }
 
 /**
@@ -39,11 +54,11 @@ internal val EntitySelectorArgument.argumentName: String
  */
 internal val singletonSelectorArgumentNames: Set<String> =
     buildSet {
-        addAll(SelectorCoordinate.entries.map { it.argumentName })
-        addAll(SelectorRangeArgument.entries.map { it.argumentName })
-        add(SelectorArgumentKeyword.LIMIT.sourceName)
-        add(SelectorArgumentKeyword.SORT.sourceName)
-        add(SelectorArgumentKeyword.LEVEL.sourceName)
-        add(SelectorArgumentKeyword.SCORES.sourceName)
-        add(SelectorArgumentKeyword.ADVANCEMENTS.sourceName)
+        addAll(SelectorCoordinate.entries.map(SelectorCoordinate::argumentName))
+        addAll(SelectorRangeArgument.entries.map(SelectorRangeArgument::argumentName))
+        addAll(
+            SelectorArgumentKeyword.entries
+                .filter(SelectorArgumentKeyword::isSingleton)
+                .map(SelectorArgumentKeyword::sourceName),
+        )
     }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentRenderer.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorArgumentRenderer.kt
@@ -1,6 +1,20 @@
 package io.github.lmliam.kotventure.core.selector
 
 import io.github.lmliam.kotventure.core.nbt.renderValue
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Advancements
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Coordinate
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.GameMode
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Level
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Limit
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Name
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Nbt
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Predicate
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Range
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Scores
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Sort
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Tag
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Team
+import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument.Type
 
 /**
  * Renders this argument as canonical `name=value` source text.
@@ -14,32 +28,27 @@ internal fun EntitySelectorArgument.render(): String = "$argumentName=${renderVa
  */
 private fun EntitySelectorArgument.renderValue(): String =
     when (this) {
-        is EntitySelectorArgument.Coordinate -> formatSelectorNumber(value)
-        is EntitySelectorArgument.Range -> range.toString()
-        is EntitySelectorArgument.Limit -> value.toString()
-        is EntitySelectorArgument.Sort -> value.value
-        is EntitySelectorArgument.Level -> range.toString()
-        is EntitySelectorArgument.GameMode -> "$negationPrefix${value.value}"
-        is EntitySelectorArgument.Name -> "$negationPrefix${renderQuotable()}"
-        is EntitySelectorArgument.Type -> "$negationPrefix${target.render()}"
-        is EntitySelectorArgument.Tag -> "$negationPrefix${condition.render()}"
-        is EntitySelectorArgument.Team -> "$negationPrefix${condition.render()}"
-        is EntitySelectorArgument.Nbt -> "$negationPrefix${snbt.value}"
-        is EntitySelectorArgument.Scores ->
-            scores.joinToString(",", "{", "}") { (objective, range) -> "$objective=$range" }
-
-        is EntitySelectorArgument.Predicate -> "$negationPrefix${key.asString()}"
-        is EntitySelectorArgument.Advancements ->
-            advancements.joinToString(",", "{", "}") { (advancement, progress) ->
-                "${advancement.asString()}=${progress.render()}"
-            }
+        is Coordinate -> formatSelectorNumber(value)
+        is Range -> range.toString()
+        is Limit -> value.toString()
+        is Sort -> value.value
+        is Level -> range.toString()
+        is GameMode -> renderNegated(value.value)
+        is Name -> renderNegated(value.renderSelectorName())
+        is Type -> renderNegated(target.render())
+        is Tag -> renderNegated(condition.render())
+        is Team -> renderNegated(condition.render())
+        is Nbt -> renderNegated(snbt.value)
+        is Scores -> scores.render()
+        is Predicate -> renderNegated(key.asString())
+        is Advancements -> advancements.render()
     }
 
 /**
- * Returns `!` when this argument is negated, or an empty string otherwise.
+ * Renders [value] with this argument's leading negation marker when applicable.
  */
-private val EntitySelectorArgument.Negatable.negationPrefix: String
-    get() = if (isNegated) SELECTOR_NEGATION_PREFIX.toString() else ""
+private fun EntitySelectorArgument.Negatable.renderNegated(value: String): String =
+    if (isNegated) "$SELECTOR_NEGATION_PREFIX$value" else value
 
 /**
  * Renders an entity type or entity-type tag.
@@ -55,8 +64,8 @@ private fun SelectorEntityType.render(): String =
 /**
  * Renders a name and quotes it when unquoted selector syntax cannot contain it.
  */
-private fun EntitySelectorArgument.Name.renderQuotable(): String =
-    if (value.all(Char::isAllowedInUnquotedSelectorToken)) value else value.quoteSelectorString()
+private fun String.renderSelectorName(): String =
+    if (isNotEmpty() && all(Char::isAllowedInUnquotedSelectorToken)) this else quoteSelectorString()
 
 /**
  * Quotes a selector string and escapes double quotes and backslashes.
@@ -86,11 +95,33 @@ private fun SelectorStringCondition.render(): String =
     }
 
 /**
+ * Renders scoreboard objective ranges.
+ */
+@JvmName("renderScoreboardObjectiveRanges")
+private fun List<SelectorScoreRequirement>.render(): String =
+    joinToString(",", "{", "}") { (objective, range) -> "$objective=$range" }
+
+/**
+ * Renders advancement requirements.
+ */
+@JvmName("renderAdvancementRequirements")
+private fun List<SelectorAdvancementRequirement>.render(): String =
+    joinToString(",", "{", "}") { (advancement, progress) ->
+        "${advancement.asString()}=${progress.render()}"
+    }
+
+/**
  * Renders complete-advancement state or a criteria map.
  */
 private fun SelectorAdvancementProgress.render(): String =
     when (this) {
         is SelectorAdvancementProgress.Completion -> completed.toString()
-        is SelectorAdvancementProgress.Criteria ->
-            criteria.joinToString(",", "{", "}") { (name, completed) -> "$name=$completed" }
+        is SelectorAdvancementProgress.Criteria -> criteria.render()
     }
+
+/**
+ * Renders advancement criteria states.
+ */
+@JvmName("renderAdvancementCriteriaStates")
+private fun List<SelectorAdvancementCriterion>.render(): String =
+    joinToString(",", "{", "}") { (name, completed) -> "$name=$completed" }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorBuilder.kt
@@ -34,6 +34,17 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     val nbtFilters = SelectorFilterGroup<NbtCompound>(SelectorArgumentKeyword.NBT)
     val predicateFilters = SelectorFilterGroup<String>(SelectorArgumentKeyword.PREDICATE)
 
+    private val filterGroups: List<SelectorFilterGroup<*>> =
+        listOf(
+            typeFilters,
+            nameFilters,
+            gamemodeFilters,
+            teamFilters,
+            tagFilters,
+            nbtFilters,
+            predicateFilters,
+        )
+
     val coordinates: Map<SelectorCoordinate, Double>
         field = mutableMapOf()
 
@@ -43,7 +54,8 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     var advancements: Map<Key, AdvancementCondition>? by once()
         private set
 
-    private var isConfiguring = false
+    private var configurationDepth = 0
+    private val isConfiguring: Boolean get() = configurationDepth > 0
 
     override val any: SelectorPresence get() = SelectorPresence.ANY
     override val none: SelectorPresence get() = SelectorPresence.NONE
@@ -59,27 +71,38 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
     override val arbitrary: SelectorSort get() = SelectorSort.ARBITRARY
 
     fun configure(configure: EntitySelectorScope.() -> Unit) {
-        isConfiguring = true
+        configurationDepth++
         try {
             configure()
         } finally {
-            isConfiguring = false
+            configurationDepth--
         }
-        validateFilters()
+
+        if (!isConfiguring) validateFilters()
     }
 
     override fun origin(
         first: OriginCoordinate,
         vararg rest: OriginCoordinate,
     ) {
-        bindCoordinates((listOf(first) + rest).map { it.coordinate to it.value })
+        bindCoordinates(
+            first = first,
+            rest = rest,
+            coordinateOf = OriginCoordinate::coordinate,
+            valueOf = OriginCoordinate::value,
+        )
     }
 
     override fun volume(
         first: VolumeDelta,
         vararg rest: VolumeDelta,
     ) {
-        bindCoordinates((listOf(first) + rest).map { it.coordinate to it.value })
+        bindCoordinates(
+            first = first,
+            rest = rest,
+            coordinateOf = VolumeDelta::coordinate,
+            valueOf = VolumeDelta::value,
+        )
     }
 
     override fun distance(range: SelectorRange) {
@@ -165,31 +188,35 @@ internal class EntitySelectorBuilder : EntitySelectorScope {
 
     override fun SelectorFilterExpression.not() {
         check(isConfiguring) {
-            "Selector filter expressions can only be negated while their selector is being configured."
+            "Selector filter expressions can only be negated while their selector is being configured"
         }
         (this as SelectorFilterEntry<*>).negate(this@EntitySelectorBuilder)
     }
 
     private fun validateFilters() {
-        setOf(
-            typeFilters,
-            nameFilters,
-            gamemodeFilters,
-            teamFilters,
-            tagFilters,
-            nbtFilters,
-            predicateFilters,
-        ).forEach { it.validate() }
+        filterGroups.forEach { it.validate() }
     }
 
-    private fun bindCoordinates(bindings: List<Pair<SelectorCoordinate, Double>>) {
+    private inline fun <T> bindCoordinates(
+        first: T,
+        rest: Array<out T>,
+        crossinline coordinateOf: (T) -> SelectorCoordinate,
+        crossinline valueOf: (T) -> Double,
+    ) {
         val staged = mutableMapOf<SelectorCoordinate, Double>()
-        bindings.forEach { (coordinate, value) ->
+
+        val bind: (T) -> Unit = {
+            val coordinate = coordinateOf(it)
+
             check(coordinate !in coordinates && coordinate !in staged) {
                 "Selector argument '${coordinate.argumentName}' may only appear once."
             }
-            staged[coordinate] = value
+
+            staged[coordinate] = valueOf(it)
         }
+
+        bind(first)
+        rest.forEach(bind)
         coordinates += staged
     }
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorHead.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorHead.kt
@@ -32,6 +32,12 @@ public enum class EntitySelectorHead(
     NEAREST_ENTITY("@n"),
     ;
 
+    internal companion object {
+        private val byToken = entries.associateBy(EntitySelectorHead::token)
+
+        fun fromToken(token: String): EntitySelectorHead? = byToken[token]
+    }
+
     internal fun supports(keyword: SelectorArgumentKeyword): Boolean =
         when (keyword) {
             SelectorArgumentKeyword.TYPE -> supportsTypeFilters

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/GameMode.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/GameMode.kt
@@ -19,4 +19,11 @@ public enum class GameMode(
 
     /** Spectator mode. */
     SPECTATOR("spectator"),
+    ;
+
+    internal companion object {
+        private val byValue = entries.associateBy(GameMode::value)
+
+        fun fromValue(value: String): GameMode? = byValue[value]
+    }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorArgumentKeyword.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorArgumentKeyword.kt
@@ -8,25 +8,29 @@ package io.github.lmliam.kotventure.core.selector
  * the renderer prints through it.
  *
  * @property sourceName vanilla selector-source spelling, such as `limit` in `limit=1`
+ * @property isSingleton whether this keyword argument can only occur one time in a selector
  */
 internal enum class SelectorArgumentKeyword(
     val sourceName: String,
+    val isSingleton: Boolean = false,
 ) {
-    LEVEL("level"),
-    LIMIT("limit"),
-    SORT("sort"),
+    LEVEL("level", isSingleton = true),
+    LIMIT("limit", isSingleton = true),
+    SORT("sort", isSingleton = true),
     GAMEMODE("gamemode"),
     NAME("name"),
     TYPE("type"),
     TAG("tag"),
     TEAM("team"),
     NBT("nbt"),
-    SCORES("scores"),
+    SCORES("scores", isSingleton = true),
     PREDICATE("predicate"),
-    ADVANCEMENTS("advancements"),
+    ADVANCEMENTS("advancements", isSingleton = true),
     ;
 
     companion object {
-        fun fromSourceName(name: String): SelectorArgumentKeyword? = entries.firstOrNull { it.sourceName == name }
+        private val bySourceName = entries.associateBy(SelectorArgumentKeyword::sourceName)
+
+        fun fromSourceName(name: String): SelectorArgumentKeyword? = bySourceName[name]
     }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorArgumentOccurrences.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorArgumentOccurrences.kt
@@ -7,41 +7,44 @@ package io.github.lmliam.kotventure.core.selector
  * change an entry's polarity before the block returns.
  */
 internal class SelectorArgumentOccurrences {
-    private val singletons = mutableSetOf<String>()
+    private val seenSingletons = mutableSetOf<String>()
 
     /** Stores the polarity that each exclusive filter group has established. */
     private val exclusivePolarities = mutableMapOf<String, SelectorFilterPolarity>()
 
     /** Records [name] and returns an error for a repeated singleton. */
     fun recordName(name: String): String? =
-        when {
-            name !in singletonSelectorArgumentNames -> null
-            singletons.add(name) -> null
-            else -> "Selector argument '$name' may only appear once."
+        if (name !in singletonSelectorArgumentNames || seenSingletons.add(name)) {
+            null
+        } else {
+            "Selector argument '$name' may only appear once."
         }
 
     /**
      * Records the polarity of [argument] and returns an exclusive-filter error.
      */
     fun recordFilter(argument: EntitySelectorArgument): String? {
-        val keyword = argument.keyword ?: return null
-        if (keyword.filterPolicy != SelectorFilterPolicy.EXCLUSIVE) return null
-
+        val keyword = argument.keyword?.takeIf { it.filterPolicy == SelectorFilterPolicy.EXCLUSIVE } ?: return null
         val name = keyword.sourceName
-        val isExclusion = (argument as EntitySelectorArgument.Negatable).isFilterExclusion
+        val polarity =
+            if ((argument as EntitySelectorArgument.Negatable).isFilterExclusion) {
+                SelectorFilterPolarity.NEGATIVE
+            } else {
+                SelectorFilterPolarity.POSITIVE
+            }
 
-        return when (exclusivePolarities[name]) {
+        return when (exclusivePolarities.putIfAbsent(name, polarity)) {
+            null -> null
+
             SelectorFilterPolarity.POSITIVE ->
                 "Selector argument '$name' is already set."
 
             SelectorFilterPolarity.NEGATIVE ->
-                if (isExclusion) null else "Selector argument '$name' cannot combine a positive value with exclusions."
-
-            null -> {
-                exclusivePolarities[name] =
-                    if (isExclusion) SelectorFilterPolarity.NEGATIVE else SelectorFilterPolarity.POSITIVE
-                null
-            }
+                if (polarity == SelectorFilterPolarity.NEGATIVE) {
+                    null
+                } else {
+                    "Selector argument '$name' cannot combine a positive value with exclusions."
+                }
         }
     }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorCoordinate.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorCoordinate.kt
@@ -25,6 +25,13 @@ public enum class SelectorCoordinate(
 
     /** Bounding-volume Z delta. */
     DZ("dz"),
+    ;
+
+    internal companion object {
+        private val byArgumentName = entries.associateBy(SelectorCoordinate::argumentName)
+
+        fun fromArgumentName(name: String): SelectorCoordinate? = byArgumentName[name]
+    }
 }
 
 internal fun validatedCoordinateValue(

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterGroup.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterGroup.kt
@@ -36,11 +36,9 @@ internal class SelectorFilterGroup<T>(
     }
 
     fun validate() {
-        if (policy != SelectorFilterPolicy.EXCLUSIVE) return
+        if (!isExclusive) return
 
-        val hasPositive = entries.any { it.polarity == SelectorFilterPolarity.POSITIVE }
-        val hasNegative = entries.any { it.polarity == SelectorFilterPolarity.NEGATIVE }
-        check(!(hasPositive && hasNegative)) {
+        check(entries.distinctBy(SelectorFilterEntry<T>::polarity).size <= 1) {
             "Selector argument '$argument' cannot combine a positive value with exclusions."
         }
     }
@@ -50,13 +48,18 @@ internal class SelectorFilterGroup<T>(
         value: T,
         polarity: SelectorFilterPolarity,
     ): SelectorFilterEntry<T> {
-        if (policy == SelectorFilterPolicy.EXCLUSIVE) {
-            check(entries.none { it.polarity == SelectorFilterPolarity.POSITIVE }) {
-                "Selector argument '$argument' is already set."
-            }
-        }
+        validateNewEntry()
         return SelectorFilterEntry(owner, argument, value, polarity).also {
             entries += it
         }
     }
+
+    private fun validateNewEntry() {
+        check(!isExclusive || entries.none { it.polarity == SelectorFilterPolarity.POSITIVE }) {
+            "Selector argument '$argument' is already set."
+        }
+    }
+
+    private val isExclusive: Boolean
+        get() = policy == SelectorFilterPolicy.EXCLUSIVE
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorRangeArgument.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorRangeArgument.kt
@@ -17,4 +17,11 @@ public enum class SelectorRangeArgument(
 
     /** Horizontal rotation. Descending wrap-around bounds are valid. */
     Y_ROTATION("y_rotation", hasNonNegativeOrderedBounds = false),
+    ;
+
+    internal companion object {
+        private val byArgumentName = entries.associateBy(SelectorRangeArgument::argumentName)
+
+        fun fromArgumentName(name: String): SelectorRangeArgument? = byArgumentName[name]
+    }
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSort.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSort.kt
@@ -19,4 +19,11 @@ public enum class SelectorSort(
 
     /** Does not request a defined result order. */
     ARBITRARY("arbitrary"),
+    ;
+
+    internal companion object {
+        private val byValue = entries.associateBy(SelectorSort::value)
+
+        fun fromValue(value: String): SelectorSort? = byValue[value]
+    }
 }

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorCoordinateTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorCoordinateTest.kt
@@ -55,6 +55,12 @@ class EntitySelectorCoordinateTest :
                         origin(1.x, 2.x)
                     }
                 }
+
+                shouldThrow<IllegalStateException> {
+                    entities {
+                        volume(1.dx, 2.dx)
+                    }
+                }
             }
 
             "finite coordinates render without unsupported exponent notation" {


### PR DESCRIPTION
## Summary

Simplify the selector model and builder state.

## Scope

- Refine selector model types and builder state.
- Keep the selector model tests with the production changes.

## Rationale

The model and builder contracts form the selector foundation. Parser edge cases are kept in the following layer so each concern remains reviewable.

## Testing

- `./gradlew :core:test --tests 'io.github.lmliam.kotventure.core.selector.*'`
- `./gradlew :core:spotlessCheck`

## Stack

This PR is part of the stacked replacement for #344.

- Depends on: [#347](https://github.com/LMLiam/Kotventure/pull/347)
- Followed by: [#349](https://github.com/LMLiam/Kotventure/pull/349)