### PR TITLE
docs(ci): explain attestation rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,11 +697,13 @@ jobs:
 
       - name: Upload QDJVM release attestation
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        env:
+          CODEQL_ACTION_ANALYSIS_KEY: .github/workflows/ci.yml:qodana
         with:
           sarif_file: release-qodana.sarif
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           sha: ${{ github.event.pull_request.head.sha }}
-          category: release-please
+          category: Kotventure/qodana
 
   non_code_qodana:
     name: QDJVM (non-code attestation)
@@ -757,11 +759,13 @@ jobs:
 
       - name: Upload QDJVM non-code attestation
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        env:
+          CODEQL_ACTION_ANALYSIS_KEY: .github/workflows/ci.yml:qodana
         with:
           sarif_file: non-code-qodana.sarif
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           sha: ${{ github.event.pull_request.head.sha }}
-          category: non-code
+          category: Kotventure/qodana
 
   vanilla:
     name: Vanilla conformance

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -140,14 +140,15 @@ When you add Release Please `extra-files`, update the allowlist in both
 
 For a trusted pure Release Please PR, the gate starts the `QDJVM (release
 attestation)` job. The job uploads a zero-result SARIF record with the `QDJVM`
-tool name. It does not run Qodana. An untrusted release candidate runs normal
-CI instead.
+tool name under the existing `Kotventure/qodana` configuration. It does not
+run Qodana. An untrusted release candidate runs normal CI instead.
 
 For a normal pull request with no code paths, CI starts the `QDJVM (non-code
 attestation)` job. The job uploads a zero-result SARIF record with the `QDJVM`
-tool name and the `non-code` category. This records the path-filter decision.
-It does not claim that Qodana scanned code. Code-path pull requests use the
-normal Qodana job instead. Release candidates do not use this attestation.
+tool name under the existing `Kotventure/qodana` configuration. This records
+the path-filter decision. It does not claim that Qodana scanned code.
+Code-path pull requests use the normal Qodana job instead. Release candidates
+do not use this attestation.
 The `Master` ruleset requires the applicable QDJVM result for each pull
 request: non-code pull requests use this attestation, code pull requests use
 the normal Qodana result, and trusted Release Please pull requests use the

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -152,6 +152,8 @@ The `Master` ruleset requires the applicable QDJVM result for each pull
 request: non-code pull requests use this attestation, code pull requests use
 the normal Qodana result, and trusted Release Please pull requests use the
 release attestation.
+The attestation SARIF declares one rule and reports zero alerts. This lets
+GitHub treat the tool as configured.
 
 ### Full builds
 


### PR DESCRIPTION
## Summary

- Document the rule declaration required by the zero-result QDJVM attestation.
- Exercise the non-code pull-request path after the CI fix.

This pull request intentionally changes documentation only.