### PR TITLE
docs(ci): explain non-code QDJVM requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -673,6 +673,17 @@ jobs:
                   driver: {
                     name: 'QDJVM',
                     version: 'release-allowlist-attestation',
+                    rules: [{
+                      id: 'attestation/release-please-files',
+                      name: 'Release Please file allowlist',
+                      shortDescription: {
+                        text: 'Release Please changed only the approved release files.',
+                      },
+                      fullDescription: {
+                        text: 'The trusted Release Please provenance check approved the release file allowlist.',
+                      },
+                      defaultConfiguration: { level: 'note' },
+                    }],
                   },
                 },
                 automationDetails: {
@@ -722,6 +733,17 @@ jobs:
                   driver: {
                     name: 'QDJVM',
                     version: 'non-code-path-attestation',
+                    rules: [{
+                      id: 'attestation/no-code-paths',
+                      name: 'No code paths changed',
+                      shortDescription: {
+                        text: 'The pull request changed no code paths.',
+                      },
+                      fullDescription: {
+                        text: 'The CI path filter found no files that require a code scan.',
+                      },
+                      defaultConfiguration: { level: 'note' },
+                    }],
                   },
                 },
                 automationDetails: {

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -148,6 +148,7 @@ attestation)` job. The job uploads a zero-result SARIF record with the `QDJVM`
 tool name and the `non-code` category. This records the path-filter decision.
 It does not claim that Qodana scanned code. Code-path pull requests use the
 normal Qodana job instead. Release candidates do not use this attestation.
+The `Master` ruleset requires this result for every pull request.
 
 ### Full builds
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -148,7 +148,10 @@ attestation)` job. The job uploads a zero-result SARIF record with the `QDJVM`
 tool name and the `non-code` category. This records the path-filter decision.
 It does not claim that Qodana scanned code. Code-path pull requests use the
 normal Qodana job instead. Release candidates do not use this attestation.
-The `Master` ruleset requires this result for every pull request.
+The `Master` ruleset requires the applicable QDJVM result for each pull
+request: non-code pull requests use this attestation, code pull requests use
+the normal Qodana result, and trusted Release Please pull requests use the
+release attestation.
 
 ### Full builds
 


### PR DESCRIPTION
This is a controlled documentation-only validation change. It verifies that an ordinary docs pull request receives the non-code QDJVM attestation and remains mergeable without heavy CI. Do not merge the generated Release Please PR during this test.