### PR TITLE
fix(ci): skip heavy CI for release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
             const releaseOnlyFiles = new Set([
               'CHANGELOG.md',
               '.release-please-manifest.json',
+              'gradle/libs.versions.toml',
             ]);
 
             if (context.eventName === 'push') {
@@ -81,7 +82,7 @@ jobs:
                   .map(f => f.filename)
                   .filter(name => !releaseOnlyFiles.has(name));
                 if (unexpected.length === 0) {
-                  core.info('Release-please merge commit (changelog/manifest only); skip heavy CI.');
+                  core.info('Release-please merge commit (release files only); skip heavy CI.');
                   core.setOutput('run', 'false');
                   return;
                 }

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -92,9 +92,7 @@ The gate skips resource-intensive jobs in these conditions:
 - **PR:** The head branch starts with `release-please--`, and only release files changed.
 - **Push:** The commit message matches `chore(master): release`, and only release files changed.
 
-The release files are `CHANGELOG.md` and `.release-please-manifest.json`.
-
-The gate does **not** skip `gradle/libs.versions.toml`. A version catalogue change always starts the full CI pipeline.
+The release files are `CHANGELOG.md`, `.release-please-manifest.json`, and `gradle/libs.versions.toml`.
 
 When you add release-please `extra-files`, update the gate allowlist in `ci.yml`.
 


### PR DESCRIPTION
## Summary

- Add `gradle/libs.versions.toml` to the Release Please CI allowlist.
- Skip heavy CI for pure release PRs and release merge commits.
- Update the CI documentation.

## Why

PR #343 changes the Release Please extra-file `gradle/libs.versions.toml`. The current allowlist did not include this file, so the release PR ran Build, CodeQL, and Qodana.

The required Status, Title, Commits, and Dependencies checks remain active.

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check`
