### PR TITLE
ci(workflows): gate merges with maintainer approval status

### DIFF
--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -4,7 +4,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_review:
-    types: [submitted]
+    types: [submitted, dismissed]
 
 permissions: {}
 
@@ -18,13 +18,52 @@ jobs:
       && github.event.comment.body == '/approve')
       || (github.event_name == 'pull_request_review'
       && github.event.review.user.login == 'LMLiam'
-      && github.event.review.state == 'approved')
+      && (github.event.review.state == 'approved'
+      || github.event.review.state == 'changes_requested'
+      || github.event.review.state == 'commented'
+      || github.event.review.state == 'dismissed'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      contents: read
       pull-requests: read
       statuses: write
     steps:
+      - name: Checkout trusted validator
+        if: >-
+          github.event_name == 'issue_comment'
+          || github.event.review.state == 'approved'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Validate pull request title
+        if: >-
+          github.event_name == 'issue_comment'
+          || github.event.review.state == 'approved'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
+        run: bash .github/scripts/validate-conventional-title.sh "$PR_TITLE"
+
+      - name: Collect commit subjects
+        if: >-
+          github.event_name == 'issue_comment'
+          || github.event.review.state == 'approved'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: >-
+          gh api --paginate
+          "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits"
+          --jq '.[].commit.message | split("\n")[0]' > commit-subjects.txt
+
+      - name: Validate commit subjects
+        if: >-
+          github.event_name == 'issue_comment'
+          || github.event.review.state == 'approved'
+        run: bash .github/scripts/validate-conventional-title.sh --stdin < commit-subjects.txt
+
       - name: Record maintainer approval status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f710d8da1b3 # v9.0.0
         with:
@@ -44,8 +83,12 @@ jobs:
               return;
             }
 
+            const reviewState = context.eventName === 'pull_request_review'
+              ? context.payload.review.state
+              : 'approved';
             const headSha = context.eventName === 'pull_request_review'
-              ? context.payload.pull_request.head.sha
+              ? (context.payload.review.commit_id
+                ?? context.payload.pull_request.head.sha)
               : pullRequest.head.sha;
 
             if (!headSha) {
@@ -56,13 +99,16 @@ jobs:
             const approvalSource = context.eventName === 'pull_request_review'
               ? 'manual pull request review'
               : '/approve command';
+            const approved = reviewState === 'approved';
 
             await github.rest.repos.createCommitStatus({
               owner,
               repo,
               sha: headSha,
-              state: 'success',
+              state: approved ? 'success' : 'failure',
               context: 'Maintainer approval',
-              description: `Approved by LMLiam via ${approvalSource}.`,
+              description: approved
+                ? `Approved by LMLiam via ${approvalSource}.`
+                : `Maintainer approval revoked by a ${reviewState} review.`,
               target_url: pullRequest.html_url,
             });

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -15,8 +15,7 @@ jobs:
       (github.event_name == 'issue_comment'
       && github.event.issue.pull_request
       && github.event.comment.user.login == 'LMLiam'
-      && (github.event.comment.body == '/approve'
-      || startsWith(github.event.comment.body, '/approve ')))
+      && github.event.comment.body == '/approve')
       || (github.event_name == 'pull_request_review'
       && github.event.review.user.login == 'LMLiam'
       && (github.event.review.state == 'approved'
@@ -35,18 +34,6 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const { owner, repo } = context.repo;
-            const approvalCommand = context.eventName === 'issue_comment'
-              ? context.payload.comment.body.trim()
-              : undefined;
-            const approvalMatch = approvalCommand?.match(
-              /^\/approve[ \t]+([0-9a-f]{40})$/i,
-            );
-
-            if (context.eventName === 'issue_comment' && !approvalMatch) {
-              core.setFailed('Use /approve followed by the full current head SHA.');
-              return;
-            }
-
             const pullNumber = context.payload.pull_request?.number
               ?? context.payload.issue?.number;
             const { data: pullRequest } = await github.rest.pulls.get({
@@ -69,21 +56,10 @@ jobs:
             const reviewState = context.eventName === 'pull_request_review'
               ? context.payload.review.state
               : 'approved';
-            const approvalSha = approvalMatch?.[1]?.toLowerCase();
-            if (
-              context.eventName === 'issue_comment'
-              && approvalSha !== currentHeadSha.toLowerCase()
-            ) {
-              core.setFailed(
-                `The approved SHA is stale. Use the current head SHA ${currentHeadSha}.`,
-              );
-              return;
-            }
-
             const headSha = context.eventName === 'pull_request_review'
               ? (context.payload.review.commit_id
                 ?? currentHeadSha)
-              : approvalSha;
+              : currentHeadSha;
 
             if (!headSha) {
               core.setFailed(`Pull request #${pullNumber} has no head commit.`);

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -25,45 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
       pull-requests: read
       statuses: write
     steps:
-      - name: Checkout trusted validator
-        if: >-
-          github.event_name == 'issue_comment'
-          || github.event.review.state == 'approved'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          persist-credentials: false
-
-      - name: Validate pull request title
-        if: >-
-          github.event_name == 'issue_comment'
-          || github.event.review.state == 'approved'
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
-        run: bash .github/scripts/validate-conventional-title.sh "$PR_TITLE"
-
-      - name: Collect commit subjects
-        if: >-
-          github.event_name == 'issue_comment'
-          || github.event.review.state == 'approved'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-        run: >-
-          gh api --paginate
-          "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits"
-          --jq '.[].commit.message | split("\n")[0]' > commit-subjects.txt
-
-      - name: Validate commit subjects
-        if: >-
-          github.event_name == 'issue_comment'
-          || github.event.review.state == 'approved'
-        run: bash .github/scripts/validate-conventional-title.sh --stdin < commit-subjects.txt
-
       - name: Record maintainer approval status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f710d8da1b3 # v9.0.0
         with:

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -3,28 +3,36 @@ name: Maintainer approval
 on:
   issue_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
 
 permissions: {}
 
 jobs:
   approve:
-    name: Approve maintainer command
+    name: Record maintainer approval
     if: >-
-      github.event.issue.pull_request
+      (github.event_name == 'issue_comment'
+      && github.event.issue.pull_request
       && github.event.comment.user.login == 'LMLiam'
-      && github.event.comment.body == '/approve'
+      && github.event.comment.body == '/approve')
+      || (github.event_name == 'pull_request_review'
+      && github.event.review.user.login == 'LMLiam'
+      && github.event.review.state == 'approved')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      pull-requests: write
+      pull-requests: read
+      statuses: write
     steps:
-      - name: Approve pull request
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: Record maintainer approval status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f710d8da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |
             const { owner, repo } = context.repo;
-            const pullNumber = context.issue.number;
+            const pullNumber = context.payload.pull_request?.number
+              ?? context.payload.issue?.number;
             const { data: pullRequest } = await github.rest.pulls.get({
               owner,
               repo,
@@ -36,10 +44,25 @@ jobs:
               return;
             }
 
-            await github.rest.pulls.createReview({
+            const headSha = context.eventName === 'pull_request_review'
+              ? context.payload.pull_request.head.sha
+              : pullRequest.head.sha;
+
+            if (!headSha) {
+              core.setFailed(`Pull request #${pullNumber} has no head commit.`);
+              return;
+            }
+
+            const approvalSource = context.eventName === 'pull_request_review'
+              ? 'manual pull request review'
+              : '/approve command';
+
+            await github.rest.repos.createCommitStatus({
               owner,
               repo,
-              pull_number: pullNumber,
-              event: 'APPROVE',
-              body: 'Approved by the maintainer slash command.',
+              sha: headSha,
+              state: 'success',
+              context: 'Maintainer approval',
+              description: `Approved by LMLiam via ${approvalSource}.`,
+              target_url: pullRequest.html_url,
             });

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -15,7 +15,8 @@ jobs:
       (github.event_name == 'issue_comment'
       && github.event.issue.pull_request
       && github.event.comment.user.login == 'LMLiam'
-      && github.event.comment.body == '/approve')
+      && (github.event.comment.body == '/approve'
+      || startsWith(github.event.comment.body, '/approve ')))
       || (github.event_name == 'pull_request_review'
       && github.event.review.user.login == 'LMLiam'
       && (github.event.review.state == 'approved'
@@ -34,6 +35,18 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const { owner, repo } = context.repo;
+            const approvalCommand = context.eventName === 'issue_comment'
+              ? context.payload.comment.body.trim()
+              : undefined;
+            const approvalMatch = approvalCommand?.match(
+              /^\/approve[ \t]+([0-9a-f]{40})$/i,
+            );
+
+            if (context.eventName === 'issue_comment' && !approvalMatch) {
+              core.setFailed('Use /approve followed by the full current head SHA.');
+              return;
+            }
+
             const pullNumber = context.payload.pull_request?.number
               ?? context.payload.issue?.number;
             const { data: pullRequest } = await github.rest.pulls.get({
@@ -47,13 +60,30 @@ jobs:
               return;
             }
 
+            const currentHeadSha = pullRequest.head.sha;
+            if (!currentHeadSha) {
+              core.setFailed(`Pull request #${pullNumber} has no head commit.`);
+              return;
+            }
+
             const reviewState = context.eventName === 'pull_request_review'
               ? context.payload.review.state
               : 'approved';
+            const approvalSha = approvalMatch?.[1]?.toLowerCase();
+            if (
+              context.eventName === 'issue_comment'
+              && approvalSha !== currentHeadSha.toLowerCase()
+            ) {
+              core.setFailed(
+                `The approved SHA is stale. Use the current head SHA ${currentHeadSha}.`,
+              );
+              return;
+            }
+
             const headSha = context.eventName === 'pull_request_review'
               ? (context.payload.review.commit_id
-                ?? context.payload.pull_request.head.sha)
-              : pullRequest.head.sha;
+                ?? currentHeadSha)
+              : approvalSha;
 
             if (!headSha) {
               core.setFailed(`Pull request #${pullNumber} has no head commit.`);


### PR DESCRIPTION
## Summary

- Replace the non-counting Actions-bot review with a `Maintainer approval` commit status.
- Support both maintainer approval paths:
  - `/approve` on a pull request.
  - A manual `APPROVED` review submitted by `LMLiam`.
- Attach the status to the exact reviewed head commit, so a new commit requires a new approval.

## Why

GitHub does not treat the `github-actions[bot]` review as a qualifying protected-branch approval. A required status check lets the explicitly authorised maintainer action gate merges without pretending that the bot is a code owner.

## Validation

- `actionlint` passes for the workflow.
- The embedded `github-script` JavaScript passes a syntax check in an async wrapper.

## Rollout

The repository ruleset's code-owner requirement is already disabled. After this PR is merged, the `Master` ruleset must require the `Maintainer approval` status and set required approving reviews to zero.