### PR TITLE
fix(ci): attest release PRs for QDJVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ permissions:
 # ║  Tier 0 ─ Triage        Gate → Changes (fast, always runs)                ║
 # ║  Tier 1 ─ Core          Lint ┤ Build (parallel, first feedback)            ║
 # ║  Tier 2 ─ Analysis      CodeQL │ Qodana │ Vanilla (after T1 passes)        ║
-# ║  Policy ─ Independent   Dependencies │ Commits                             ║
+# ║  Policy ─ Independent   Dependencies │ Commits │ Release attestation       ║
 # ║  Status ─ Aggregator    Required check (merge gate + merge queue)          ║
 # ╚══════════════════════════════════════════════════════════════════════════════╝
 
@@ -53,6 +53,7 @@ jobs:
       pull-requests: read
     outputs:
       run: ${{ steps.decide.outputs.run }}
+      release_only: ${{ steps.decide.outputs.release_only }}
     steps:
       - name: Decide whether heavy CI should run
         id: decide
@@ -61,6 +62,7 @@ jobs:
           script: |
             const ALWAYS = () => {
               core.setOutput('run', 'true');
+              core.setOutput('release_only', 'false');
             };
 
             const releaseOnlyFiles = new Set([
@@ -79,11 +81,12 @@ jobs:
                   head: context.payload.after,
                 });
                 const unexpected = comparison.data.files
-                  .map(f => f.filename)
+                  .flatMap(f => [f.filename, f.previous_filename].filter(Boolean))
                   .filter(name => !releaseOnlyFiles.has(name));
                 if (unexpected.length === 0) {
                   core.info('Release-please merge commit (release files only); skip heavy CI.');
                   core.setOutput('run', 'false');
+                  core.setOutput('release_only', 'false');
                   return;
                 }
                 core.info(`Release commit has non-release changes; run heavy CI: ${unexpected.join(', ')}`);
@@ -113,12 +116,13 @@ jobs:
             });
 
             const unexpected = files
-              .map((file) => file.filename)
+              .flatMap((file) => [file.filename, file.previous_filename].filter(Boolean))
               .filter((name) => !releaseOnlyFiles.has(name));
 
             if (unexpected.length === 0) {
               core.info('Pure release-please PR; skip heavy CI.');
               core.setOutput('run', 'false');
+              core.setOutput('release_only', 'true');
               return;
             }
 
@@ -556,6 +560,49 @@ jobs:
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
+
+  release_qodana:
+    name: QDJVM (release attestation)
+    needs: gate
+    if: github.event_name == 'pull_request' && needs.gate.result == 'success' && needs.gate.outputs.release_only == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Create release attestation
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('node:fs');
+            const sha = context.payload.pull_request.head.sha;
+            const sarif = {
+              $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+              version: '2.1.0',
+              runs: [{
+                tool: {
+                  driver: {
+                    name: 'QDJVM',
+                    version: 'release-allowlist-attestation',
+                  },
+                },
+                automationDetails: {
+                  id: `release-please/${sha}`,
+                },
+                results: [],
+              }],
+            };
+            fs.writeFileSync('release-qodana.sarif', JSON.stringify(sarif));
+            core.info(`Created the release attestation for ${sha}.`);
+
+      - name: Upload QDJVM release attestation
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          sarif_file: release-qodana.sarif
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          sha: ${{ github.event.pull_request.head.sha }}
+          category: release-please
 
   vanilla:
     name: Vanilla conformance

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -36,7 +36,8 @@ CI
 │
 ├─ Policy (independent of tiers) ──────────────────────────────────
 │   ├─ Dependencies      (dependency-review-action, PRs only)
-│   └─ Commits           (push-to-master subject validation)
+│   ├─ Commits           (push-to-master subject validation)
+│   └─ Release attestation (pure release-please PRs)
 │
 └─ Status (required merge-gate check) ─────────────────────────────
     └─ Aggregates Tier 1 + Vanilla + Dependencies
@@ -66,6 +67,7 @@ The `changes` job in `ci.yml` defines these code paths:
 |-------|:-----------:|:----------:|:------:|:------:|
 | PR (code paths) | ✓ | ✓ | ✓ | ✓ |
 | PR (docs/process only) | ✓ | — | — | — |
+| PR (release-please files only) | ✓ | — | QDJVM attestation | — |
 | Push to `master` (code paths) | ✓ | ✓ | ✓ | ✓ |
 | Push to `master` (docs only) | ✓ | — | — | — |
 | `merge_group` | ✓ | ✓ (path filter skipped) | ✓ | ✓ |
@@ -95,6 +97,10 @@ The gate skips resource-intensive jobs in these conditions:
 The release files are `CHANGELOG.md`, `.release-please-manifest.json`, and `gradle/libs.versions.toml`.
 
 When you add release-please `extra-files`, update the gate allowlist in `ci.yml`.
+
+For a pure release-please PR, the gate also starts the `QDJVM (release attestation)` job. The job uploads a zero-result
+SARIF record with the `QDJVM` tool name. It does not run Qodana. The gate starts this job only when the release branch
+and the complete changed-file allowlist match. If any other file changes, the gate starts the normal CI jobs instead.
 
 ### Full builds
 
@@ -219,7 +225,8 @@ The **Master** repository ruleset protects the default branch. The rulesets API 
 - Require one approval and a code-owner review. Dismiss stale reviews and resolve conversations. Permit only squash
   merges.
 - Require **Status**, **Title**, **Commits**, and **Dependencies**. Require them to be current with the base branch.
-- Block Qodana (`QDJVM`) alerts that have medium or higher security severity, or error severity.
+- Block Qodana (`QDJVM`) alerts that have medium or higher security severity, or error severity. A pure release PR uses
+  the release attestation after the gate verifies that no source files changed.
 - Permit maintainers to bypass the rules in an emergency.
 
 [CODEOWNERS](../.github/CODEOWNERS) assigns `@LMLiam` as the default owner. It also assigns this owner to


### PR DESCRIPTION
## Summary

- Skip Build, CodeQL, Qodana, and Vanilla for pure release-please PRs.
- Upload a zero-result SARIF record with the QDJVM tool name for those PRs.
- Keep genuine QDJVM analysis for every other PR.
- Check both current and previous paths so renames cannot bypass the release allowlist.

## Related Issues

This addresses the QDJVM merge block on PR #343.

## Scope

- [ ] Build tooling
- [x] GitHub Actions workflow
- [ ] Dependency bump
- [ ] Repo config (labels, CODEOWNERS, etc.)

## Review Notes

The release attestation runs only after the Gate verifies the release branch and complete allowlist. It does not run Qodana. The existing ruleset remains unchanged.

## Checklist

- [x] Verify the workflow with actionlint and YAML parsing
- [x] Verify the SARIF shape and JavaScript syntax
- [x] Update `docs/CI.md`
- [ ] Run the full Gradle build (not applicable to CI-only changes)