### PR TITLE
ci(release): harden Release Please PR trust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,11 +152,14 @@ jobs:
 
               return runs
                 .filter((run) => {
-                  const matchingPullRequest = (run.pull_requests || [])
-                    .find((candidate) => candidate.number === pullRequest.number);
-                  return matchingPullRequest
-                    && (matchingPullRequest.head?.sha === pullRequest.head.sha
-                      || run.head_sha === pullRequest.head.sha);
+                  const associatedPullRequests = run.pull_requests || [];
+                  return run.event === 'pull_request_target'
+                    && run.head_sha === pullRequest.head.sha
+                    && run.head_branch === pullRequest.head.ref
+                    && (associatedPullRequests.length === 0
+                      || associatedPullRequests.some(
+                        (candidate) => candidate.number === pullRequest.number,
+                      ));
                 })
                 .sort((left, right) => new Date(right.created_at) - new Date(left.created_at))[0];
             };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [master]
+    types: [opened, edited, synchronize, reopened]
   push:
     branches: [master]
   merge_group:
@@ -49,11 +50,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      actions: read
       contents: read
       pull-requests: read
     outputs:
       run: ${{ steps.decide.outputs.run }}
       release_only: ${{ steps.decide.outputs.release_only }}
+      release_candidate: ${{ steps.decide.outputs.release_candidate }}
     steps:
       - name: Decide whether heavy CI should run
         id: decide
@@ -63,6 +66,13 @@ jobs:
             const ALWAYS = () => {
               core.setOutput('run', 'true');
               core.setOutput('release_only', 'false');
+              core.setOutput('release_candidate', 'false');
+            };
+
+            const FORCE_FULL = () => {
+              core.setOutput('run', 'true');
+              core.setOutput('release_only', 'false');
+              core.setOutput('release_candidate', 'true');
             };
 
             const releaseOnlyFiles = new Set([
@@ -72,25 +82,6 @@ jobs:
             ]);
 
             if (context.eventName === 'push') {
-              const commitMsg = context.payload.head_commit?.message || '';
-              if (/^chore\(master\): release\b/.test(commitMsg)) {
-                const comparison = await github.rest.repos.compareCommits({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  base: context.payload.before,
-                  head: context.payload.after,
-                });
-                const unexpected = comparison.data.files
-                  .flatMap(f => [f.filename, f.previous_filename].filter(Boolean))
-                  .filter(name => !releaseOnlyFiles.has(name));
-                if (unexpected.length === 0) {
-                  core.info('Release-please merge commit (release files only); skip heavy CI.');
-                  core.setOutput('run', 'false');
-                  core.setOutput('release_only', 'false');
-                  return;
-                }
-                core.info(`Release commit has non-release changes; run heavy CI: ${unexpected.join(', ')}`);
-              }
               ALWAYS();
               return;
             }
@@ -101,33 +92,123 @@ jobs:
               return;
             }
 
-            const headRef = context.payload.pull_request.head.ref;
-            if (!headRef.startsWith('release-please--')) {
-              core.info(`Branch ${headRef}: not a release-please PR; run heavy CI.`);
+            const pullRequest = context.payload.pull_request;
+            const repository = `${context.repo.owner}/${context.repo.repo}`;
+            let files;
+            try {
+              files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullRequest.number,
+                per_page: 100,
+              });
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              core.warning(`Could not read pull-request files; run full CI: ${message}`);
+              FORCE_FULL();
+              return;
+            }
+
+            const unexpected = [...new Set(files
+              .flatMap((file) => [file.filename, file.previous_filename].filter(Boolean))
+              .filter((name) => !releaseOnlyFiles.has(name)))].sort();
+            const pureRelease = unexpected.length === 0;
+            const releaseCandidate = pullRequest.head?.ref?.startsWith('release-please--') || pureRelease;
+
+            if (!releaseCandidate) {
               ALWAYS();
               return;
             }
 
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
+            const trustedMetadata =
+              context.payload.repository?.full_name === repository
+              && pullRequest.base.repo?.full_name === repository
+              && pullRequest.base.ref === 'master'
+              && pullRequest.head.repo?.full_name === repository
+              && pullRequest.head.ref === 'release-please--branches--master'
+              && pullRequest.user.login === 'release-please-kotventure[bot]'
+              && pullRequest.user.type === 'Bot'
+              && context.payload.sender?.login === 'release-please-kotventure[bot]'
+              && context.payload.sender?.type === 'Bot';
 
-            const unexpected = files
-              .flatMap((file) => [file.filename, file.previous_filename].filter(Boolean))
-              .filter((name) => !releaseOnlyFiles.has(name));
-
-            if (unexpected.length === 0) {
-              core.info('Pure release-please PR; skip heavy CI.');
-              core.setOutput('run', 'false');
-              core.setOutput('release_only', 'true');
+            if (!trustedMetadata || !pureRelease) {
+              if (unexpected.length > 0) {
+                core.info(`Release candidate has non-release changes; run full CI: ${unexpected.join(', ')}`);
+              } else {
+                core.info('Release candidate lacks trusted App provenance; run full CI.');
+              }
+              FORCE_FULL();
               return;
             }
 
-            core.info(`Release-please PR has non-release changes; run heavy CI: ${unexpected.join(', ')}`);
-            ALWAYS();
+            const findProvenanceRun = async () => {
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'release-provenance.yml',
+                event: 'pull_request_target',
+                per_page: 100,
+              });
+
+              return runs
+                .filter((run) => {
+                  const matchingPullRequest = (run.pull_requests || [])
+                    .find((candidate) => candidate.number === pullRequest.number);
+                  return matchingPullRequest
+                    && (matchingPullRequest.head?.sha === pullRequest.head.sha
+                      || run.head_sha === pullRequest.head.sha);
+                })
+                .sort((left, right) => new Date(right.created_at) - new Date(left.created_at))[0];
+            };
+
+            let provenanceRun;
+            try {
+              for (let attempt = 0; attempt < 6; attempt += 1) {
+                provenanceRun = await findProvenanceRun();
+                if (provenanceRun?.status === 'completed' || attempt === 5) {
+                  break;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 10_000));
+              }
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              core.warning(`Could not read trusted Release Please provenance; run full CI: ${message}`);
+              FORCE_FULL();
+              return;
+            }
+
+            if (!provenanceRun || provenanceRun.status !== 'completed') {
+              core.info('Trusted Release Please provenance is missing or incomplete; run full CI.');
+              FORCE_FULL();
+              return;
+            }
+
+            let jobs;
+            try {
+              jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: provenanceRun.id,
+                per_page: 100,
+              });
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              core.warning(`Could not read the provenance job result; run full CI: ${message}`);
+              FORCE_FULL();
+              return;
+            }
+            const trustedJob = jobs.find((job) => job.name === 'Trusted release provenance');
+
+            if (trustedJob?.status === 'completed' && trustedJob.conclusion === 'success') {
+              core.info('Trusted Release Please provenance verified; skip heavy CI.');
+              core.setOutput('run', 'false');
+              core.setOutput('release_only', 'true');
+              core.setOutput('release_candidate', 'true');
+              return;
+            }
+
+            core.info('Trusted Release Please provenance did not succeed; run full CI.');
+            FORCE_FULL();
 
   changes:
     name: Detect changes
@@ -185,9 +266,13 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           FILTER_CODE: ${{ steps.filter.outputs.code }}
           FILTER_VANILLA: ${{ steps.filter.outputs.vanilla }}
+          RELEASE_CANDIDATE: ${{ needs.gate.outputs.release_candidate }}
         run: |
           set -euo pipefail
-          if [[ "$EVENT_NAME" == "pull_request" || "$EVENT_NAME" == "push" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" && "$RELEASE_CANDIDATE" == "true" ]]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "vanilla=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$EVENT_NAME" == "pull_request" || "$EVENT_NAME" == "push" ]]; then
             echo "code=${FILTER_CODE}" >> "$GITHUB_OUTPUT"
             echo "vanilla=${FILTER_VANILLA}" >> "$GITHUB_OUTPUT"
           else
@@ -750,11 +835,7 @@ jobs:
           fi
 
           if [[ "$run" != "true" ]]; then
-            if [[ "$EVENT_NAME" == "push" ]]; then
-              echo "::notice::Skipped (release-please merge commit)."
-            else
-              echo "::notice::Skipped (pure release-please PR)."
-            fi
+            echo "::notice::Skipped (trusted pure Release Please PR)."
             exit 0
           fi
 

--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -1,0 +1,54 @@
+name: Release provenance
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  trusted-release-provenance:
+    name: Trusted release provenance
+    if: >-
+      github.event.repository.full_name == github.repository
+      && github.event.pull_request.base.repo.full_name == github.repository
+      && github.event.pull_request.base.ref == 'master'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.head.ref == 'release-please--branches--master'
+      && github.event.pull_request.user.login == 'release-please-kotventure[bot]'
+      && github.event.pull_request.user.type == 'Bot'
+      && github.event.sender.login == 'release-please-kotventure[bot]'
+      && github.event.sender.type == 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify Release Please files
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const releaseOnlyFiles = new Set([
+              'CHANGELOG.md',
+              '.release-please-manifest.json',
+              'gradle/libs.versions.toml',
+            ]);
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const unexpected = [...new Set(files
+              .flatMap((file) => [file.filename, file.previous_filename].filter(Boolean))
+              .filter((name) => !releaseOnlyFiles.has(name)))].sort();
+
+            if (unexpected.length > 0) {
+              core.setFailed(`Unexpected Release Please files: ${unexpected.join(', ')}`);
+              return;
+            }
+
+            core.info('Release Please provenance is valid for the release-file allowlist.');

--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -1,6 +1,8 @@
 name: Release provenance
 
 on:
+  # Security boundary for pull_request_target: do not check out PR code or use repository secrets.
+  # Keep contents and pull-requests permissions read-only.
   pull_request_target:
     branches: [master]
     types: [opened, edited, synchronize, reopened]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,23 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+    permissions: {}
     steps:
-      - name: Run release-please
+      - name: Generate Release Please App token
+        id: release-please-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Run Release Please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.release-please-app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -108,6 +108,20 @@ The trusted decision requires all of these conditions:
 The release files are `CHANGELOG.md`, `.release-please-manifest.json`, and
 `gradle/libs.versions.toml`.
 
+The `release-provenance.yml` workflow is the canonical authority for the
+release-only result. The `ci.yml` gate repeats the current-event identity and
+file checks before it accepts that result. Keep these values aligned:
+
+- The workflow identifier is `release-provenance.yml`.
+- The trusted job name is `Trusted release provenance`.
+- The repository, base branch, head branch, bot login, GitHub types, and event
+  sender must match the policy above.
+- The current and previous file names must match the release-file allowlist.
+
+Do not move this contract into a local script or composite action used by the
+`pull_request` workflow. That code can come from the pull request. If the two
+checks differ, the gate runs full CI.
+
 Titles, labels, commit messages, branch prefixes, and file lists do not prove
 Release Please identity. A release-like branch or a pure release-file change
 that does not pass the provenance check forces the normal CI path. This also

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -12,6 +12,7 @@ For local development commands, see [CONTRIBUTING.md](../.github/CONTRIBUTING.md
 |----------|------|----------|---------|
 | **CI** | `ci.yml` | PR, push, `merge_group`, weekly schedule, `workflow_dispatch` | Gate, path filter, parallel lint, build, and analysis. Always reports the required status check |
 | **PR** | `pr.yml` | `pull_request_target` | Title + commit validation, area labels |
+| **Release provenance** | `release-provenance.yml` | `pull_request_target` | Verifies Release Please identity and release files from the default branch |
 | **Release** | `release.yml` | push `master` | Opens or updates release PRs. Creates tags and releases after merge |
 | **OpenSSF Scorecard** | `scorecard.yml` | weekly schedule, `branch_protection_rule`, `workflow_dispatch` | Supply-chain scorecard + SARIF |
 
@@ -21,7 +22,7 @@ For local development commands, see [CONTRIBUTING.md](../.github/CONTRIBUTING.md
 CI
 │
 ├─ Tier 0: Triage ─────────────────────────────────────────────────
-│   ├─ Gate              (skip release-please PRs + merge commits)
+│   ├─ Gate              (verify provenance before a release-only skip)
 │   └─ Detect changes    (path filter → code, vanilla)
 │
 ├─ Tier 1: Core (parallel, fast feedback) ─────────────────────────
@@ -37,7 +38,8 @@ CI
 ├─ Policy (independent of tiers) ──────────────────────────────────
 │   ├─ Dependencies      (dependency-review-action, PRs only)
 │   ├─ Commits           (push-to-master subject validation)
-│   └─ Release attestation (pure release-please PRs)
+│   ├─ Release provenance (default-branch metadata check)
+│   └─ Release attestation (trusted release-please PRs)
 │
 └─ Status (required merge-gate check) ─────────────────────────────
     └─ Aggregates Tier 1 + Vanilla + Dependencies
@@ -67,7 +69,8 @@ The `changes` job in `ci.yml` defines these code paths:
 |-------|:-----------:|:----------:|:------:|:------:|
 | PR (code paths) | ✓ | ✓ | ✓ | ✓ |
 | PR (docs/process only) | ✓ | — | — | — |
-| PR (release-please files only) | ✓ | — | QDJVM attestation | — |
+| PR (trusted Release Please files only) | ✓ | — | QDJVM attestation | — |
+| PR (untrusted release candidate) | ✓ | ✓ | ✓ | ✓ |
 | Push to `master` (code paths) | ✓ | ✓ | ✓ | ✓ |
 | Push to `master` (docs only) | ✓ | — | — | — |
 | `merge_group` | ✓ | ✓ (path filter skipped) | ✓ | ✓ |
@@ -85,22 +88,41 @@ Select Actions → **CI** → **Run workflow**. A manual workflow always starts 
 
 Module names must match `[A-Za-z0-9_-]+`.
 
-### Heavy CI gate (release-please)
+### Heavy CI gate (Release Please)
 
-The CI workflow contains this gate in its `gate` job. The gate handles pull requests and merge commits on `master`.
+The `gate` job skips resource-intensive jobs only for a trusted Release Please
+pull request. The `release-provenance.yml` workflow supplies the independent
+check from the default branch. It does not check out the pull request.
 
-The gate skips resource-intensive jobs in these conditions:
+The trusted decision requires all of these conditions:
 
-- **PR:** The head branch starts with `release-please--`, and only release files changed.
-- **Push:** The commit message matches `chore(master): release`, and only release files changed.
+- The event is a pull-request event for `LMLiam/Kotventure`.
+- The base branch is `master`.
+- The head repository is `LMLiam/Kotventure`.
+- The head branch is exactly `release-please--branches--master`.
+- The author is `release-please-kotventure[bot]` with GitHub type `Bot`.
+- The event sender is `release-please-kotventure[bot]` with GitHub type `Bot`.
+- Current and previous file names are in the release-file allowlist.
+- The trusted provenance job for the current head SHA completed successfully.
 
-The release files are `CHANGELOG.md`, `.release-please-manifest.json`, and `gradle/libs.versions.toml`.
+The release files are `CHANGELOG.md`, `.release-please-manifest.json`, and
+`gradle/libs.versions.toml`.
 
-When you add release-please `extra-files`, update the gate allowlist in `ci.yml`.
+Titles, labels, commit messages, branch prefixes, and file lists do not prove
+Release Please identity. A release-like branch or a pure release-file change
+that does not pass the provenance check forces the normal CI path. This also
+forces full path-filtered CI for a human or fork lookalike.
 
-For a pure release-please PR, the gate also starts the `QDJVM (release attestation)` job. The job uploads a zero-result
-SARIF record with the `QDJVM` tool name. It does not run Qodana. The gate starts this job only when the release branch
-and the complete changed-file allowlist match. If any other file changes, the gate starts the normal CI jobs instead.
+The gate no longer skips CI for a push to `master` based on a commit message.
+Every push uses the normal CI path.
+
+When you add Release Please `extra-files`, update the allowlist in both
+`ci.yml` and `release-provenance.yml`.
+
+For a trusted pure Release Please PR, the gate starts the `QDJVM (release
+attestation)` job. The job uploads a zero-result SARIF record with the `QDJVM`
+tool name. It does not run Qodana. An untrusted release candidate runs normal
+CI instead.
 
 ### Full builds
 
@@ -162,7 +184,10 @@ For an occasional diagnostic scan, give `build-scan: true` to `gradle-job`. The 
 
 | Surface | Behaviour |
 |---------|-----------|
-| Default workflow permissions | `contents: read` |
+| Default workflow permissions | Set the repository default to `contents: read` |
+| Release provenance workflow | Uses `contents: read` and `pull-requests: read`. Does not check out pull-request code |
+| CI gate | Uses `actions: read`, `contents: read`, and `pull-requests: read` |
+| Release workflow | Uses an installation token from `release-please-kotventure`. Its `GITHUB_TOKEN` has no permissions |
 | Build job | Uses `checks: write` and `contents: read`. Cannot write to pull requests. Clears `GITHUB_TOKEN` for Gradle |
 | PR feedback job | Uses `actions: read`, `pull-requests: write`, and `contents: read`. Posts one metrics comment. Uses the cache or artefacts before a base JAR-only build. Clears `GITHUB_TOKEN` for Gradle |
 | Build scans | Off by default. Enable with `build-scan: true` |
@@ -232,6 +257,27 @@ The **Master** repository ruleset protects the default branch. The rulesets API 
 [CODEOWNERS](../.github/CODEOWNERS) assigns `@LMLiam` as the default owner. It also assigns this owner to
 `.github/workflows/`, `.github/actions/`, `.github/scripts/`, and related CI configuration. Thus, code-owner review
 applies to automation changes.
+
+## Release branch protection
+
+Configure an active `Protect Release Please branches` ruleset for
+`refs/heads/release-please--branches--*`. It must block branch creation,
+updates, deletion, and non-fast-forward updates.
+
+The ruleset must have one bypass actor. The actor is the
+`release-please-kotventure` GitHub App Integration. Administrators, repository
+roles, teams, users, `github-actions[bot]`, and unrelated Apps must not bypass
+this ruleset.
+
+Treat this ruleset as a deployment prerequisite for the release-only CI skip.
+Do not merge or enable the workflow changes until GitHub confirms the active
+ruleset, its ref pattern, and its sole App Integration bypass. Keep full CI
+enabled until this verification is complete.
+
+Install the App only on `LMLiam/Kotventure`. Give it Metadata read, Contents
+read/write, Issues read/write, and Pull requests read/write. Store the App ID
+in `RELEASE_PLEASE_APP_ID`. Store the private key in
+`RELEASE_PLEASE_APP_PRIVATE_KEY`. Do not store a private key in the repository.
 
 ## Required vs optional checks
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -56,10 +56,6 @@ Human edits, human commits, fork pull requests, copied titles, copied labels,
 and release-like branches run normal CI. Titles and labels are not
 authentication data.
 
-PR #343 is human-authored. Do not merge or close it in this phase. It runs full
-CI. A later App-created Release Please PR is required for the release-only
-optimisation.
-
 ## App setup and key rotation
 
 If the App does not exist, register `release-please-kotventure` in GitHub.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,16 +6,82 @@ After the release PR merge, release-please makes the Git tag and GitHub Release.
 
 ## Release Automation
 
-The `Release Please` workflow runs after a push to `master`. It reads `release-please-config.json` and
-`.release-please-manifest.json`. Then, it opens or updates one root release PR.
+The `Release Please` workflow runs after a push to `master`. It reads
+`release-please-config.json` and `.release-please-manifest.json`. Then, it
+opens or updates one root release PR.
 
-The workflow uses `RELEASE_PLEASE_TOKEN` when it is available. If it is not available, the workflow uses `GITHUB_TOKEN`.
-Use `RELEASE_PLEASE_TOKEN` for normal releases. Items made with `GITHUB_TOKEN` do not start subsequent workflows.
+The workflow creates a short-lived installation token for the dedicated GitHub
+App `release-please-kotventure`. The resulting bot login is
+`release-please-kotventure[bot]`. Release Please receives this token explicitly.
+The workflow does not use a personal access token, a machine-user token, or a
+fallback `GITHUB_TOKEN` token.
 
-`RELEASE_PLEASE_TOKEN` is usually a fine-grained personal access token or GitHub App installation token.
-It needs repository permission to write contents, issues, and pull requests. GitHub attributes a personal token to its user account.
-Thus, heavy CI uses a **path-based** release-please gate instead of actor detection. Refer to [CI.md](./CI.md).
-A GitHub App or machine-user token gives the automation a clear identity with the same workflow.
+Install the App only on `LMLiam/Kotventure`. Give it these repository
+permissions:
+
+- Metadata: read.
+- Contents: read and write.
+- Issues: read and write.
+- Pull requests: read and write.
+
+Store the App ID in the Actions variable `RELEASE_PLEASE_APP_ID`. Store the
+private key in the Actions secret `RELEASE_PLEASE_APP_PRIVATE_KEY`. Do not
+print or commit the private key.
+
+The workflow scopes the installation token to this repository. The action
+revokes the token after the job. Refer to [CI.md](./CI.md) for the trust and
+permission model.
+
+## Release PR provenance
+
+The Release Please branch is `release-please--branches--master`. Configure an
+active `Protect Release Please branches` ruleset for
+`refs/heads/release-please--branches--*`.
+
+The ruleset must allow only the `release-please-kotventure` App Integration to
+create, update, or delete these branches. It must block force pushes. It must
+not give bypass access to administrators, repository roles, teams, users,
+`github-actions[bot]`, or unrelated GitHub Apps.
+
+Treat the active ruleset as a deployment prerequisite. Do not merge or enable
+the workflow changes until GitHub confirms the ruleset, ref pattern, and sole
+App bypass. Keep full CI enabled until this verification is complete.
+
+The CI gate skips heavy jobs only after `release-provenance.yml` verifies the
+App identity, repository, branch, event sender, and complete release-file
+allowlist. The provenance workflow runs from the default branch. It does not
+check out the pull request.
+
+Human edits, human commits, fork pull requests, copied titles, copied labels,
+and release-like branches run normal CI. Titles and labels are not
+authentication data.
+
+PR #343 is human-authored. Do not merge or close it in this phase. It runs full
+CI. A later App-created Release Please PR is required for the release-only
+optimisation.
+
+## App setup and key rotation
+
+If the App does not exist, register `release-please-kotventure` in GitHub.
+Do not add `[bot]` to the registered App name. GitHub adds the suffix to the
+bot login.
+
+Install the App only on `LMLiam/Kotventure`. Disable webhooks. Generate a
+private key and store it directly in the repository secret. Do not paste the
+key into chat or a terminal command.
+
+If the key is exposed or rotation is due, generate a new key in GitHub. Store
+the new key in `RELEASE_PLEASE_APP_PRIVATE_KEY`. Run a controlled Release
+Please test. Revoke the old key only after the new key works.
+
+If the App must be replaced, disable the release workflow first. Install the
+replacement App only on this repository. Update the variable, secret, and
+ruleset bypass. Verify the App bot login and branch ruleset. Then enable the
+workflow.
+
+If a Release Please run cannot update its branch, check the App installation,
+repository scope, App permissions, variable name, secret presence, and the
+ruleset Integration ID. Do not add an administrator or role bypass.
 
 ## Version Policy
 
@@ -30,16 +96,22 @@ After a release automation change, compare the policy with [ROADMAP.md](./ROADMA
 
 ## Branch Protection
 
-Keep `master` protected and release through the release PR. The **Master** ruleset requires a PR, reviews, and specified status checks.
-[CI.md](./CI.md) lists these checks. Release automation must update the release branch and apply release labels.
-Merge the release PR only after all required checks pass.
+Keep `master` protected and release through the release PR. The **Master**
+ruleset requires a PR, reviews, and specified status checks. [CI.md](./CI.md)
+lists these checks. Release automation must update the release branch and
+apply release labels. Merge the release PR only after all required checks pass.
 
-Use `RELEASE_PLEASE_TOKEN` so the release PR starts the normal CI workflows.
-Release-please can open a PR with `GITHUB_TOKEN`, but GitHub prevents subsequent workflows from that token.
+A trusted pure Release Please PR changes only the changelog, manifest, and
+`gradle/libs.versions.toml`. It does not run the heavy Build, Qodana, and
+CodeQL work. Dependency Review and conventional-title checks remain required.
+An untrusted release candidate runs normal CI. The workflow also applies
+labels. Refer to [CI.md](./CI.md).
 
-A pure release-please PR changes only the changelog, manifest, and `gradle/libs.versions.toml`.
-It does not run the heavy Build, Qodana, and CodeQL work. Dependency Review and conventional-title checks remain required.
-The workflow also applies labels. Refer to [CI.md](./CI.md).
+If rollback is required, keep full CI enabled. Disable the release workflow
+before changing the App. Disable the release-branch ruleset before removing
+its bypass. Remove the repository variable and secret without reading the
+private key. Uninstall the App and revoke its key through GitHub. Do not
+restore the old personal access token or the weak branch-name check.
 
 ## Publishing Coordination
 


### PR DESCRIPTION
## Summary

This draft implements the approved Release Please security hardening.

- Authenticate Release Please with the dedicated `release-please-kotventure` GitHub App.
- Scope the short-lived installation token to `LMLiam/Kotventure`.
- Add default-branch provenance checks for the exact App-created release PR.
- Run full CI for human, fork, label, title, branch-name, sender, and stale-provenance lookalikes.
- Keep the QDJVM release attestation for trusted release PRs.
- Remove the push release-message optimisation.
- Document App setup, ruleset operation, rotation, validation, and rollback.

## Security controls

- The active `Protect Release Please branches` ruleset protects `release-please--branches--*`.
- Its sole bypass actor is the `release-please-kotventure` Integration.
- The provenance workflow uses `pull_request_target`, read-only permissions, no checkout, exact repository and identity checks, and the complete release-file allowlist.
- The CI gate requires a successful provenance result for the same PR and head SHA.
- PR #343 remains untouched. This change does not merge or close it.
- This change does not publish a release.

## Validation

- `actionlint .github/workflows/*.yml`
- Ruby YAML parsing for all workflows
- `git diff --check`
- Secret-marker scan
- Release Please configuration and manifest unchanged
- App installation, permissions, repository scope, variable, and secret presence verified
- Human branch creation and update attempts rejected by the ruleset
- App temporary branch create, update, and delete operations verified

The positive provenance skip cannot run until this workflow is on the default branch. Until then, the CI gate fails closed and runs normal CI. The existing `RELEASE_PLEASE_TOKEN` secret remains until the new workflow has run successfully.