### PR TITLE
ci(github): add maintainer approval command

### DIFF
--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -1,0 +1,45 @@
+name: Maintainer approval
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  approve:
+    name: Approve maintainer command
+    if: >-
+      github.event.issue.pull_request
+      && github.event.comment.user.login == 'LMLiam'
+      && github.event.comment.body == '/approve'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Approve pull request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pullNumber = context.issue.number;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+
+            if (pullRequest.state !== 'open') {
+              core.setFailed(`Pull request #${pullNumber} is not open.`);
+              return;
+            }
+
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number: pullNumber,
+              event: 'APPROVE',
+              body: 'Approved by the maintainer slash command.',
+            });


### PR DESCRIPTION
## Summary

Add a maintainer-only `/approve` command for pull request comments.

## Scope

- Add `.github/workflows/maintainer-approval.yml`.
- Listen only for newly created `issue_comment` events.
- Run only for pull requests where the exact commenter login is `LMLiam` and the exact body is `/approve`.
- Use the pinned `actions/github-script` action to submit an `APPROVE` review.
- Grant the job only `pull-requests: write`; do not check out or execute pull request code.

## Rationale

Stacked pull requests authored by the repository owner cannot be approved by that same account. This workflow lets the owner request an approval from the repository's GitHub Actions bot. The workflow becomes active after it is merged because `issue_comment` workflows run from the default branch.

## Testing

- `actionlint .github/workflows/maintainer-approval.yml`
- Ruby YAML parsing
- `git diff --check`
- Verified repository Actions settings allow workflow tokens to approve pull request reviews.

## Security

The workflow uses the least required token permission, exact actor and command matching, an explicit pull request guard, and no untrusted checkout or shell interpolation.