### PR TITLE
docs(ci): describe documentation-only checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,9 +686,6 @@ jobs:
                     }],
                   },
                 },
-                automationDetails: {
-                  id: `release-please/${sha}`,
-                },
                 results: [],
               }],
             };
@@ -747,9 +744,6 @@ jobs:
                       defaultConfiguration: { level: 'note' },
                     }],
                   },
-                },
-                automationDetails: {
-                  id: `non-code/${sha}`,
                 },
                 results: [],
               }],

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -143,10 +143,11 @@ attestation)` job. The job uploads a zero-result SARIF record with the `QDJVM`
 tool name under the existing `Kotventure/qodana` configuration. It does not
 run Qodana. An untrusted release candidate runs normal CI instead.
 
-For a normal pull request with no code paths, CI starts the `QDJVM (non-code
-attestation)` job. The job uploads a zero-result SARIF record with the `QDJVM`
-tool name under the existing `Kotventure/qodana` configuration. This records
-the path-filter decision. It does not claim that Qodana scanned code.
+For a normal documentation-only pull request with no code paths, CI starts the
+`QDJVM (non-code attestation)` job. The job uploads a zero-result SARIF record
+with the `QDJVM` tool name under the existing `Kotventure/qodana`
+configuration. This records the path-filter decision. It does not claim that
+Qodana scanned code.
 Code-path pull requests use the normal Qodana job instead. Release candidates
 do not use this attestation.
 The `Master` ruleset requires the applicable QDJVM result for each pull


### PR DESCRIPTION
## Summary

- Clarify the no-code-path pull-request condition.
- Validate the non-code QDJVM attestation against the shared Qodana configuration.

This pull request intentionally changes documentation only.