### PR TITLE
fix(selector): harden parser edge cases

### DIFF
--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/EntitySelectorParser.kt
@@ -2,7 +2,6 @@ package io.github.lmliam.kotventure.core.selector
 
 import io.github.lmliam.kotventure.core.selector.parsing.SelectorReader
 import io.github.lmliam.kotventure.core.selector.parsing.readArgumentValue
-import io.github.lmliam.kotventure.core.selector.readSelectorArgument
 
 /**
  * Parses one complete Java Edition entity selector.
@@ -32,8 +31,7 @@ private fun SelectorReader.readSelectorHead(): EntitySelectorHead {
     expect('@', "Expected '@' to begin an entity selector")
     val tokenOffset = offset
     val token = "@${readWhile { it != '[' }}"
-    return EntitySelectorHead.entries.firstOrNull { it.token == token }
-        ?: failAt(tokenOffset, "Unsupported selector head")
+    return EntitySelectorHead.fromToken(token) ?: failAt(tokenOffset, "Unsupported selector head")
 }
 
 private fun SelectorReader.readSelectorArguments(head: EntitySelectorHead): List<EntitySelectorArgument> {
@@ -57,11 +55,17 @@ private fun SelectorReader.readSelectorArgument(
     occurrences: SelectorArgumentOccurrences,
 ): EntitySelectorArgument {
     val nameOffset = offset
-    val name = readWhile { it !in "=,]" }
-    if (name.isEmpty()) failAt(nameOffset, "Expected selector argument")
+    val name = readSelectorArgumentName(nameOffset)
+
     occurrences.recordName(name)?.let { failAt(nameOffset, it) }
     expect('=', "Expected '=' after selector argument '$name'")
-    val argument = readArgumentValue(head, name, nameOffset)
-    occurrences.recordFilter(argument)?.let { failAt(nameOffset, it) }
-    return argument
+
+    return readArgumentValue(head, name, nameOffset).also { argument ->
+        occurrences.recordFilter(argument)?.let { failAt(nameOffset, it) }
+    }
 }
+
+private fun SelectorReader.readSelectorArgumentName(nameOffset: Int): String =
+    readWhile { it !in "=,]" }.ifEmpty {
+        failAt(nameOffset, "Expected selector argument")
+    }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorArgumentParsing.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorArgumentParsing.kt
@@ -11,8 +11,8 @@ internal fun SelectorReader.readArgumentValue(
     name: String,
     nameOffset: Int,
 ): EntitySelectorArgument {
-    SelectorCoordinate.entries.find { it.argumentName == name }?.let { return readCoordinateArgument(it) }
-    SelectorRangeArgument.entries.find { it.argumentName == name }?.let { return readRangeArgument(it) }
+    SelectorCoordinate.fromArgumentName(name)?.let { return readCoordinateArgument(it) }
+    SelectorRangeArgument.fromArgumentName(name)?.let { return readRangeArgument(it) }
 
     val keyword =
         SelectorArgumentKeyword.fromSourceName(name)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorFilterArgumentParsing.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorFilterArgumentParsing.kt
@@ -8,40 +8,42 @@ import io.github.lmliam.kotventure.core.selector.SelectorStringCondition
 import io.github.lmliam.kotventure.core.selector.SnbtCompoundSource
 
 private inline fun <T> SelectorReader.withNegation(block: SelectorReader.(isNegated: Boolean) -> T): T {
-    val negated = consumeNegation()
-    return block(negated)
+    val isNegated = consumeNegation()
+    return block(isNegated)
 }
 
 internal fun SelectorReader.readGamemodeArgument(): EntitySelectorArgument.GameMode =
-    withNegation { negated ->
+    withNegation { isNegated ->
         val tokenOffset = offset
         val token = readValueToken()
-        val gamemode =
-            GameMode.entries.find { it.value == token }
+        val gameMode =
+            GameMode.fromValue(token)
                 ?: failAt(tokenOffset, "Unsupported game mode '$token'")
-        EntitySelectorArgument.GameMode(gamemode, negated)
+
+        EntitySelectorArgument.GameMode(gameMode, isNegated)
     }
 
 internal fun SelectorReader.readNameArgument(): EntitySelectorArgument.Name =
-    withNegation { negated ->
-        val next = peek()
-        if (next == '"' || next == '\'') return@withNegation EntitySelectorArgument.Name(readQuotedString(), negated)
+    withNegation { isNegated ->
+        val name =
+            when (peek()) {
+                '"', '\'' -> readQuotedString()
+                else -> readValidatedValueToken(description = "name")
+            }
 
-        val tokenOffset = offset
-        val token = readValueToken()
-        validateUnquotedToken(token, tokenOffset, description = "name")
-        EntitySelectorArgument.Name(token, negated)
+        EntitySelectorArgument.Name(name, isNegated)
     }
 
 internal fun SelectorReader.readTypeArgument(): EntitySelectorArgument.Type =
-    withNegation { negated ->
+    withNegation { isNegated ->
         val target =
             if (consume('#')) {
                 SelectorEntityType.Tag(readSelectorKey())
             } else {
                 SelectorEntityType.Direct(readSelectorKey())
             }
-        EntitySelectorArgument.Type(target, negated)
+
+        EntitySelectorArgument.Type(target, isNegated)
     }
 
 internal fun SelectorReader.readTagArgument(): EntitySelectorArgument.Tag =
@@ -51,20 +53,34 @@ internal fun SelectorReader.readTeamArgument(): EntitySelectorArgument.Team =
     EntitySelectorArgument.Team(readStringCondition())
 
 private fun SelectorReader.readStringCondition(): SelectorStringCondition =
-    withNegation { negated ->
-        val tokenOffset = offset
-        val token = readValueToken().also { if (it.isNotEmpty()) validateUnquotedToken(it, tokenOffset) }
-        SelectorStringCondition(token, negated)
+    withNegation { isNegated ->
+        SelectorStringCondition(readValidatedValueToken(allowEmpty = true), isNegated)
     }
 
 internal fun SelectorReader.readNbtArgument(): EntitySelectorArgument.Nbt =
-    withNegation { negated ->
+    withNegation { isNegated ->
         val start = offset
         validateSnbtCompound()
-        EntitySelectorArgument.Nbt(SnbtCompoundSource(substringFrom(start)), negated)
+        EntitySelectorArgument.Nbt(SnbtCompoundSource(substringFrom(start)), isNegated)
     }
 
 internal fun SelectorReader.readPredicateArgument(): EntitySelectorArgument.Predicate =
-    withNegation { negated -> EntitySelectorArgument.Predicate(readSelectorKey(), negated) }
+    withNegation { isNegated ->
+        EntitySelectorArgument.Predicate(readSelectorKey(), isNegated)
+    }
+
+private fun SelectorReader.readValidatedValueToken(
+    description: String = "token",
+    allowEmpty: Boolean = false,
+): String {
+    val tokenOffset = offset
+    val token = readValueToken()
+
+    if (token.isNotEmpty() || !allowEmpty) {
+        validateUnquotedToken(token, tokenOffset, description)
+    }
+
+    return token
+}
 
 private fun SelectorReader.consumeNegation(): Boolean = consume(SELECTOR_NEGATION_PREFIX)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorMapParsing.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorMapParsing.kt
@@ -45,11 +45,8 @@ private fun <T> SelectorReader.readSelectorMap(
 
     return buildList {
         while (true) {
-            val keyOffset = offset
-            val key = readWhile { it != '=' && it != ',' && it != '}' }
-            if (key.isEmpty()) failAt(keyOffset, "Expected $entryName")
-            expect('=')
-            add(readEntry(key, keyOffset))
+            val entry = readSelectorMapEntry(entryName)
+            add(readEntry(entry.key, entry.offset))
 
             when {
                 consume('}') -> break
@@ -59,3 +56,20 @@ private fun <T> SelectorReader.readSelectorMap(
         }
     }
 }
+
+private fun SelectorReader.readSelectorMapEntry(entryName: String): SelectorMapEntry {
+    val offset = offset
+    val key = readWhile { it !in "=,}" }
+
+    if (key.isEmpty()) {
+        failAt(offset, "Expected $entryName")
+    }
+
+    expect('=')
+    return SelectorMapEntry(key, offset)
+}
+
+private data class SelectorMapEntry(
+    val key: String,
+    val offset: Int,
+)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorRangeBounds.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorRangeBounds.kt
@@ -6,25 +6,70 @@ private const val RANGE_SEPARATOR = ".."
 /**
  * Holds parsed bounds and their source offsets for precise validation errors.
  */
-internal class SelectorRangeBounds<T : Comparable<T>>(
+internal class SelectorRangeBounds<T : Comparable<T>> private constructor(
     private val reader: SelectorReader,
-    val minimum: T?,
-    private val minimumOffset: Int,
-    val maximum: T?,
-    private val maximumOffset: Int,
+    private val lower: Bound<T>?,
+    private val upper: Bound<T>?,
 ) {
+    val minimum: T?
+        get() = lower?.value
+
+    val maximum: T?
+        get() = upper?.value
+
     fun requireNonNegative(
         argument: String,
         zero: T,
     ) {
-        if (minimum != null && minimum < zero) reader.failAt(minimumOffset, "'$argument' bounds must be non-negative")
-        if (maximum != null && maximum < zero) reader.failAt(maximumOffset, "'$argument' bounds must be non-negative")
+        if (lower != null && lower.value < zero) {
+            reader.failAt(lower.offset, "'$argument' bounds must be non-negative")
+        }
+
+        if (upper != null && upper.value < zero) {
+            reader.failAt(upper.offset, "'$argument' bounds must be non-negative")
+        }
     }
 
     fun requireOrdered(argument: String) {
-        if (minimum != null && maximum != null && minimum > maximum) {
-            reader.failAt(maximumOffset, "'$argument' minimum must not exceed maximum")
+        val lower = lower ?: return
+        val upper = upper ?: return
+
+        if (lower.value > upper.value) {
+            reader.failAt(upper.offset, "'$argument' minimum must not exceed maximum")
         }
+    }
+
+    private data class Bound<T>(
+        val value: T,
+        val offset: Int,
+    )
+
+    companion object {
+        fun <T : Comparable<T>> exact(
+            reader: SelectorReader,
+            value: T,
+            offset: Int,
+        ): SelectorRangeBounds<T> =
+            Bound(value, offset).let { bound ->
+                SelectorRangeBounds(
+                    reader = reader,
+                    lower = bound,
+                    upper = bound,
+                )
+            }
+
+        fun <T : Comparable<T>> ranged(
+            reader: SelectorReader,
+            minimum: T?,
+            minimumOffset: Int,
+            maximum: T?,
+            maximumOffset: Int,
+        ): SelectorRangeBounds<T> =
+            SelectorRangeBounds(
+                reader = reader,
+                lower = minimum?.let { Bound(it, minimumOffset) },
+                upper = maximum?.let { Bound(it, maximumOffset) },
+            )
     }
 }
 
@@ -35,11 +80,16 @@ internal fun <T : Comparable<T>> SelectorReader.readRangeBounds(
     val minimum = readBound()
 
     if (!consume(RANGE_SEPARATOR)) {
-        minimum ?: failAt(minimumOffset, "Expected a range")
-        return SelectorRangeBounds(this, minimum, minimumOffset, minimum, minimumOffset)
+        return SelectorRangeBounds.exact(
+            reader = this,
+            value = minimum ?: failAt(minimumOffset, "Expected a range"),
+            offset = minimumOffset,
+        )
     }
 
-    if (peek() == '.') fail("Range contains more than one '$RANGE_SEPARATOR' separator")
+    if (peek() == '.') {
+        fail("Range contains more than one '$RANGE_SEPARATOR' separator")
+    }
 
     val maximumOffset = offset
     val maximum = readBound()
@@ -48,19 +98,26 @@ internal fun <T : Comparable<T>> SelectorReader.readRangeBounds(
         failAt(minimumOffset, "Range must contain at least one bound")
     }
 
-    return SelectorRangeBounds(this, minimum, minimumOffset, maximum, maximumOffset)
+    return SelectorRangeBounds.ranged(
+        reader = this,
+        minimum = minimum,
+        minimumOffset = minimumOffset,
+        maximum = maximum,
+        maximumOffset = maximumOffset,
+    )
 }
 
 /** Reads a bound token up to a value delimiter or [RANGE_SEPARATOR]. */
 internal fun SelectorReader.readRangeBoundToken(): String {
     val start = offset
+
     while (true) {
-        val ch = peek() ?: break
-        when (ch) {
-            ',', ']', '}' -> break
-            '.' if peek(1) == '.' -> break
+        when (peek()) {
+            null, ',', ']', '}' -> break
+            '.' -> if (peek(1) == '.') break else skip()
             else -> skip()
         }
     }
+
     return substringFrom(start)
 }

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorRangeParsing.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorRangeParsing.kt
@@ -7,10 +7,12 @@ import io.github.lmliam.kotventure.core.selector.SelectorRangeArgument
 /** Reads and validates a floating-point range for [argument]. */
 internal fun SelectorReader.readDoubleRange(argument: SelectorRangeArgument): SelectorRange {
     val bounds = readRangeBounds { readDoubleBound() }
+
     if (argument.hasNonNegativeOrderedBounds) {
         bounds.requireNonNegative(argument.argumentName, zero = 0.0)
         bounds.requireOrdered(argument.argumentName)
     }
+
     return SelectorRange(bounds.minimum, bounds.maximum)
 }
 
@@ -25,7 +27,11 @@ internal fun SelectorReader.readIntRange(
     nonNegative: Boolean,
 ): SelectorIntRange {
     val bounds = readRangeBounds { readIntBound() }
-    if (nonNegative) bounds.requireNonNegative(argumentName, zero = 0)
+
+    if (nonNegative) {
+        bounds.requireNonNegative(argumentName, zero = 0)
+    }
+
     bounds.requireOrdered(argumentName)
     return SelectorIntRange(bounds.minimum, bounds.maximum)
 }
@@ -35,8 +41,9 @@ internal fun SelectorReader.readIntRange(
  */
 private inline fun <T> SelectorReader.readBound(parser: (String, Int) -> T?): T? {
     val start = offset
-    val token = readRangeBoundToken()
-    return if (token.isEmpty()) null else parser(token, start)
+    return readRangeBoundToken()
+        .takeUnless(String::isEmpty)
+        ?.let { parser(it, start) }
 }
 
 private fun SelectorReader.readIntBound(): Int? = readBound(::parseSelectorInt)

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorReader.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorReader.kt
@@ -15,11 +15,10 @@ internal class SelectorReader(
     var offset: Int = 0
         private set
 
-    fun isAtEnd(): Boolean = offset == source.length
+    fun isAtEnd(): Boolean = offset >= source.length
 
     /** Returns the character [distance] positions ahead without consuming it. */
-    @Suppress("NOTHING_TO_INLINE")
-    inline fun peek(distance: Int = 0): Char? = source.getOrNull(offset + distance)
+    fun peek(distance: Int = 0): Char? = source.getOrNull(offset + distance)
 
     fun skip() {
         offset++
@@ -30,22 +29,32 @@ internal class SelectorReader(
      *
      * Returns `true` when the character was present.
      */
-    fun consume(expected: Char): Boolean = (peek() == expected).also { if (it) offset++ }
+    fun consume(expected: Char): Boolean {
+        if (peek() != expected) return false
+
+        offset++
+        return true
+    }
 
     /**
      * Consumes [expected] if it is the next token.
      *
      * Returns `true` when the token was present.
      */
-    fun consume(expected: String): Boolean =
-        source.startsWith(expected, offset).also { if (it) offset += expected.length }
+    fun consume(expected: String): Boolean {
+        if (!source.startsWith(expected, offset)) return false
+
+        offset += expected.length
+        return true
+    }
 
     fun expect(
         expected: Char,
         message: String = "Expected '$expected'",
     ) {
-        if (peek() != expected) fail(message)
-        offset++
+        if (!consume(expected)) {
+            fail(message)
+        }
     }
 
     /**
@@ -53,7 +62,11 @@ internal class SelectorReader(
      */
     inline fun readWhile(predicate: (Char) -> Boolean): String {
         val start = offset
-        while (peek()?.let(predicate) == true) offset++
+
+        while (peek()?.let(predicate) == true) {
+            offset++
+        }
+
         return substringFrom(start)
     }
 

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorScalarArgumentParsing.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorScalarArgumentParsing.kt
@@ -1,6 +1,5 @@
 package io.github.lmliam.kotventure.core.selector.parsing
 
-import io.github.lmliam.kotventure.core.selector.EntitySelector
 import io.github.lmliam.kotventure.core.selector.EntitySelectorArgument
 import io.github.lmliam.kotventure.core.selector.SelectorCoordinate
 import io.github.lmliam.kotventure.core.selector.SelectorRangeArgument
@@ -16,19 +15,18 @@ internal fun SelectorReader.readLevelArgument(): EntitySelectorArgument.Level =
     EntitySelectorArgument.Level(readIntRange("level", nonNegative = true))
 
 /** Reads a positive `limit` value. */
-internal fun SelectorReader.readLimitArgument(): EntitySelectorArgument.Limit {
-    val limit = readValidatedInt("Selector limit must be positive") { it > 0 }
-    return EntitySelectorArgument.Limit(limit)
-}
+internal fun SelectorReader.readLimitArgument(): EntitySelectorArgument.Limit =
+    EntitySelectorArgument.Limit(
+        readValidatedInt("Selector limit must be positive") { it > 0 },
+    )
 
 /** Reads a [SelectorSort] value. */
 internal fun SelectorReader.readSortArgument(): EntitySelectorArgument.Sort {
     val start = offset
     val token = readValueToken()
-    val sort =
-        SelectorSort.entries.firstOrNull { it.value == token }
-            ?: failAt(start, "Unsupported selector sort '$token'")
-    return EntitySelectorArgument.Sort(sort)
+    return EntitySelectorArgument.Sort(
+        SelectorSort.fromValue(token) ?: failAt(start, "Unsupported selector sort '$token'"),
+    )
 }
 
 /**

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorSnbtParsing.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorSnbtParsing.kt
@@ -28,12 +28,16 @@ private inline fun SelectorReader.readSnbtElements(
 ) {
     skipSnbtWhitespace()
     if (consume(closingDelimiter)) return
+
     while (true) {
         readElement()
         skipSnbtWhitespace()
+
         if (consume(closingDelimiter)) return
+
         expect(',')
         skipSnbtWhitespace()
+
         if (consume(closingDelimiter)) return
     }
 }
@@ -57,40 +61,32 @@ private fun SelectorReader.validateSnbtValue() {
 private fun SelectorReader.validateSnbtListOrArray() {
     expect('[')
     skipSnbtWhitespace()
-    val arrayType = peek()
-    if (arrayType != null && arrayType in SNBT_TYPED_ARRAY_PREFIXES && peek(1) == ';') {
+
+    val typedArrayKind =
+        SnbtTypedArrayKind
+            .fromPrefix(peek())
+            ?.takeIf { peek(1) == ';' }
+
+    if (typedArrayKind != null) {
         skip()
         skip()
-        readSnbtElements(']') { validateSnbtTypedArrayValue(arrayType) }
-        return
+        readSnbtElements(']') { validateSnbtTypedArrayValue(typedArrayKind) }
+    } else {
+        readSnbtElements(']') { validateSnbtValue() }
     }
-    readSnbtElements(']') { validateSnbtValue() }
 }
 
 /**
  * Validates one typed-array element at its source offset.
  */
-private fun SelectorReader.validateSnbtTypedArrayValue(arrayType: Char) {
+private fun SelectorReader.validateSnbtTypedArrayValue(kind: SnbtTypedArrayKind) {
     val valueOffset = offset
     val value = readSnbtUnquotedScalar()
-    if (!isValidSnbtTypedArrayValue(value, arrayType)) {
-        failAt(valueOffset, "Invalid $arrayType array value '$value'")
+
+    if (!kind.accepts(value)) {
+        failAt(valueOffset, "Invalid ${kind.prefix} array value '$value'")
     }
 }
-
-/**
- * Checks the suffix and numeric range of one typed-array element.
- */
-private fun isValidSnbtTypedArrayValue(
-    value: String,
-    arrayType: Char,
-): Boolean =
-    when (arrayType) {
-        'B' -> value.endsWith('b', ignoreCase = true) && value.dropLast(1).toByteOrNull() != null
-        'I' -> value.toIntOrNull() != null
-        'L' -> value.endsWith('l', ignoreCase = true) && value.dropLast(1).toLongOrNull() != null
-        else -> false
-    }
 
 /**
  * Validates one quoted or unquoted compound key.
@@ -101,7 +97,7 @@ private fun SelectorReader.validateSnbtCompoundKey() {
         null -> fail("Expected SNBT compound key")
         else ->
             readWhile(Char::isAllowedInUnquotedSelectorToken)
-                .let { if (it.isEmpty()) fail("Expected SNBT compound key") }
+                .ifEmpty { fail("Expected SNBT compound key") }
     }
 }
 
@@ -114,15 +110,18 @@ private fun SelectorReader.validateSnbtCompoundKey() {
  */
 private fun SelectorReader.readSnbtUnquotedScalar(): String {
     val start = offset
-    while (peek()?.let { !it.isSnbtScalarTerminator() && it.isAllowedInUnquotedSelectorToken() } == true) {
-        skip()
+
+    while (true) {
+        val character = peek() ?: break
+
+        when {
+            character.isSnbtScalarTerminator() -> break
+            character.isAllowedInUnquotedSelectorToken() -> skip()
+            else -> fail("Invalid unquoted SNBT token")
+        }
     }
-    if (peek()?.let { !it.isSnbtScalarTerminator() } == true) {
-        fail("Invalid unquoted SNBT token")
-    }
-    return substringFrom(start).also {
-        if (it.isEmpty()) fail("Expected SNBT value")
-    }
+
+    return substringFrom(start).ifEmpty { fail("Expected SNBT value") }
 }
 
 /**
@@ -137,4 +136,26 @@ private fun SelectorReader.skipSnbtWhitespace() {
     while (peek()?.isWhitespace() == true) skip()
 }
 
-private val SNBT_TYPED_ARRAY_PREFIXES: Set<Char> = setOf('B', 'I', 'L')
+private enum class SnbtTypedArrayKind(
+    val prefix: Char,
+) {
+    BYTE('B') {
+        override fun accepts(value: String): Boolean =
+            value.endsWith('b', ignoreCase = true) && value.dropLast(1).toByteOrNull() != null
+    },
+
+    INT('I') {
+        override fun accepts(value: String): Boolean = value.toIntOrNull() != null
+    },
+
+    LONG('L') {
+        override fun accepts(value: String): Boolean =
+            value.endsWith('l', ignoreCase = true) && value.dropLast(1).toLongOrNull() != null
+    }, ;
+
+    abstract fun accepts(value: String): Boolean
+
+    companion object {
+        fun fromPrefix(prefix: Char?): SnbtTypedArrayKind? = entries.firstOrNull { it.prefix == prefix }
+    }
+}

--- a/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorStringParsing.kt
+++ b/modules/core/src/main/kotlin/io/github/lmliam/kotventure/core/selector/parsing/SelectorStringParsing.kt
@@ -1,9 +1,14 @@
 package io.github.lmliam.kotventure.core.selector.parsing
 
 import io.github.lmliam.kotventure.core.selector.isAllowedInUnquotedSelectorToken
+import io.github.lmliam.kotventure.core.selector.parsing.readQuotedStringEscape
+
+private const val VALUE_DELIMITERS = ",]}"
+private const val QUOTE_CHARACTERS = "'\""
+private const val QUOTED_STRING_ESCAPES = "\"'\\"
 
 /** Reads until the next selector value delimiter (`,`, `]`, or `}`). */
-internal fun SelectorReader.readValueToken(): String = readWhile { it !in ",]}" }
+internal fun SelectorReader.readValueToken(): String = readWhile { it !in VALUE_DELIMITERS }
 
 /**
  * Validates an unquoted selector token.
@@ -36,18 +41,29 @@ internal fun SelectorReader.validateUnquotedToken(
  */
 internal fun SelectorReader.readQuotedString(): String {
     val quoteOffset = offset
-    val quote = peek()?.takeIf { it in "'\"" } ?: error("readQuotedString requires the cursor to be on a quote")
+    val quote =
+        peek()?.takeIf(Char::isSelectorQuote)
+            ?: error("readQuotedString requires the cursor to be on a quote")
     skip()
 
     return buildString {
         while (true) {
             val characterOffset = offset
-            val character = peek() ?: failAt(quoteOffset, "Unterminated quoted string")
-            skip()
-            when (character) {
-                quote -> return@buildString
-                '\\' -> append(handleEscape(quoteOffset, characterOffset))
-                else -> append(character)
+            when (val character = peek() ?: failAt(quoteOffset, "Unterminated quoted string")) {
+                quote -> {
+                    skip()
+                    return@buildString
+                }
+
+                '\\' -> {
+                    skip()
+                    append(readQuotedStringEscape(quoteOffset, characterOffset))
+                }
+
+                else -> {
+                    skip()
+                    append(character)
+                }
             }
         }
     }
@@ -56,12 +72,17 @@ internal fun SelectorReader.readQuotedString(): String {
 /**
  * Reads one quoted-string escape and reports an error at the opening quote or backslash.
  */
-private fun SelectorReader.handleEscape(
+private fun SelectorReader.readQuotedStringEscape(
     quoteOffset: Int,
     escapeOffset: Int,
 ): Char {
     val escaped = peek() ?: failAt(quoteOffset, "Unterminated quoted string")
-    if (escaped !in "\"'\\") failAt(escapeOffset, "Invalid quoted-string escape")
+    if (!escaped.isQuotedStringEscape()) failAt(escapeOffset, "Invalid quoted-string escape")
+
     skip()
     return escaped
 }
+
+private fun Char.isSelectorQuote(): Boolean = this in QUOTE_CHARACTERS
+
+private fun Char.isQuotedStringEscape(): Boolean = this in QUOTED_STRING_ESCAPES

--- a/modules/core/src/test/java/io/github/lmliam/kotventure/core/selector/parsing/SelectorReaderTest.kt
+++ b/modules/core/src/test/java/io/github/lmliam/kotventure/core/selector/parsing/SelectorReaderTest.kt
@@ -1,0 +1,57 @@
+package io.github.lmliam.kotventure.core.selector.parsing
+
+import io.github.lmliam.kotventure.core.selector.EntitySelectorParseException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class SelectorReaderTest :
+    StringSpec(
+        {
+            "treats offsets at or beyond the source length as end of input" {
+                val reader = SelectorReader("x")
+
+                reader.isAtEnd() shouldBe false
+
+                reader.skip()
+                reader.isAtEnd() shouldBe true
+
+                reader.skip()
+                reader.isAtEnd() shouldBe true
+            }
+
+            "successful token consumption commits the cursor" {
+                val reader = SelectorReader("abcXYZ")
+
+                reader.consume("abc") shouldBe true
+                reader.peek() shouldBe 'X'
+                reader.consume("XYZ") shouldBe true
+                reader.isAtEnd() shouldBe true
+            }
+
+            "failed token consumption preserves its starting offset for a later parse" {
+                val reader = SelectorReader("abcdef")
+
+                reader.consume("ab") shouldBe true
+                val startingOffset = reader.offset
+
+                reader.consume("cXYZ") shouldBe false
+                reader.offset shouldBe startingOffset
+                reader.peek() shouldBe 'c'
+
+                reader.consume("cde") shouldBe true
+                reader.peek() shouldBe 'f'
+            }
+
+            "failed expectation leaves the cursor at its failure offset" {
+                val reader = SelectorReader("abc")
+
+                val failure = shouldThrow<EntitySelectorParseException> { reader.expect('x') }
+
+                failure.offset shouldBe 0
+                reader.peek() shouldBe 'a'
+                reader.consume("abc") shouldBe true
+                reader.isAtEnd() shouldBe true
+            }
+        },
+    )

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterArgumentParsingTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterArgumentParsingTest.kt
@@ -29,6 +29,73 @@ class SelectorFilterArgumentParsingTest :
                         )
             }
 
+            "preserves negation across every modeled filter argument" {
+                val parsed =
+                    parseSelector(
+                        """@e[gamemode=!creative,name=!Boss,type=!minecraft:zombie,type=!#minecraft:raiders,tag=!hidden,team=!red,nbt=!{Health:1b},predicate=!my_pack:hidden]""",
+                    )
+
+                parsed.arguments.filterIsInstance<EntitySelectorArgument.GameMode>().single() shouldBe
+                        EntitySelectorArgument.GameMode(GameMode.CREATIVE, isNegated = true)
+                parsed.arguments.filterIsInstance<EntitySelectorArgument.Name>().single() shouldBe
+                        EntitySelectorArgument.Name("Boss", isNegated = true)
+                parsed.arguments.filterIsInstance<EntitySelectorArgument.Type>() shouldBe
+                        listOf(
+                            EntitySelectorArgument.Type(
+                                SelectorEntityType.Direct(key("minecraft", "zombie")),
+                                isNegated = true,
+                            ),
+                            EntitySelectorArgument.Type(
+                                SelectorEntityType.Tag(key("minecraft", "raiders")),
+                                isNegated = true,
+                            ),
+                        )
+                parsed.arguments.filterIsInstance<EntitySelectorArgument.Tag>().single() shouldBe
+                        EntitySelectorArgument.Tag(SelectorStringCondition.Named("hidden", isNegated = true))
+                parsed.arguments.filterIsInstance<EntitySelectorArgument.Team>().single() shouldBe
+                        EntitySelectorArgument.Team(SelectorStringCondition.Named("red", isNegated = true))
+
+                val nbt = parsed.arguments.filterIsInstance<EntitySelectorArgument.Nbt>().single()
+                nbt.isNegated shouldBe true
+                nbt.snbt.value shouldBe "{Health:1b}"
+
+                parsed.arguments.filterIsInstance<EntitySelectorArgument.Predicate>().single() shouldBe
+                        EntitySelectorArgument.Predicate(key("my_pack", "hidden"), isNegated = true)
+            }
+
+            "does not consume exclamation marks inside non-negated values" {
+                val parsed =
+                    parseSelector(
+                        """@e[gamemode=creative,name="!Boss",type=minecraft:zombie,tag=visible,team=red,predicate=my_pack:hidden,nbt={value:"!kept"}]""",
+                    )
+
+                parsed.arguments.filterIsInstance<EntitySelectorArgument.GameMode>().single() shouldBe
+                        EntitySelectorArgument.GameMode(GameMode.CREATIVE, isNegated = false)
+                parsed.arguments.filterIsInstance<EntitySelectorArgument.Name>().single() shouldBe
+                        EntitySelectorArgument.Name("!Boss", isNegated = false)
+                parsed.arguments.filterIsInstance<EntitySelectorArgument.Type>().single() shouldBe
+                        EntitySelectorArgument.Type(
+                            SelectorEntityType.Direct(key("minecraft", "zombie")),
+                            isNegated = false,
+                        )
+                parsed.arguments.filterIsInstance<EntitySelectorArgument.Tag>().single() shouldBe
+                        EntitySelectorArgument.Tag(SelectorStringCondition.Named("visible", isNegated = false))
+                parsed.arguments.filterIsInstance<EntitySelectorArgument.Team>().single() shouldBe
+                        EntitySelectorArgument.Team(SelectorStringCondition.Named("red", isNegated = false))
+                parsed.arguments.filterIsInstance<EntitySelectorArgument.Predicate>().single() shouldBe
+                        EntitySelectorArgument.Predicate(key("my_pack", "hidden"), isNegated = false)
+
+                val nbt = parsed.arguments.filterIsInstance<EntitySelectorArgument.Nbt>().single()
+                nbt.isNegated shouldBe false
+                nbt.snbt.value shouldBe "{value:\"!kept\"}"
+            }
+
+            "rejects repeated filter negation" {
+                "@e[name=!" shouldFailToParseAt "!Boss]"
+                "@e[type=!" shouldFailToParseAt "!minecraft:zombie]"
+                "@e[nbt=!" shouldFailToParseAt "!{}]"
+            }
+
             "renders decoded selector names canonically" {
                 parseSelector("""@e[name='Boss Mob']""") shouldRenderAs """@e[name="Boss Mob"]"""
                 """@e[name="Boss \"Mob\""]""".shouldBeCanonicalSelector()

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterArgumentParsingTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorFilterArgumentParsingTest.kt
@@ -79,9 +79,9 @@ class SelectorFilterArgumentParsingTest :
                             isNegated = false,
                         )
                 parsed.arguments.filterIsInstance<EntitySelectorArgument.Tag>().single() shouldBe
-                        EntitySelectorArgument.Tag(SelectorStringCondition.Named("visible", isNegated = false))
+                        EntitySelectorArgument.Tag(SelectorStringCondition.Named("visible"))
                 parsed.arguments.filterIsInstance<EntitySelectorArgument.Team>().single() shouldBe
-                        EntitySelectorArgument.Team(SelectorStringCondition.Named("red", isNegated = false))
+                        EntitySelectorArgument.Team(SelectorStringCondition.Named("red"))
                 parsed.arguments.filterIsInstance<EntitySelectorArgument.Predicate>().single() shouldBe
                         EntitySelectorArgument.Predicate(key("my_pack", "hidden"), isNegated = false)
 

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorScalarArgumentParsingTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorScalarArgumentParsingTest.kt
@@ -22,6 +22,69 @@ class SelectorScalarArgumentParsingTest :
                         )
             }
 
+            "parses decimal points as part of floating-point range bounds" {
+                val parsed =
+                    parseSelector("@e[distance=1.5,x_rotation=1.5..2.5,y_rotation=..2.5]")
+                val ranges = parsed.arguments.filterIsInstance<EntitySelectorArgument.Range>()
+
+                ranges.size shouldBe 3
+                ranges[0].range.minimum shouldBe 1.5
+                ranges[0].range.maximum shouldBe 1.5
+                ranges[1].range.minimum shouldBe 1.5
+                ranges[1].range.maximum shouldBe 2.5
+                ranges[2].range.minimum shouldBe null
+                ranges[2].range.maximum shouldBe 2.5
+            }
+
+            "parses open-ended and negative decimal floating-point bounds" {
+                val openAbove =
+                    parseSelector("@e[distance=1.5..]")
+                        .arguments
+                        .filterIsInstance<EntitySelectorArgument.Range>()
+                        .single()
+                        .range
+                val negative =
+                    parseSelector("@e[x_rotation=-1.5..-0.25]")
+                        .arguments
+                        .filterIsInstance<EntitySelectorArgument.Range>()
+                        .single()
+                        .range
+
+                openAbove.minimum shouldBe 1.5
+                openAbove.maximum shouldBe null
+                negative.minimum shouldBe -1.5
+                negative.maximum shouldBe -0.25
+            }
+
+            "parses integer range separators independently from decimal bounds" {
+                val parsed = parseSelector("@e[level=1..2,scores={kills=-1..}]")
+                val level =
+                    parsed.arguments
+                        .filterIsInstance<EntitySelectorArgument.Level>()
+                        .single()
+                        .range
+                val score =
+                    parsed.arguments
+                        .filterIsInstance<EntitySelectorArgument.Scores>()
+                        .single()
+                        .scores
+                        .single()
+                        .range
+
+                level.minimum shouldBe 1
+                level.maximum shouldBe 2
+                score.minimum shouldBe -1
+                score.maximum shouldBe null
+            }
+
+            "rejects repeated range separators instead of accepting a valid prefix" {
+                "@e[distance=1.." shouldFailToParseAt ".2]"
+                "@e[distance=1.." shouldFailToParseAt "..2]"
+                "@e[distance=1..2" shouldFailToParseAt "..3]"
+                "@e[distance=..1" shouldFailToParseAt "..2]"
+                "@e[distance=" shouldFailToParseAt "1.2.3]"
+            }
+
             "rejects malformed coordinate values" {
                 "@e[x=" shouldFailToParseAt "NaN]"
                 "@e[x=" shouldFailToParseAt "1..2]"

--- a/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSnbtParsingTest.kt
+++ b/modules/core/src/test/kotlin/io/github/lmliam/kotventure/core/selector/SelectorSnbtParsingTest.kt
@@ -3,6 +3,7 @@ package io.github.lmliam.kotventure.core.selector
 import io.github.lmliam.kotventure.test.selector.shouldBeCanonicalSelector
 import io.github.lmliam.kotventure.test.selector.shouldFailToParseAt
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 
 class SelectorSnbtParsingTest :
     StringSpec(
@@ -16,6 +17,28 @@ class SelectorSnbtParsingTest :
                 """
                 @e[nbt={Bytes:[B;-128b,+127b],Ints:[I;-2147483648,+2147483647],Longs:[L;-9223372036854775808L,+9223372036854775807L]}]
                 """.trimIndent().shouldBeCanonicalSelector()
+            }
+
+            "parses signed typed arrays with kind-specific suffixes" {
+                val parsed =
+                    parseSelector("@e[nbt={Bytes:[B;1b,-2B],Ints:[I;1,-2],Longs:[L;1l,-2L]}]")
+                val nbt = parsed.arguments.filterIsInstance<EntitySelectorArgument.Nbt>().single()
+
+                nbt.snbt.value shouldBe "{Bytes:[B;1b,-2B],Ints:[I;1,-2],Longs:[L;1l,-2L]}"
+            }
+
+            "rejects typed-array elements with the wrong suffix" {
+                "@e[nbt={values:[B;" shouldFailToParseAt "1]}]"
+                "@e[nbt={values:[B;" shouldFailToParseAt "1l]}]"
+                "@e[nbt={values:[I;" shouldFailToParseAt "1b]}]"
+                "@e[nbt={values:[I;" shouldFailToParseAt "1l]}]"
+                "@e[nbt={values:[L;" shouldFailToParseAt "1]}]"
+                "@e[nbt={values:[L;" shouldFailToParseAt "1b]}]"
+            }
+
+            "rejects repeated typed-array suffixes" {
+                "@e[nbt={values:[B;" shouldFailToParseAt "1bb]}]"
+                "@e[nbt={values:[L;" shouldFailToParseAt "1ll]}]"
             }
 
             "preserves Java Edition 26.2 SNBT container forms" {
@@ -47,6 +70,14 @@ class SelectorSnbtParsingTest :
                 "@e[nbt={Data:[I;" shouldFailToParseAt "-2147483649]}]"
                 "@e[nbt={Data:[L;" shouldFailToParseAt "9223372036854775808L]}]"
                 "@e[nbt={Data:[L;" shouldFailToParseAt "-9223372036854775809L]}]"
+            }
+
+            "rejects invalid characters in unquoted SNBT scalars immediately" {
+                "@e[nbt={id:minecraft" shouldFailToParseAt ":stone}]"
+            }
+
+            "rejects empty unquoted SNBT values" {
+                "@e[nbt={value:" shouldFailToParseAt "}]"
             }
         },
     )


### PR DESCRIPTION
## Summary

Harden selector parser edge cases.

## Scope

- Refine selector parsing, rollback, ranges, and negation.
- Keep SNBT typed-array parsing coverage and the related selector regression tests with the parser changes.

## Rationale

Parser correctness is a separate concern from the selector model. Keeping rollback, range, negation, and typed-array cases here makes the parsing contract reviewable in isolation.

## Testing

- `./gradlew :core:test --tests 'io.github.lmliam.kotventure.core.selector.*'`
- `./gradlew :core:spotlessCheck`

## Stack

This PR is part of the stacked replacement for #344.

- Depends on: [#348](https://github.com/LMLiam/Kotventure/pull/348)
- Followed by: [#350](https://github.com/LMLiam/Kotventure/pull/350)