### PR TITLE
docs(ci): clarify Release Please verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -692,6 +692,55 @@ jobs:
           sha: ${{ github.event.pull_request.head.sha }}
           category: release-please
 
+  non_code_qodana:
+    name: QDJVM (non-code attestation)
+    needs: [gate, changes]
+    if: >-
+      github.event_name == 'pull_request'
+      && needs.gate.result == 'success'
+      && needs.gate.outputs.run == 'true'
+      && needs.gate.outputs.release_candidate == 'false'
+      && needs.changes.result == 'success'
+      && needs.changes.outputs.code == 'false'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Create non-code attestation
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('node:fs');
+            const sha = context.payload.pull_request.head.sha;
+            const sarif = {
+              $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+              version: '2.1.0',
+              runs: [{
+                tool: {
+                  driver: {
+                    name: 'QDJVM',
+                    version: 'non-code-path-attestation',
+                  },
+                },
+                automationDetails: {
+                  id: `non-code/${sha}`,
+                },
+                results: [],
+              }],
+            };
+            fs.writeFileSync('non-code-qodana.sarif', JSON.stringify(sarif));
+            core.info(`Created the non-code attestation for ${sha}.`);
+
+      - name: Upload QDJVM non-code attestation
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          sarif_file: non-code-qodana.sarif
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          sha: ${{ github.event.pull_request.head.sha }}
+          category: non-code
+
   vanilla:
     name: Vanilla conformance
     needs: [lint, build, changes]

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -39,6 +39,7 @@ CI
 │   ├─ Dependencies      (dependency-review-action, PRs only)
 │   ├─ Commits           (push-to-master subject validation)
 │   ├─ Release provenance (default-branch metadata check)
+│   ├─ QDJVM non-code attestation (docs/process-only PRs)
 │   └─ Release attestation (trusted release-please PRs)
 │
 └─ Status (required merge-gate check) ─────────────────────────────
@@ -68,7 +69,7 @@ The `changes` job in `ci.yml` defines these code paths:
 | Event | CI workflow | Heavy jobs | Qodana | CodeQL |
 |-------|:-----------:|:----------:|:------:|:------:|
 | PR (code paths) | ✓ | ✓ | ✓ | ✓ |
-| PR (docs/process only) | ✓ | — | — | — |
+| PR (docs/process only) | ✓ | — | non-code attestation | — |
 | PR (trusted Release Please files only) | ✓ | — | QDJVM attestation | — |
 | PR (untrusted release candidate) | ✓ | ✓ | ✓ | ✓ |
 | Push to `master` (code paths) | ✓ | ✓ | ✓ | ✓ |
@@ -142,6 +143,12 @@ attestation)` job. The job uploads a zero-result SARIF record with the `QDJVM`
 tool name. It does not run Qodana. An untrusted release candidate runs normal
 CI instead.
 
+For a normal pull request with no code paths, CI starts the `QDJVM (non-code
+attestation)` job. The job uploads a zero-result SARIF record with the `QDJVM`
+tool name and the `non-code` category. This records the path-filter decision.
+It does not claim that Qodana scanned code. Code-path pull requests use the
+normal Qodana job instead. Release candidates do not use this attestation.
+
 ### Full builds
 
 Pull requests, pushes, merge groups, schedules, and manual dispatches use the complete default task set:
@@ -205,6 +212,7 @@ For an occasional diagnostic scan, give `build-scan: true` to `gradle-job`. The 
 | Default workflow permissions | Set the repository default to `contents: read` |
 | Release provenance workflow | Uses `contents: read` and `pull-requests: read`. Does not check out pull-request code |
 | CI gate | Uses `actions: read`, `contents: read`, and `pull-requests: read` |
+| Non-code QDJVM attestation | Uses `contents: read` and `security-events: write`. Does not check out pull-request code |
 | Release workflow | Uses an installation token from `release-please-kotventure`. Its `GITHUB_TOKEN` has no permissions |
 | Build job | Uses `checks: write` and `contents: read`. Cannot write to pull requests. Clears `GITHUB_TOKEN` for Gradle |
 | PR feedback job | Uses `actions: read`, `pull-requests: write`, and `contents: read`. Posts one metrics comment. Uses the cache or artefacts before a base JAR-only build. Clears `GITHUB_TOKEN` for Gradle |

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -130,6 +130,10 @@ forces full path-filtered CI for a human or fork lookalike.
 The gate no longer skips CI for a push to `master` based on a commit message.
 Every push uses the normal CI path.
 
+When a later release-worthy change creates a Release Please pull request, verify
+that the pull request is authored by `release-please-kotventure[bot]` before
+relying on the release-only CI path.
+
 When you add Release Please `extra-files`, update the allowlist in both
 `ci.yml` and `release-provenance.yml`.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-# Release Please updates the project version in this catalogue.
 project = "0.26.0"
 adventureApi = "5.2.0"
 dokka = "2.2.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+# Release Please updates the project version in this catalogue.
 project = "0.26.0"
 adventureApi = "5.2.0"
 dokka = "2.2.0"


### PR DESCRIPTION
This is a controlled documentation-only validation change. Merge it to trigger Release Please and verify the App-authored release PR path. Do not merge the generated release PR during this test.