### PR TITLE
docs(ci): validate documentation-only qodana path

### DIFF
--- a/docs/qodana-validation-docs-only.md
+++ b/docs/qodana-validation-docs-only.md
@@ -1,0 +1,4 @@
+# Temporary Qodana validation
+
+This file validates the documentation-only CI path. Remove this file after the
+validation run.


### PR DESCRIPTION
This is a temporary validation PR. Do not merge. It changes one file under docs/ to verify that the gate sets documentation_only=true, skips Tier 1 and other heavy jobs, and uploads the zero-result QDJVM attestation under Kotventure/qodana.