### PR TITLE
refactor(minimessage): simplify component dispatch and style emission

### DIFF
--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslComponents.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslComponents.kt
@@ -11,55 +11,34 @@ import net.kyori.adventure.text.StorageNBTComponent
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.TranslatableComponent
 
-/** Emits [component], or only its children when it is an empty and unstyled text root. */
+/** Emits [component], or only its children when it is an empty, unstyled text root. */
 internal fun KotlinSourceBuilder.appendRoot(component: Component) {
-    if (component is TextComponent && component.content().isEmpty() && !hasDslOutput(component.style())) {
-        component.children().forEach { appendComponent(it) }
-        return
+    if (component.isEmptyTextRoot()) {
+        component.children().forEach(::appendComponent)
+    } else {
+        appendComponent(component)
     }
-
-    appendComponent(component)
 }
 
+/** Emits the applicable Kotventure DSL representation of [component]. */
 internal fun KotlinSourceBuilder.appendComponent(component: Component) {
-    val emitter =
-        componentEmitters.firstOrNull { it.accepts(component) }
-            ?: conversionError("miniToDsl cannot represent component type ${component::class.qualifiedName}.")
+    when (component) {
+        is TextComponent -> appendText(component)
+        is TranslatableComponent -> appendTranslatable(component)
+        is KeybindComponent -> appendKeybind(component)
+        is ScoreComponent -> appendScore(component)
+        is SelectorComponent -> appendSelector(component)
+        is BlockNBTComponent -> appendBlockNbt(component)
+        is EntityNBTComponent -> appendEntityNbt(component)
+        is StorageNBTComponent -> appendStorageNbt(component)
+        is ObjectComponent -> appendObject(component)
 
-    emitter.emit(this, component)
-}
-
-private val componentEmitters: List<ComponentEmitter> =
-    listOf(
-        componentEmitter<TextComponent> { appendText(it) },
-        componentEmitter<TranslatableComponent> { appendTranslatable(it) },
-        componentEmitter<KeybindComponent> { appendKeybind(it) },
-        componentEmitter<ScoreComponent> { appendScore(it) },
-        componentEmitter<SelectorComponent> { appendSelector(it) },
-        componentEmitter<BlockNBTComponent> { appendBlockNbt(it) },
-        componentEmitter<EntityNBTComponent> { appendEntityNbt(it) },
-        componentEmitter<StorageNBTComponent> { appendStorageNbt(it) },
-        componentEmitter<ObjectComponent> { appendObject(it) },
-    )
-
-private class ComponentEmitter(
-    private val accepts: (Component) -> Boolean,
-    private val emitComponent: KotlinSourceBuilder.(Component) -> Unit,
-) {
-    fun accepts(component: Component): Boolean = accepts.invoke(component)
-
-    fun emit(
-        builder: KotlinSourceBuilder,
-        component: Component,
-    ) {
-        emitComponent.invoke(builder, component)
+        else ->
+            conversionError(
+                "miniToDsl cannot represent component type ${component::class.qualifiedName}.",
+            )
     }
 }
 
-private inline fun <reified T : Component> componentEmitter(
-    noinline emit: KotlinSourceBuilder.(T) -> Unit,
-): ComponentEmitter =
-    ComponentEmitter(
-        accepts = { it is T },
-        emitComponent = { component -> emit(component as T) },
-    )
+private fun Component.isEmptyTextRoot(): Boolean =
+    this is TextComponent && content().isEmpty() && !hasDslOutput(style())

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslStyle.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/MiniMessageToDslStyle.kt
@@ -9,51 +9,88 @@ import net.kyori.adventure.text.format.TextDecoration.STRIKETHROUGH
 import net.kyori.adventure.text.format.TextDecoration.State
 import net.kyori.adventure.text.format.TextDecoration.UNDERLINED
 
-private val DECORATIONS: List<TextDecoration> = listOf(BOLD, ITALIC, UNDERLINED, STRIKETHROUGH, OBFUSCATED)
+private val standardDecorations: List<TextDecoration> =
+    listOf(
+        BOLD,
+        ITALIC,
+        UNDERLINED,
+        STRIKETHROUGH,
+        OBFUSCATED,
+    )
 
-private fun TextDecoration.dslFunction(): String = name.lowercase()
+private val TextDecoration.dslFunctionName: String
+    get() = name.lowercase()
 
+/** Returns whether [style] requires any generated DSL output. */
 internal fun hasDslOutput(style: Style): Boolean =
     style.color() != null ||
+            style.shadowColor() != null ||
             style.font() != null ||
             style.insertion() != null ||
-            style.shadowColor() != null ||
             style.clickEvent() != null ||
             style.hoverEvent() != null ||
-            DECORATIONS.any { decoration -> style.decoration(decoration) != State.NOT_SET }
+            style.hasExplicitDecorationState()
 
+/** Emits the complete Kotventure DSL representation of [style]. */
 internal fun KotlinSourceBuilder.appendStyle(style: Style) {
-    style.color()?.let { color -> line("color(${colorLiteral(color)})") }
-    style.shadowColor()?.let { shadow -> line("shadow(${shadowColorLiteral(shadow)})") }
-
-    DECORATIONS.forEach { decoration ->
-        if (style.decoration(decoration) == State.TRUE) {
-            line("${decoration.dslFunction()}()")
-        }
+    style.color()?.let {
+        line("color(${colorLiteral(it)})")
     }
 
-    appendStyleBlock(style)
+    style.shadowColor()?.let {
+        line("shadow(${shadowColorLiteral(it)})")
+    }
 
-    style.clickEvent()?.let { event -> appendClickEvent(event) }
-    style.hoverEvent()?.let { event -> appendHoverEvent(event) }
+    style.decorationsIn(State.TRUE).forEach {
+        line("${it.dslFunctionName}()")
+    }
+
+    appendStyleOverrides(style)
+
+    style.clickEvent()?.let {
+        appendClickEvent(it)
+    }
+
+    style.hoverEvent()?.let {
+        appendHoverEvent(it)
+    }
 }
 
 /**
- * Emits a style block for font, insertion, and disabled decorations.
+ * Emits properties that must appear inside the explicit `style` block.
+ *
+ * This includes font, insertion, and decoration states set explicitly to `false`.
  */
-private fun KotlinSourceBuilder.appendStyleBlock(style: Style) {
+private fun KotlinSourceBuilder.appendStyleOverrides(style: Style) {
     val font = style.font()
     val insertion = style.insertion()
-    val disabledDecorations =
-        DECORATIONS.filter { decoration -> style.decoration(decoration) == State.FALSE }
+    val disabledDecorations = style.decorationsIn(State.FALSE)
 
     if (font == null && insertion == null && disabledDecorations.isEmpty()) {
         return
     }
 
     block("style") {
-        font?.let { line("font(${keyLiteral(it)})") }
-        insertion?.let { line("insertion(\"${escapeKotlinString(it)}\")") }
-        disabledDecorations.forEach { decoration -> line("${decoration.dslFunction()}(false)") }
+        font?.let {
+            line("font(${keyLiteral(it)})")
+        }
+
+        insertion?.let {
+            line("insertion(${quoted(it)})")
+        }
+
+        disabledDecorations.forEach {
+            line("${it.dslFunctionName}(false)")
+        }
     }
 }
+
+private fun Style.hasExplicitDecorationState(): Boolean =
+    standardDecorations.any {
+        decoration(it) != State.NOT_SET
+    }
+
+private fun Style.decorationsIn(state: State): List<TextDecoration> =
+    standardDecorations.filter {
+        decoration(it) == state
+    }


### PR DESCRIPTION
## Summary

Simplify MiniMessage component dispatch and style emission.

## Scope

- Refine MiniMessage component dispatch.
- Simplify style emission in the component conversion layer.

## Rationale

This layer depends on the source-emission helpers below it but is independent of selector, SNBT, and template validation behaviour.

## Testing

- `./gradlew :minimessage:test :minimessage:spotlessCheck`

## Stack

This PR is part of the stacked replacement for #344.

- Depends on: [#350](https://github.com/LMLiam/Kotventure/pull/350)
- Followed by: [#352](https://github.com/LMLiam/Kotventure/pull/352)