### PR TITLE
refactor(minimessage): simplify selector and SNBT conversion

### DIFF
--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SelectorToDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SelectorToDsl.kt
@@ -7,6 +7,7 @@ import io.github.lmliam.kotventure.core.selector.SelectorAdvancementProgress
 import io.github.lmliam.kotventure.core.selector.SelectorCoordinate
 import io.github.lmliam.kotventure.core.selector.SelectorEntityType
 import io.github.lmliam.kotventure.core.selector.SelectorIntRange
+import io.github.lmliam.kotventure.core.selector.SelectorNegatable
 import io.github.lmliam.kotventure.core.selector.SelectorRange
 import io.github.lmliam.kotventure.core.selector.SelectorRangeArgument
 import io.github.lmliam.kotventure.core.selector.SelectorStringCondition
@@ -14,19 +15,224 @@ import io.github.lmliam.kotventure.core.selector.SelectorStringCondition
 /**
  * Emits the typed selector expression for [selector].
  *
- * Arguments keep model order. Coordinate arguments combine into one `origin` or `volume` call at the position of the
- * first coordinate in that group.
+ * Arguments retain model order. Coordinates in the same group are combined into one `origin` or `volume` call at the
+ * position of that group's first coordinate.
  */
 internal fun KotlinSourceBuilder.appendEntitySelector(selector: EntitySelector) {
-    val factory = selector.head.factoryName
+    val factory = selector.head.dslFactoryName
+
     if (selector.arguments.isEmpty()) {
         line("$factory()")
     } else {
-        block(factory) { appendArguments(selector.arguments) }
+        block(factory) {
+            appendSelectorArguments(selector.arguments)
+        }
     }
 }
 
-private val EntitySelectorHead.factoryName: String
+private fun KotlinSourceBuilder.appendSelectorArguments(arguments: List<EntitySelectorArgument>) {
+    val coordinatesByGroup =
+        arguments
+            .filterIsInstance<EntitySelectorArgument.Coordinate>()
+            .groupBy { it.coordinate.groupFunctionName }
+    val emittedCoordinateGroups = mutableSetOf<String>()
+
+    arguments.forEach { argument ->
+        when (argument) {
+            is EntitySelectorArgument.Coordinate -> {
+                val group = argument.coordinate.groupFunctionName
+
+                if (emittedCoordinateGroups.add(group)) {
+                    appendCoordinateGroup(
+                        function = group,
+                        coordinates = coordinatesByGroup.getValue(group),
+                    )
+                }
+            }
+
+            is EntitySelectorArgument.Range ->
+                line(
+                    "${argument.argument.dslFunctionName}(${argument.range.toDslArgument()})",
+                )
+
+            is EntitySelectorArgument.Level ->
+                line("level(${argument.range.toDslArgument()})")
+
+            is EntitySelectorArgument.Limit ->
+                line("limit(${argument.value})")
+
+            is EntitySelectorArgument.Sort ->
+                line("sort(${argument.value.name.lowercase()})")
+
+            is EntitySelectorArgument.GameMode ->
+                line(
+                    argument.withNegation(
+                        "gamemode(${argument.value.name.lowercase()})",
+                    ),
+                )
+
+            is EntitySelectorArgument.Name ->
+                line(
+                    argument.withNegation(
+                        "name(${quoted(argument.value)})",
+                    ),
+                )
+
+            is EntitySelectorArgument.Type ->
+                line(
+                    argument.withNegation(
+                        argument.target.toDslCall(),
+                    ),
+                )
+
+            is EntitySelectorArgument.Tag ->
+                appendStringCondition(
+                    function = "tag",
+                    condition = argument.condition,
+                )
+
+            is EntitySelectorArgument.Team ->
+                appendStringCondition(
+                    function = "team",
+                    condition = argument.condition,
+                )
+
+            is EntitySelectorArgument.Nbt ->
+                appendNbtFilter(argument)
+
+            is EntitySelectorArgument.Predicate ->
+                line(
+                    argument.withNegation(
+                        "predicate(${keyLiteral(argument.key)})",
+                    ),
+                )
+
+            is EntitySelectorArgument.Scores ->
+                appendScores(argument)
+
+            is EntitySelectorArgument.Advancements ->
+                appendAdvancements(argument)
+        }
+    }
+}
+
+/** Emits one grouped `origin` or `volume` call. */
+private fun KotlinSourceBuilder.appendCoordinateGroup(
+    function: String,
+    coordinates: List<EntitySelectorArgument.Coordinate>,
+) {
+    val arguments =
+        coordinates.joinToString(separator = ", ") {
+            "${it.value.toCoordinateLiteral()}.${it.coordinate.argumentName}"
+        }
+
+    line("$function($arguments)")
+}
+
+/** Emits a named or presence-based tag or team condition. */
+private fun KotlinSourceBuilder.appendStringCondition(
+    function: String,
+    condition: SelectorStringCondition,
+) {
+    when (condition) {
+        is SelectorStringCondition.Named ->
+            line(
+                condition.withNegation(
+                    "$function(${quoted(condition.value)})",
+                ),
+            )
+
+        is SelectorStringCondition.Presence ->
+            line(
+                "$function(${condition.value.name.lowercase()})",
+            )
+    }
+}
+
+private fun KotlinSourceBuilder.appendNbtFilter(argument: EntitySelectorArgument.Nbt) {
+    val snbt = argument.snbt.value
+    val body =
+        snbtToDslBody(snbt)
+            ?: conversionError(
+                "miniToDsl cannot represent selector SNBT $snbt",
+            )
+    val expression =
+        if (body.isEmpty()) {
+            "nbt { }"
+        } else {
+            "nbt { $body }"
+        }
+
+    line(argument.withNegation(expression))
+}
+
+private fun KotlinSourceBuilder.appendScores(argument: EntitySelectorArgument.Scores) {
+    appendEntriesBlock(
+        function = "scores",
+        entries = argument.scores,
+    ) { score ->
+        line(
+            "${quoted(score.objective)} eq ${score.range.toDslArgument()}",
+        )
+    }
+}
+
+private fun KotlinSourceBuilder.appendAdvancements(argument: EntitySelectorArgument.Advancements) {
+    appendEntriesBlock(
+        function = "advancements",
+        entries = argument.advancements,
+    ) { requirement ->
+        val advancement = keyLiteral(requirement.advancement)
+
+        when (val progress = requirement.progress) {
+            is SelectorAdvancementProgress.Completion ->
+                line("$advancement eq ${progress.completed}")
+
+            is SelectorAdvancementProgress.Criteria ->
+                appendAdvancementCriteria(
+                    advancement = advancement,
+                    progress = progress,
+                )
+        }
+    }
+}
+
+private fun KotlinSourceBuilder.appendAdvancementCriteria(
+    advancement: String,
+    progress: SelectorAdvancementProgress.Criteria,
+) {
+    if (progress.criteria.isEmpty()) {
+        line("$advancement eq { }")
+        return
+    }
+
+    block("$advancement eq") {
+        progress.criteria.forEach { criterion ->
+            line(
+                "${quoted(criterion.name)} eq ${criterion.completed}",
+            )
+        }
+    }
+}
+
+private fun <T> KotlinSourceBuilder.appendEntriesBlock(
+    function: String,
+    entries: List<T>,
+    appendEntry: KotlinSourceBuilder.(T) -> Unit,
+) {
+    if (entries.isEmpty()) {
+        line("$function { }")
+        return
+    }
+
+    block(function) {
+        entries.forEach { entry ->
+            appendEntry(entry)
+        }
+    }
+}
+
+private val EntitySelectorHead.dslFactoryName: String
     get() =
         when (this) {
             EntitySelectorHead.NEAREST_PLAYER -> "nearestPlayer"
@@ -37,73 +243,15 @@ private val EntitySelectorHead.factoryName: String
             EntitySelectorHead.NEAREST_ENTITY -> "nearestEntity"
         }
 
-/**
- * Emits selector arguments in model order and groups coordinates.
- */
-private fun KotlinSourceBuilder.appendArguments(arguments: List<EntitySelectorArgument>) {
-    val emittedCoordinateGroups = mutableSetOf<String>()
-
-    arguments.forEach { argument ->
-        when (argument) {
-            is EntitySelectorArgument.Coordinate ->
-                emitCoordinateGroupIfFirstSeen(argument.coordinate.groupFunction, arguments, emittedCoordinateGroups)
-
-            is EntitySelectorArgument.Range ->
-                line("${argument.argument.dslFunction}(${argument.range.toDslArgument()})")
-
-            is EntitySelectorArgument.Level -> line("level(${argument.range.toDslArgument()})")
-            is EntitySelectorArgument.Limit -> line("limit(${argument.value})")
-            is EntitySelectorArgument.Sort -> line("sort(${argument.value.name.lowercase()})")
-
-            is EntitySelectorArgument.GameMode ->
-                line("${argument.negation}gamemode(${argument.value.name.lowercase()})")
-
-            is EntitySelectorArgument.Name ->
-                line("${argument.negation}name(${quoted(argument.value)})")
-
-            is EntitySelectorArgument.Type ->
-                line("${argument.negation}${argument.target.dslFunction}(${keyLiteral(argument.target.key)})")
-
-            is EntitySelectorArgument.Tag -> appendStringCondition("tag", argument.condition)
-            is EntitySelectorArgument.Team -> appendStringCondition("team", argument.condition)
-
-            is EntitySelectorArgument.Nbt -> appendNbtFilter(argument)
-            is EntitySelectorArgument.Predicate ->
-                line("${argument.negation}predicate(${keyLiteral(argument.key)})")
-
-            is EntitySelectorArgument.Scores -> appendScores(argument)
-            is EntitySelectorArgument.Advancements -> appendAdvancements(argument)
-        }
-    }
-}
-
-/**
- * Emits one coordinate group at its first occurrence.
- */
-private fun KotlinSourceBuilder.emitCoordinateGroupIfFirstSeen(
-    groupFunction: String,
-    arguments: List<EntitySelectorArgument>,
-    emittedGroups: MutableSet<String>,
-) {
-    if (!emittedGroups.add(groupFunction)) return
-
-    val coordinates =
-        arguments
-            .filterIsInstance<EntitySelectorArgument.Coordinate>()
-            .filter { it.coordinate.groupFunction == groupFunction }
-            .joinToString(", ") { "${it.value.toCoordinateLiteral()}.${it.coordinate.argumentName}" }
-
-    line("$groupFunction($coordinates)")
-}
-
-private val SelectorCoordinate.groupFunction: String
+private val SelectorCoordinate.groupFunctionName: String
     get() =
         when (this) {
             SelectorCoordinate.X, SelectorCoordinate.Y, SelectorCoordinate.Z -> "origin"
+
             SelectorCoordinate.DX, SelectorCoordinate.DY, SelectorCoordinate.DZ -> "volume"
         }
 
-private val SelectorRangeArgument.dslFunction: String
+private val SelectorRangeArgument.dslFunctionName: String
     get() =
         when (this) {
             SelectorRangeArgument.DISTANCE -> "distance"
@@ -111,94 +259,67 @@ private val SelectorRangeArgument.dslFunction: String
             SelectorRangeArgument.Y_ROTATION -> "yaw"
         }
 
-private val SelectorEntityType.dslFunction: String
+private val SelectorEntityType.dslFunctionName: String
     get() =
         when (this) {
             is SelectorEntityType.Direct -> "type"
             is SelectorEntityType.Tag -> "typeTag"
         }
 
-private val EntitySelectorArgument.Negatable.negation: String
-    get() = if (isNegated) "!" else ""
+private fun SelectorEntityType.toDslCall(): String = "$dslFunctionName(${keyLiteral(key)})"
 
-/** Emits a named or presence condition. */
-private fun KotlinSourceBuilder.appendStringCondition(
-    function: String,
-    condition: SelectorStringCondition,
-) {
-    when (condition) {
-        is SelectorStringCondition.Named ->
-            line("${if (condition.isNegated) "!" else ""}$function(${quoted(condition.value)})")
-
-        is SelectorStringCondition.Presence ->
-            line("$function(${condition.value.name.lowercase()})")
-    }
-}
-
-private fun KotlinSourceBuilder.appendNbtFilter(argument: EntitySelectorArgument.Nbt) {
-    val body =
-        snbtToDslBody(argument.snbt.value)
-            ?: conversionError("miniToDsl cannot represent selector SNBT ${argument.snbt.value}")
-    val call = if (body.isEmpty()) "nbt { }" else "nbt { $body }"
-    line("${argument.negation}$call")
-}
-
-private fun KotlinSourceBuilder.appendScores(argument: EntitySelectorArgument.Scores) =
-    appendEntryBlock("scores", argument.scores) { score ->
-        line("${quoted(score.objective)} eq ${score.range.toDslArgument()}")
-    }
-
-private fun KotlinSourceBuilder.appendAdvancements(argument: EntitySelectorArgument.Advancements) =
-    appendEntryBlock("advancements", argument.advancements) { requirement ->
-        val advancement = keyLiteral(requirement.advancement)
-        when (val progress = requirement.progress) {
-            is SelectorAdvancementProgress.Completion -> line("$advancement eq ${progress.completed}")
-            is SelectorAdvancementProgress.Criteria -> appendCriteria(advancement, progress)
-        }
-    }
-
-private fun KotlinSourceBuilder.appendCriteria(
-    advancement: String,
-    progress: SelectorAdvancementProgress.Criteria,
-) {
-    if (progress.criteria.isEmpty()) {
-        line("$advancement eq { }")
+private fun SelectorNegatable.withNegation(expression: String): String =
+    if (isNegated) {
+        "!$expression"
     } else {
-        block("$advancement eq") {
-            progress.criteria.forEach { line("${quoted(it.name)} eq ${it.completed}") }
-        }
+        expression
     }
-}
 
-private fun <T> KotlinSourceBuilder.appendEntryBlock(
-    function: String,
-    entries: List<T>,
-    appendEntry: KotlinSourceBuilder.(T) -> Unit,
-) {
-    if (entries.isEmpty()) {
-        line("$function { }")
-    } else {
-        block(function) { entries.forEach { appendEntry(it) } }
-    }
-}
+private fun SelectorRange.toDslArgument(): String =
+    rangeDslArgument(
+        minimum = minimum,
+        maximum = maximum,
+        render = ::kotlinDoubleLiteral,
+    )
 
-private fun SelectorRange.toDslArgument(): String = rangeDslArgument(minimum, maximum, Double::toString)
+private fun SelectorIntRange.toDslArgument(): String =
+    rangeDslArgument(
+        minimum = minimum,
+        maximum = maximum,
+        render = ::kotlinIntLiteral,
+    )
 
-private fun SelectorIntRange.toDslArgument(): String = rangeDslArgument(minimum, maximum, Int::toString)
-
-private fun <T> rangeDslArgument(
+private fun <T : Any> rangeDslArgument(
     minimum: T?,
     maximum: T?,
     render: (T) -> String,
 ): String =
     when {
-        minimum != null && minimum == maximum -> "exactly(${render(minimum)})"
-        minimum != null && maximum != null -> "${render(minimum)}..${render(maximum)}"
-        minimum != null -> "atLeast(${render(minimum)})"
-        else -> "atMost(${render(checkNotNull(maximum))})"
+        minimum != null && minimum == maximum ->
+            "exactly(${render(minimum)})"
+
+        minimum != null && maximum != null ->
+            "${render(minimum)}..${render(maximum)}"
+
+        minimum != null ->
+            "atLeast(${render(minimum)})"
+
+        else ->
+            "atMost(${render(checkNotNull(maximum))})"
     }
 
 private fun Double.toCoordinateLiteral(): String {
-    val literal = toString()
-    return if (this < 0 || 'E' in literal) "($literal)" else literal
+    if (!isFinite()) {
+        conversionError("miniToDsl cannot represent non-finite selector coordinate $this")
+    }
+
+    val literal = kotlinDoubleLiteral(this)
+    val requiresParentheses =
+        literal.startsWith('-') || 'E' in literal
+
+    return if (requiresParentheses) {
+        "($literal)"
+    } else {
+        literal
+    }
 }

--- a/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDsl.kt
+++ b/modules/minimessage/src/main/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDsl.kt
@@ -15,70 +15,123 @@ import net.kyori.adventure.nbt.ShortBinaryTag
 import net.kyori.adventure.nbt.StringBinaryTag
 import net.kyori.adventure.nbt.TagStringIO
 
-private val tagStringIO = TagStringIO.tagStringIO()
+private val snbtReader = TagStringIO.tagStringIO()
 
 /**
- * Converts an SNBT compound to the body of a Kotventure NBT block.
+ * Converts an SNBT compound into the body of a Kotventure NBT block.
  *
- * The result contains the `"key" eq value` calls. An empty compound returns an empty string.
+ * The result contains the `"key" eq value` expressions. Compound keys are sorted alphabetically because NBT compounds
+ * do not define an iteration order. An empty compound produces an empty string.
  *
- * Keys use alphabetical order so output is deterministic. NBT compounds do not define key order.
- *
- * @return The DSL body, or null when the source is malformed, has trailing content, or contains an unsupported tag
- * type.
+ * @return the generated DSL body, or `null` when [snbt] is malformed, contains trailing input, or contains an
+ * unsupported tag type.
  */
 internal fun snbtToDslBody(snbt: String): String? {
     val compound =
         try {
-            tagStringIO.asCompound(snbt)
+            snbtReader.asCompound(snbt)
         } catch (_: Exception) {
-            return null
+            null
         }
-    return renderCompoundBody(compound)
+
+    return compound?.toDslBody()
 }
 
-private fun renderCompoundBody(compound: CompoundBinaryTag): String? =
-    compound
-        .keySet()
-        .sorted()
-        .map { key ->
-            val tag = compound.get(key) ?: return null
-            val value = renderTag(tag) ?: return null
-            "\"${escapeKotlinString(key)}\" eq $value"
-        }.joinToString("; ")
+private fun CompoundBinaryTag.toDslBody(): String? {
+    val entries = ArrayList<String>(keySet().size)
 
-private fun renderTag(tag: BinaryTag): String? =
-    when (tag) {
-        is ByteBinaryTag -> kotlinByteLiteral(tag.value())
-        is ShortBinaryTag -> kotlinShortLiteral(tag.value())
-        is IntBinaryTag -> kotlinIntLiteral(tag.value())
-        is LongBinaryTag -> kotlinLongLiteral(tag.value())
-        is FloatBinaryTag -> kotlinFloatLiteral(tag.value())
-        is DoubleBinaryTag -> kotlinDoubleLiteral(tag.value())
-        is StringBinaryTag -> "\"${escapeKotlinString(tag.value())}\""
-        is ByteArrayBinaryTag ->
-            tag.value().joinToString(", ", prefix = "byteArrayOf(", postfix = ")")
+    for (key in keySet().sorted()) {
+        val tag = get(key) ?: return null
+        val value = tag.toDslLiteral() ?: return null
 
-        is IntArrayBinaryTag ->
-            tag.value().joinToString(", ", prefix = "intArrayOf(", postfix = ")") { kotlinIntLiteral(it) }
-
-        is LongArrayBinaryTag ->
-            tag.value().joinToString(", ", prefix = "longArrayOf(", postfix = ")") { kotlinLongLiteral(it) }
-
-        is CompoundBinaryTag ->
-            renderCompoundBody(tag)?.toCompoundLiteral()
-
-        is ListBinaryTag ->
-            renderListLiteral(tag)
-
-        else -> null
+        entries += "${quoted(key)} eq $value"
     }
 
-private fun renderListLiteral(list: ListBinaryTag): String? {
-    if (list.size() == 0) return "list()"
-
-    val elements = list.map { renderTag(it) ?: return null }
-    return elements.joinToString(", ", prefix = "list(", postfix = ")")
+    return entries.joinToString(separator = "; ")
 }
 
-private fun String.toCompoundLiteral(): String = if (isEmpty()) "{ }" else "{ $this }"
+private fun BinaryTag.toDslLiteral(): String? =
+    when (this) {
+        is ByteBinaryTag ->
+            kotlinByteLiteral(value())
+
+        is ShortBinaryTag ->
+            kotlinShortLiteral(value())
+
+        is IntBinaryTag ->
+            kotlinIntLiteral(value())
+
+        is LongBinaryTag ->
+            kotlinLongLiteral(value())
+
+        is FloatBinaryTag ->
+            kotlinFloatLiteral(value())
+
+        is DoubleBinaryTag ->
+            kotlinDoubleLiteral(value())
+
+        is StringBinaryTag ->
+            quoted(value())
+
+        is ByteArrayBinaryTag ->
+            value().toDslLiteral()
+
+        is IntArrayBinaryTag ->
+            value().toDslLiteral()
+
+        is LongArrayBinaryTag ->
+            value().toDslLiteral()
+
+        is CompoundBinaryTag ->
+            toDslBody()?.toCompoundLiteral()
+
+        is ListBinaryTag ->
+            toDslLiteral()
+
+        else ->
+            null
+    }
+
+private fun ListBinaryTag.toDslLiteral(): String? {
+    val elements = ArrayList<String>(size())
+
+    for (element in this) {
+        elements += element.toDslLiteral() ?: return null
+    }
+
+    return elements.joinToString(
+        separator = ", ",
+        prefix = "list(",
+        postfix = ")",
+    )
+}
+
+private fun ByteArray.toDslLiteral(): String =
+    joinToString(
+        separator = ", ",
+        prefix = "byteArrayOf(",
+        postfix = ")",
+    )
+
+private fun IntArray.toDslLiteral(): String =
+    joinToString(
+        separator = ", ",
+        prefix = "intArrayOf(",
+        postfix = ")",
+        transform = ::kotlinIntLiteral,
+    )
+
+private fun LongArray.toDslLiteral(): String =
+    joinToString(
+        separator = ", ",
+        prefix = "longArrayOf(",
+        postfix = ")",
+        transform = ::kotlinLongLiteral,
+    )
+
+private fun String.toCompoundLiteral(): String =
+    if (isEmpty()) {
+        "{ }"
+    } else {
+        "{ $this }"
+    }

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSelectorTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/MiniMessageToDslSelectorTest.kt
@@ -1,6 +1,8 @@
 package io.github.lmliam.kotventure.minimessage
 
+import io.github.lmliam.kotventure.core.selector.EntitySelectorParseException
 import io.github.lmliam.kotventure.minimessage.conversion.MiniMessageToDslWriter
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import net.kyori.adventure.text.Component
@@ -124,6 +126,83 @@ class MiniMessageToDslSelectorTest :
                         """.trimIndent()
                 }
 
+                test("emits Kotlin-safe constants for selector integer boundaries") {
+                    val pattern = "@e[scores={kills=-2147483648}]"
+
+                    assertGoldenRoundTrip(
+                        input = "<selector:'$pattern'>",
+                        expectedSource =
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    scores {
+                                        "kills" eq exactly(Int.MIN_VALUE)
+                                    }
+                                }
+                            )
+                        }
+                        """.trimIndent(),
+                        expectedComponent = Component.selector(pattern),
+                    )
+                }
+
+                test("quotes empty and escaped selector names") {
+                    writeSelector("""@e[name=""]""") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    name("")
+                                }
+                            )
+                        }
+                        """.trimIndent()
+
+                    writeSelector("""@e[name="A\"B\\C"]""") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    name("A\"B\\C")
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("preserves the order of multiple scoreboard objectives") {
+                    writeSelector("@e[scores={z=0..,a=1..2,m=..3}]") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    scores {
+                                        "z" eq atLeast(0)
+                                        "a" eq 1..2
+                                        "m" eq atMost(3)
+                                    }
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("emits explicit advancement completion states") {
+                    writeSelector("@e[advancements={minecraft:story/root=false}]") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    advancements {
+                                        key("minecraft", "story/root") eq false
+                                    }
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
                 test("emits empty compound maps and empty SNBT containers") {
                     writeSelector("@e[nbt={},scores={},advancements={minecraft:story/root={}}]") shouldBe
                             """
@@ -148,6 +227,85 @@ class MiniMessageToDslSelectorTest :
                             selector(
                                 entities {
                                     nbt { "Items" eq list() }
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("parenthesises negative-zero coordinates") {
+                    writeSelector("@e[x=-0.0]") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    origin((-0.0).x)
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("parenthesises coordinates rendered with exponent notation") {
+                    writeSelector("@e[x=100000000000000000000]") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    origin((1.0E20).x)
+                                }
+                            )
+                        }
+                        """.trimIndent()
+
+                    writeSelector("@e[x=-0.00000000000000000001]") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    origin((-1.0E-20).x)
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("rejects non-finite coordinates") {
+                    shouldThrow<EntitySelectorParseException> {
+                        writeSelector("@e[x=NaN]")
+                    }
+
+                    shouldThrow<EntitySelectorParseException> {
+                        writeSelector("@e[x=Infinity]")
+                    }
+                }
+
+                test("groups interleaved coordinates at each group's first position") {
+                    writeSelector("@e[x=1,limit=5,dx=2,y=3,sort=nearest,dy=4,z=5,dz=6]") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    origin(1.0.x, 3.0.y, 5.0.z)
+                                    limit(5)
+                                    volume(2.0.dx, 4.0.dy, 6.0.dz)
+                                    sort(nearest)
+                                }
+                            )
+                        }
+                        """.trimIndent()
+                }
+
+                test("emits a volume group before an origin group when volume appears first") {
+                    writeSelector("@e[dx=2,limit=5,x=1,dy=4,sort=nearest,y=3,dz=6,z=5]") shouldBe
+                            """
+                        component {
+                            selector(
+                                entities {
+                                    volume(2.0.dx, 4.0.dy, 6.0.dz)
+                                    limit(5)
+                                    origin(1.0.x, 3.0.y, 5.0.z)
+                                    sort(nearest)
                                 }
                             )
                         }

--- a/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDslTest.kt
+++ b/modules/minimessage/src/test/kotlin/io/github/lmliam/kotventure/minimessage/conversion/SnbtToDslTest.kt
@@ -177,7 +177,13 @@ class SnbtToDslTest :
             }
 
             "renders an empty list as list()" {
-                snbtToDslBody("{items:[]}") shouldBe "\"items\" eq list()"
+                snbtToDslBody("{items:[]}") shouldBe
+                        "\"items\" eq list()"
+            }
+
+            "renders an empty nested compound" {
+                snbtToDslBody("{value:{}}") shouldBe
+                        "\"value\" eq { }"
             }
 
             "parses quoted keys" {
@@ -188,6 +194,11 @@ class SnbtToDslTest :
             "parses escaped strings" {
                 snbtToDslBody("{msg:\"say \\\"hello\\\"\"}") shouldBe
                         "\"msg\" eq \"say \\\"hello\\\"\""
+            }
+
+            "escapes compound keys and dollar signs" {
+                snbtToDslBody($$"{\"quoted\\\"key\":\"$value\"}") shouldBe
+                        $$"\"quoted\\\"key\" eq \"\\$value\""
             }
 
             "returns null for trailing garbage" {


### PR DESCRIPTION
## Summary

Simplify MiniMessage selector and SNBT conversion.

## Scope

- Refine selector conversion and coordinate-literal formatting.
- Keep exponent-coordinate, negative-zero, and interleaved-coordinate coverage with selector conversion.
- Keep SNBT conversion and typed-array coverage with the conversion changes.

## Rationale

Selector and SNBT conversion are related output-format concerns above the component dispatch layer, with dedicated regression coverage for their literal contracts.

## Testing

- `./gradlew :minimessage:test --tests 'io.github.lmliam.kotventure.minimessage.MiniMessageToDslSelectorTest' --tests 'io.github.lmliam.kotventure.minimessage.conversion.SnbtToDslTest'`
- `./gradlew :minimessage:spotlessCheck`

## Stack

This PR is part of the stacked replacement for #344.

- Depends on: [#351](https://github.com/LMLiam/Kotventure/pull/351)
- Followed by: [#353](https://github.com/LMLiam/Kotventure/pull/353)