### PR TITLE
ci(qodana): combine real and documentation-only analysis

### DIFF
--- a/.agents/skills/fixing-ci-failures/SKILL.md
+++ b/.agents/skills/fixing-ci-failures/SKILL.md
@@ -61,4 +61,5 @@ fixtures. The cache uses the server bundle SHA-1. You can start the check again 
   `:<module>:build` plus root verification: kover/BOM/release/Dokka reports) inputs. Manual, scheduled, and merge-queue
   runs do not use path filters. The default pull-request and push Build uses the full multiproject task set.
 - A documentation-only pull request correctly skips resource-intensive jobs. A green Status check with skipped jobs is
-  correct. Markdown under `modules/**` counts as code.
+  correct. Markdown under `modules/**` uses the documentation path only when the file is the module root
+  `README.md`; other module paths count as code.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,22 +57,25 @@ jobs:
       run: ${{ steps.decide.outputs.run }}
       release_only: ${{ steps.decide.outputs.release_only }}
       release_candidate: ${{ steps.decide.outputs.release_candidate }}
+      documentation_only: ${{ steps.decide.outputs.documentation_only }}
     steps:
       - name: Decide whether heavy CI should run
         id: decide
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            const ALWAYS = () => {
+            const ALWAYS = (documentationOnly = false) => {
               core.setOutput('run', 'true');
               core.setOutput('release_only', 'false');
               core.setOutput('release_candidate', 'false');
+              core.setOutput('documentation_only', documentationOnly ? 'true' : 'false');
             };
 
             const FORCE_FULL = () => {
               core.setOutput('run', 'true');
               core.setOutput('release_only', 'false');
               core.setOutput('release_candidate', 'true');
+              core.setOutput('documentation_only', 'false');
             };
 
             const releaseOnlyFiles = new Set([
@@ -80,6 +83,21 @@ jobs:
               '.release-please-manifest.json',
               'gradle/libs.versions.toml',
             ]);
+
+            const documentationPathPatterns = [
+              /^README\.md$/,
+              /^LICENSE\.md$/,
+              /^AGENTS\.md$/,
+              /^docs\/.+$/,
+              /^\.github\/(?:CONTRIBUTING|SUPPORT)\.md$/,
+              /^\.github\/pull_request_template\.md$/,
+              /^\.github\/(?:PULL_REQUEST_TEMPLATE|ISSUE_TEMPLATE)\/[^/]+$/,
+              /^modules\/[^/]+\/README\.md$/,
+              /^assets\/.+\.(?:svg|png|jpe?g|gif|webp)$/i,
+            ];
+
+            const isDocumentationPath = (name) =>
+              documentationPathPatterns.some((pattern) => pattern.test(name));
 
             if (context.eventName === 'push') {
               ALWAYS();
@@ -109,14 +127,28 @@ jobs:
               return;
             }
 
+            const changedFileCount = pullRequest.changed_files;
+            if (!Number.isInteger(changedFileCount) || changedFileCount <= 0 || files.length !== changedFileCount) {
+              core.warning(
+                `Could not verify the complete pull-request file list (returned ${files.length}; expected ${changedFileCount ?? 'unknown'}); run full CI.`,
+              );
+              FORCE_FULL();
+              return;
+            }
+
             const unexpected = [...new Set(files
               .flatMap((file) => [file.filename, file.previous_filename].filter(Boolean))
               .filter((name) => !releaseOnlyFiles.has(name)))].sort();
+            const changedPaths = files
+              .flatMap((file) => [file.filename, file.previous_filename].filter(Boolean));
+            const documentationOnly = changedPaths.length > 0
+              && changedPaths.every(isDocumentationPath);
+            core.setOutput('documentation_only', documentationOnly ? 'true' : 'false');
             const pureRelease = unexpected.length === 0;
             const releaseCandidate = pullRequest.head?.ref?.startsWith('release-please--') || pureRelease;
 
             if (!releaseCandidate) {
-              ALWAYS();
+              ALWAYS(documentationOnly);
               return;
             }
 
@@ -222,6 +254,7 @@ jobs:
     outputs:
       code: ${{ steps.resolve.outputs.code }}
       vanilla: ${{ steps.resolve.outputs.vanilla }}
+      documentation_only: ${{ steps.resolve.outputs.documentation_only }}
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request' || github.event_name == 'push'
@@ -270,17 +303,41 @@ jobs:
           FILTER_CODE: ${{ steps.filter.outputs.code }}
           FILTER_VANILLA: ${{ steps.filter.outputs.vanilla }}
           RELEASE_CANDIDATE: ${{ needs.gate.outputs.release_candidate }}
+          DOCUMENTATION_ONLY: ${{ needs.gate.outputs.documentation_only }}
         run: |
           set -euo pipefail
           if [[ "$EVENT_NAME" == "pull_request" && "$RELEASE_CANDIDATE" == "true" ]]; then
-            echo "code=true" >> "$GITHUB_OUTPUT"
-            echo "vanilla=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$EVENT_NAME" == "pull_request" || "$EVENT_NAME" == "push" ]]; then
-            echo "code=${FILTER_CODE}" >> "$GITHUB_OUTPUT"
-            echo "vanilla=${FILTER_VANILLA}" >> "$GITHUB_OUTPUT"
+            {
+              echo "code=true"
+              echo "vanilla=true"
+              echo "documentation_only=false"
+            } >> "$GITHUB_OUTPUT"
+          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+            if [[ "$DOCUMENTATION_ONLY" == "true" ]]; then
+              {
+                echo "code=false"
+                echo "vanilla=false"
+                echo "documentation_only=true"
+              } >> "$GITHUB_OUTPUT"
+            else
+              {
+                echo "code=true"
+                echo "vanilla=${FILTER_VANILLA}"
+                echo "documentation_only=false"
+              } >> "$GITHUB_OUTPUT"
+            fi
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            {
+              echo "code=${FILTER_CODE}"
+              echo "vanilla=${FILTER_VANILLA}"
+              echo "documentation_only=false"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "code=true" >> "$GITHUB_OUTPUT"
-            echo "vanilla=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "code=true"
+              echo "vanilla=true"
+              echo "documentation_only=false"
+            } >> "$GITHUB_OUTPUT"
           fi
 
   # ╭──────────────────────────────────────────────────────────────────────────╮

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,7 +668,20 @@ jobs:
 
   qodana:
     name: Qodana
-    needs: [lint, build]
+    needs: [gate, changes, lint, build]
+    if: >-
+      always()
+      && needs.gate.result == 'success'
+      && needs.gate.outputs.run == 'true'
+      && needs.changes.result == 'success'
+      && (
+        needs.changes.outputs.documentation_only == 'true'
+        || (
+          needs.changes.outputs.documentation_only == 'false'
+          && needs.lint.result == 'success'
+          && needs.build.result == 'success'
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -678,6 +691,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
+        if: needs.changes.outputs.documentation_only != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -685,6 +699,7 @@ jobs:
           persist-credentials: false
 
       - name: Scan with Qodana
+        if: needs.changes.outputs.documentation_only != 'true'
         uses: JetBrains/qodana-action@4861e015da555e86a72b862892aba6c2b93e6891 # v2026.1.3
         with:
           cache-dir: ${{ runner.temp }}/qodana/caches
@@ -696,15 +711,60 @@ jobs:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
 
       - name: Normalize Qodana SARIF regions
-        if: always()
+        if: always() && needs.changes.outputs.documentation_only != 'true'
         shell: bash
         run: bash .github/scripts/normalize-qodana-sarif.sh "${{ runner.temp }}/qodana/results/qodana.sarif.json"
 
       - name: Upload Qodana results to code scanning
-        if: always()
+        if: always() && needs.changes.outputs.documentation_only != 'true'
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
+
+      - name: Create documentation-only attestation
+        if: needs.changes.outputs.documentation_only == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('node:fs');
+            const sha = context.payload.pull_request.head.sha;
+            const sarif = {
+              $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+              version: '2.1.0',
+              runs: [{
+                tool: {
+                  driver: {
+                    name: 'QDJVM',
+                    version: 'documentation-only-path-attestation',
+                    rules: [{
+                      id: 'attestation/documentation-only-paths',
+                      name: 'Documentation-only paths',
+                      shortDescription: {
+                        text: 'The pull request changed only approved documentation paths.',
+                      },
+                      fullDescription: {
+                        text: 'The CI path classifier approved every changed path as documentation-only.',
+                      },
+                      defaultConfiguration: { level: 'note' },
+                    }],
+                  },
+                },
+                results: [],
+              }],
+            };
+            fs.writeFileSync('documentation-only-qodana.sarif', JSON.stringify(sarif));
+            core.info(`Created the documentation-only attestation for ${sha}.`);
+
+      - name: Upload documentation-only attestation
+        if: needs.changes.outputs.documentation_only == 'true'
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        env:
+          CODEQL_ACTION_ANALYSIS_KEY: .github/workflows/ci.yml:qodana
+        with:
+          sarif_file: documentation-only-qodana.sarif
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          sha: ${{ github.event.pull_request.head.sha }}
+          category: Kotventure/qodana
 
   release_qodana:
     name: QDJVM (release attestation)
@@ -755,65 +815,6 @@ jobs:
           CODEQL_ACTION_ANALYSIS_KEY: .github/workflows/ci.yml:qodana
         with:
           sarif_file: release-qodana.sarif
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          sha: ${{ github.event.pull_request.head.sha }}
-          category: Kotventure/qodana
-
-  non_code_qodana:
-    name: QDJVM (non-code attestation)
-    needs: [gate, changes]
-    if: >-
-      github.event_name == 'pull_request'
-      && needs.gate.result == 'success'
-      && needs.gate.outputs.run == 'true'
-      && needs.gate.outputs.release_candidate == 'false'
-      && needs.changes.result == 'success'
-      && needs.changes.outputs.code == 'false'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Create non-code attestation
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const fs = require('node:fs');
-            const sha = context.payload.pull_request.head.sha;
-            const sarif = {
-              $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
-              version: '2.1.0',
-              runs: [{
-                tool: {
-                  driver: {
-                    name: 'QDJVM',
-                    version: 'non-code-path-attestation',
-                    rules: [{
-                      id: 'attestation/no-code-paths',
-                      name: 'No code paths changed',
-                      shortDescription: {
-                        text: 'The pull request changed no code paths.',
-                      },
-                      fullDescription: {
-                        text: 'The CI path filter found no files that require a code scan.',
-                      },
-                      defaultConfiguration: { level: 'note' },
-                    }],
-                  },
-                },
-                results: [],
-              }],
-            };
-            fs.writeFileSync('non-code-qodana.sarif', JSON.stringify(sarif));
-            core.info(`Created the non-code attestation for ${sha}.`);
-
-      - name: Upload QDJVM non-code attestation
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
-        env:
-          CODEQL_ACTION_ANALYSIS_KEY: .github/workflows/ci.yml:qodana
-        with:
-          sarif_file: non-code-qodana.sarif
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           sha: ${{ github.event.pull_request.head.sha }}
           category: Kotventure/qodana

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -45,8 +45,10 @@ CI
     └─ Aggregates Tier 1 + Vanilla + Dependencies
 ```
 
-Tier 2 starts only after Tier 1 passes. This sequence prevents unnecessary analysis of code that does not compile or
-pass lint. The Status job always starts. It reports one required check that controls merges.
+For code changes, Tier 2 starts only after Tier 1 passes. A documentation-only pull request can run the Qodana
+documentation attestation when Lint and Build are skipped. The attestation does not check out or analyse code. This
+sequence prevents unnecessary analysis of code that does not compile or pass lint. The Status job always starts. It
+reports one required check that controls merges.
 
 The workflow listens for `merge_group` events. Merge groups, schedules, and manual dispatches do not use the path
 filter. They always start the full pipeline: Build, Vanilla, Qodana, and CodeQL.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -32,14 +32,13 @@ CI
 │
 ├─ Tier 2: Deep Analysis (after Tier 1 passes) ────────────────────
 │   ├─ CodeQL            (actions + java-kotlin matrix)
-│   ├─ Qodana            (static analysis + SARIF)
+│   ├─ Qodana            (static analysis or documentation attestation + SARIF)
 │   └─ Vanilla conformance  (MC-backed selector tests, path-filtered)
 │
 ├─ Policy (independent of tiers) ──────────────────────────────────
 │   ├─ Dependencies      (dependency-review-action, PRs only)
 │   ├─ Commits           (push-to-master subject validation)
 │   ├─ Release provenance (default-branch metadata check)
-│   ├─ QDJVM non-code attestation (docs/process-only PRs)
 │   └─ Release attestation (trusted release-please PRs)
 │
 └─ Status (required merge-gate check) ─────────────────────────────
@@ -54,9 +53,32 @@ filter. They always start the full pipeline: Build, Vanilla, Qodana, and CodeQL.
 
 ## When workflows run
 
-### Code paths
+### Path classification
 
-The `changes` job in `ci.yml` defines these code paths:
+The `gate` job classifies every current and previous pull-request file name. It
+uses the documentation-only allowlist below. A pull request qualifies for the
+documentation path only when it has at least one file and every file name
+matches one of these patterns:
+
+- `README.md`, `LICENSE.md`, or `AGENTS.md` at the repository root.
+- Any file under `docs/`.
+- `.github/CONTRIBUTING.md`, `.github/SUPPORT.md`, or
+  `.github/pull_request_template.md`.
+- Any file under `.github/PULL_REQUEST_TEMPLATE/` or
+  `.github/ISSUE_TEMPLATE/`.
+- `modules/<module>/README.md`.
+- An `svg`, `png`, `jpg`, `jpeg`, `gif`, or `webp` file under `assets/`,
+  including subdirectories.
+
+The classifier checks both names for a rename. It sends an empty or incomplete
+file list, an API error, an unknown path, and a rename with an unknown old or
+new path to the full CI path. This rule is fail closed.
+
+All other paths use the full CI path. This includes source files, module build
+files, Gradle files, Qodana configuration, workflows, actions, scripts,
+ownership files, dependency files, release files, and unknown paths.
+
+The full CI path includes these code paths:
 
 - `modules/**`, `gradle/**`, `buildSrc/**`
 - `build.gradle`, `settings.gradle`, `gradle.properties`, `gradlew`, `gradlew.bat`
@@ -69,7 +91,7 @@ The `changes` job in `ci.yml` defines these code paths:
 | Event | CI workflow | Heavy jobs | Qodana | CodeQL |
 |-------|:-----------:|:----------:|:------:|:------:|
 | PR (code paths) | ✓ | ✓ | ✓ | ✓ |
-| PR (docs/process only) | ✓ | — | non-code attestation | — |
+| PR (approved docs-only paths) | ✓ | — | QDJVM documentation attestation | — |
 | PR (trusted Release Please files only) | ✓ | — | QDJVM attestation | — |
 | PR (untrusted release candidate) | ✓ | ✓ | ✓ | ✓ |
 | Push to `master` (code paths) | ✓ | ✓ | ✓ | ✓ |
@@ -143,17 +165,25 @@ attestation)` job. The job uploads a zero-result SARIF record with the `QDJVM`
 tool name under the existing `Kotventure/qodana` configuration. It does not
 run Qodana. An untrusted release candidate runs normal CI instead.
 
-For a normal documentation-only pull request with no code paths, CI starts the
-`QDJVM (non-code attestation)` job. The job uploads a zero-result SARIF record
-with the `QDJVM` tool name under the existing `Kotventure/qodana`
-configuration. This records the path-filter decision. It does not claim that
-Qodana scanned code. The result is tied to the pull-request head commit.
-Code-path pull requests use the normal Qodana job instead. Release candidates
-do not use this attestation.
+For a normal documentation-only pull request, the `Qodana` job uses its
+documentation-only path. It does not check out pull-request code or run
+Qodana. It uploads a zero-result SARIF record with the `QDJVM` tool name under
+the existing `Kotventure/qodana` configuration. This records the path
+classification. It does not claim that Qodana scanned code. The result is tied
+to the pull-request head commit.
+
+Code-path pull requests use the same `Qodana` job for the real Qodana scan.
+The job keeps the existing Qodana permissions because the combined design uses
+the real scan as its permission baseline. The documentation path does not use
+the extra capabilities to check out or execute pull-request code. Release
+candidates do not use this attestation.
+
 The `Master` ruleset requires the applicable QDJVM result for each pull
-request: non-code pull requests use this attestation, code pull requests use
-the normal Qodana result, and trusted Release Please pull requests use the
-release attestation.
+request: documentation-only pull requests use this attestation, code pull
+requests use the real Qodana result, and trusted Release Please pull requests
+use the release attestation. Both paths use the stable
+`.github/workflows/ci.yml:qodana` analysis key and `Kotventure/qodana`
+category.
 The attestation SARIF declares one rule and reports zero alerts. This lets
 GitHub treat the tool as configured.
 
@@ -220,7 +250,7 @@ For an occasional diagnostic scan, give `build-scan: true` to `gradle-job`. The 
 | Default workflow permissions | Set the repository default to `contents: read` |
 | Release provenance workflow | Uses `contents: read` and `pull-requests: read`. Does not check out pull-request code |
 | CI gate | Uses `actions: read`, `contents: read`, and `pull-requests: read` |
-| Non-code QDJVM attestation | Uses `contents: read` and `security-events: write`. Does not check out pull-request code |
+| Qodana and documentation attestation | Uses the existing `checks: write`, `contents: read`, `pull-requests: write`, and `security-events: write` permissions. The documentation path does not check out pull-request code |
 | Release workflow | Uses an installation token from `release-please-kotventure`. Its `GITHUB_TOKEN` has no permissions |
 | Build job | Uses `checks: write` and `contents: read`. Cannot write to pull requests. Clears `GITHUB_TOKEN` for Gradle |
 | PR feedback job | Uses `actions: read`, `pull-requests: write`, and `contents: read`. Posts one metrics comment. Uses the cache or artefacts before a base JAR-only build. Clears `GITHUB_TOKEN` for Gradle |


### PR DESCRIPTION
## Summary

- classify documentation-only pull requests with an explicit fail-closed allowlist
- run the real Qodana job or the zero-result QDJVM attestation in one stable job
- keep unknown, incomplete, and API-failed classifications on the full CI path
- document the path policy and the combined job permissions

## Validation

- actionlint .github/workflows/ci.yml
- Ruby YAML parsing for all GitHub workflows
- git diff --check
- classifier cases for allowed paths, unknown paths, renames, and empty input
- native Codex review: no actionable defects

This change does not modify release configuration, versioning, or the Release Please and release-attestation paths. It does not change the primary worktree.