### PR TITLE
test(ci): validate qodana unknown path

### DIFF
--- a/qodana-validation-unknown.txt
+++ b/qodana-validation-unknown.txt
@@ -1,0 +1,1 @@
+Temporary validation file. Remove this file after the CI run.


### PR DESCRIPTION
This is a temporary validation PR. Do not merge. It changes an unknown root path to verify fail-closed classification and the real Qodana path.