### PR TITLE
fix(ci): expose workflow-run checks

### DIFF
--- a/.github/scripts/normalize-qodana-sarif.sh
+++ b/.github/scripts/normalize-qodana-sarif.sh
@@ -38,7 +38,8 @@ jq '
             | (if (.startColumn? | type) == "number" and .startColumn < 1 then .startColumn = 1 else . end)
         end;
 
-    walk(
+    .runs |= map(del(.automationDetails))
+    | walk(
         if type == "object" and (.region? | type) == "object" then
             .region |= normalize_region
         else

--- a/.github/scripts/pr-metrics-publisher.js
+++ b/.github/scripts/pr-metrics-publisher.js
@@ -172,6 +172,7 @@ function setSourceOutputs(core, source) {
     core.setOutput('run_attempt', String(source.runAttempt));
     core.setOutput('pull_number', String(source.pullRequest));
     core.setOutput('artifact_id', String(source.artifactId));
+    core.setOutput('head_sha', source.headSha);
 }
 
 async function validateSource({
@@ -241,7 +242,7 @@ async function publishMetrics({
     });
 
     if (!source) {
-        return;
+        return false;
     }
 
     const result = validateResultProvenance(
@@ -278,6 +279,7 @@ async function publishMetrics({
     });
 
     core.info(`Published CI metrics for PR #${source.pullRequest}`);
+    return true;
 }
 
 module.exports = {

--- a/.github/scripts/pr-metrics-publisher.test.js
+++ b/.github/scripts/pr-metrics-publisher.test.js
@@ -29,6 +29,7 @@ const {
     ARTIFACT_API_URL,
     ARTIFACT_ID,
     ARTIFACT_STORAGE_URL,
+    HEAD_SHA,
     makeArtifact,
     makeArtifactFetch,
     makeDownloadOptions,
@@ -567,6 +568,7 @@ describe('publisher orchestration', () => {
         assert.equal(outputs.get('publish'), 'true');
         assert.equal(outputs.get('artifact_id'), '700');
         assert.equal(outputs.get('pull_number'), '42');
+        assert.equal(outputs.get('head_sha'), HEAD_SHA);
     });
 
     test('sets publish=false when source validation rejects publication', async () => {
@@ -605,7 +607,7 @@ describe('publisher orchestration', () => {
         const inputs = makeInputs();
         const warnings = [];
 
-        await publishMetrics({
+        const published = await publishMetrics({
             github: makeGithub({
                 run: inputs.run,
                 pullRequest: {
@@ -623,6 +625,7 @@ describe('publisher orchestration', () => {
             artifactDirectory: 'unused',
         });
 
+        assert.equal(published, false);
         assert.equal(warnings.length, 1);
         assert.match(
                 warnings[0],
@@ -668,7 +671,7 @@ describe('publisher orchestration', () => {
             return paginate(method, parameters);
         };
 
-        await publishMetrics({
+        const published = await publishMetrics({
             github,
             context: makeWorkflowRunContext(inputs.run),
             core: {
@@ -678,6 +681,7 @@ describe('publisher orchestration', () => {
             artifactDirectory: directory,
         });
 
+        assert.equal(published, true);
         assert.equal(publishedComments.length, 1);
         assert.equal(publishedComments[0].issue_number, 42);
         assert.match(

--- a/.github/scripts/qodana-check-registration.js
+++ b/.github/scripts/qodana-check-registration.js
@@ -13,13 +13,12 @@ const {
 
 const QODANA_PR_CHECK_NAME = 'Qodana / pull request';
 
-async function registerQodanaCheck({
+async function createQodanaCheck({
   github,
   context,
   source,
   qodanaRunId,
   qodanaRunAttempt,
-  outputDirectory,
 }) {
   const externalId = buildCheckExternalId({
     kind: 'qodana-pr',
@@ -27,7 +26,7 @@ async function registerQodanaCheck({
     runAttempt: qodanaRunAttempt,
     headSha: source.headSha,
   });
-  const check = await createWorkflowCheck({
+  return createWorkflowCheck({
     github,
     context,
     name: QODANA_PR_CHECK_NAME,
@@ -35,6 +34,15 @@ async function registerQodanaCheck({
     externalId,
     summary: 'Qodana is analysing the validated pull-request source.',
   });
+}
+
+function writeQodanaCheckRegistration({
+  check,
+  source,
+  qodanaRunId,
+  qodanaRunAttempt,
+  outputDirectory,
+}) {
   const artifactName = buildCheckArtifactName({
     sourceKind: source.sourceKind,
     runId: source.runId,
@@ -46,8 +54,9 @@ async function registerQodanaCheck({
     baseSha: source.baseSha,
   });
   fs.mkdirSync(outputDirectory, { recursive: true });
+  const filePath = path.join(outputDirectory, QODANA_CHECK_FILE_NAME);
   fs.writeFileSync(
-    path.join(outputDirectory, QODANA_CHECK_FILE_NAME),
+    filePath,
     `${JSON.stringify({
       version: 1,
       artifactName,
@@ -56,10 +65,11 @@ async function registerQodanaCheck({
     })}\n`,
     { mode: 0o600 },
   );
-  return { artifactName, check };
+  return { artifactName, filePath };
 }
 
 module.exports = {
   QODANA_PR_CHECK_NAME,
-  registerQodanaCheck,
+  createQodanaCheck,
+  writeQodanaCheckRegistration,
 };

--- a/.github/scripts/qodana-check-registration.js
+++ b/.github/scripts/qodana-check-registration.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  QODANA_CHECK_FILE_NAME,
+  buildCheckArtifactName,
+} = require('./qodana-contract.js');
+const {
+  buildCheckExternalId,
+  createWorkflowCheck,
+} = require('./workflow-run-check.js');
+
+const QODANA_PR_CHECK_NAME = 'Qodana / pull request';
+
+async function registerQodanaCheck({
+  github,
+  context,
+  source,
+  qodanaRunId,
+  qodanaRunAttempt,
+  outputDirectory,
+}) {
+  const externalId = buildCheckExternalId({
+    kind: 'qodana-pr',
+    runId: qodanaRunId,
+    runAttempt: qodanaRunAttempt,
+    headSha: source.headSha,
+  });
+  const check = await createWorkflowCheck({
+    github,
+    context,
+    name: QODANA_PR_CHECK_NAME,
+    headSha: source.headSha,
+    externalId,
+    summary: 'Qodana is analysing the validated pull-request source.',
+  });
+  const artifactName = buildCheckArtifactName({
+    sourceKind: source.sourceKind,
+    runId: source.runId,
+    runAttempt: source.runAttempt,
+    qodanaRunId,
+    qodanaRunAttempt,
+    checkRunId: check.id,
+    headSha: source.headSha,
+    baseSha: source.baseSha,
+  });
+  fs.mkdirSync(outputDirectory, { recursive: true });
+  fs.writeFileSync(
+    path.join(outputDirectory, QODANA_CHECK_FILE_NAME),
+    `${JSON.stringify({
+      version: 1,
+      artifactName,
+      check,
+      pullRequest: source.pullRequest,
+    })}\n`,
+    { mode: 0o600 },
+  );
+  return { artifactName, check };
+}
+
+module.exports = {
+  QODANA_PR_CHECK_NAME,
+  registerQodanaCheck,
+};

--- a/.github/scripts/qodana-contract.js
+++ b/.github/scripts/qodana-contract.js
@@ -5,6 +5,9 @@ const CI_WORKFLOW_PATH = '.github/workflows/ci.yml';
 const QODANA_WORKFLOW_NAME = 'Qodana';
 const QODANA_WORKFLOW_PATH = '.github/workflows/qodana.yml';
 const QODANA_ARTIFACT_PREFIX = 'qodana-sarif-';
+const QODANA_CHECK_ARTIFACT_PREFIX = 'qodana-check-';
+const QODANA_CHECK_FILE_NAME = 'qodana-check.json';
+const MAX_CHECK_ARTIFACT_BYTES = 64 * 1024;
 const QODANA_SARIF_FILE_NAME = 'qodana.sarif.json';
 const MAX_ARTIFACT_BYTES = 16 * 1024 * 1024;
 const MAX_SARIF_BYTES = 16 * 1024 * 1024;
@@ -139,22 +142,69 @@ function parseArtifactName(name) {
   };
 }
 
+function buildCheckArtifactName({
+  sourceKind,
+  runId,
+  runAttempt,
+  qodanaRunId,
+  qodanaRunAttempt,
+  checkRunId,
+  headSha,
+  baseSha,
+}) {
+  if (!['code', 'documentation', 'release'].includes(sourceKind)) {
+    throw new Error('Qodana source kind is invalid');
+  }
+  return `${QODANA_CHECK_ARTIFACT_PREFIX}${sourceKind}-${requirePositiveInteger(runId, 'CI workflow run id')}-${requirePositiveInteger(runAttempt, 'CI workflow run attempt')}-${requirePositiveInteger(qodanaRunId, 'Qodana workflow run id')}-${requirePositiveInteger(qodanaRunAttempt, 'Qodana workflow run attempt')}-${requirePositiveInteger(checkRunId, 'check run id')}-${requireSha(headSha, 'head SHA')}-${requireSha(baseSha, 'base SHA')}`;
+}
+
+function parseCheckArtifactName(name) {
+  if (typeof name !== 'string') {
+    return null;
+  }
+  const match = name.match(
+    new RegExp(`^${QODANA_CHECK_ARTIFACT_PREFIX}(code|documentation|release)-(\\d+)-(\\d+)-(\\d+)-(\\d+)-(\\d+)-([0-9a-f]{40})-([0-9a-f]{40})$`),
+  );
+  if (!match) {
+    return null;
+  }
+  const integers = match.slice(2, 7).map(Number);
+  if (integers.some((value) => !Number.isSafeInteger(value) || value < 1)) {
+    return null;
+  }
+  return {
+    sourceKind: match[1],
+    ciRunId: integers[0],
+    ciRunAttempt: integers[1],
+    qodanaRunId: integers[2],
+    qodanaRunAttempt: integers[3],
+    checkRunId: integers[4],
+    headSha: match[7],
+    baseSha: match[8],
+  };
+}
+
 module.exports = {
   CI_WORKFLOW_NAME,
   CI_WORKFLOW_PATH,
   DOCUMENTATION_PATH_PATTERNS,
   MAX_ARTIFACT_BYTES,
+  MAX_CHECK_ARTIFACT_BYTES,
   MAX_SARIF_BYTES,
   MAX_SARIF_RESULTS,
   QODANA_ARTIFACT_PREFIX,
+  QODANA_CHECK_ARTIFACT_PREFIX,
+  QODANA_CHECK_FILE_NAME,
   QODANA_SARIF_FILE_NAME,
   QODANA_WORKFLOW_NAME,
   QODANA_WORKFLOW_PATH,
   RELEASE_ONLY_FILES,
   buildArtifactName,
+  buildCheckArtifactName,
   changedPathNames,
   classifyChangedFiles,
   isDocumentationPath,
   isSafeRepositoryPath,
   parseArtifactName,
+  parseCheckArtifactName,
 };

--- a/.github/scripts/qodana-publisher-validation.js
+++ b/.github/scripts/qodana-publisher-validation.js
@@ -2,12 +2,15 @@
 
 const {
   MAX_ARTIFACT_BYTES,
+  MAX_CHECK_ARTIFACT_BYTES,
   MAX_SARIF_BYTES,
   MAX_SARIF_RESULTS,
   QODANA_ARTIFACT_PREFIX,
+  QODANA_CHECK_ARTIFACT_PREFIX,
   QODANA_WORKFLOW_NAME,
   QODANA_WORKFLOW_PATH,
   parseArtifactName,
+  parseCheckArtifactName,
 } = require('./qodana-contract.js');
 
 class QodanaPublicationRejectedError extends Error {}
@@ -56,10 +59,12 @@ function validateQodanaWorkflowSource({ eventRun, run, workflow, repository }) {
   }
   requireEqual(eventRun.event, 'workflow_run', 'workflow run event');
   requireEqual(eventRun.status, 'completed', 'workflow run event status');
-  requireEqual(eventRun.conclusion, 'success', 'workflow run event conclusion');
+  requireEqual(eventRun.conclusion, run.conclusion, 'workflow run event conclusion');
   requireEqual(run.event, 'workflow_run', 'workflow run event');
   requireEqual(run.status, 'completed', 'workflow run status');
-  requireEqual(run.conclusion, 'success', 'workflow run conclusion');
+  if (!['success', 'failure', 'cancelled', 'timed_out'].includes(run.conclusion)) {
+    reject('workflow run conclusion is invalid');
+  }
   requireEqual(run.repository?.full_name, repository.full_name, 'workflow run repository');
   requireEqual(run.repository?.id, repository.id, 'workflow run repository id');
   requireEqual(run.head_repository?.full_name, repository.full_name, 'workflow head repository');
@@ -74,7 +79,48 @@ function validateQodanaWorkflowSource({ eventRun, run, workflow, repository }) {
     runId: requirePositiveInteger(run.id, 'Qodana workflow run id'),
     runAttempt: requirePositiveInteger(run.run_attempt, 'Qodana workflow run attempt'),
     repository: repository.full_name,
+    conclusion: run.conclusion,
   };
+}
+
+function selectQodanaCheckArtifact({ artifacts, qodanaRun, repository }) {
+  if (!Array.isArray(artifacts)) {
+    reject('workflow artifacts are missing');
+  }
+  const candidates = artifacts
+    .filter((artifact) => typeof artifact?.name === 'string'
+      && artifact.name.startsWith(QODANA_CHECK_ARTIFACT_PREFIX))
+    .map((artifact) => ({ artifact, descriptor: parseCheckArtifactName(artifact.name) }))
+    .filter(({ descriptor }) => descriptor?.qodanaRunId === qodanaRun.id
+      && descriptor.qodanaRunAttempt === qodanaRun.run_attempt);
+  if (candidates.length !== 1) {
+    reject(`expected exactly one Qodana check artifact, found ${candidates.length}`);
+  }
+  const [{ artifact, descriptor }] = candidates;
+  requirePositiveInteger(artifact.id, 'Qodana check artifact id');
+  if (artifact.expired !== false) {
+    reject('Qodana check artifact is expired');
+  }
+  if (!Number.isSafeInteger(artifact.size_in_bytes)
+    || artifact.size_in_bytes < 1
+    || artifact.size_in_bytes > MAX_CHECK_ARTIFACT_BYTES) {
+    reject('Qodana check artifact size is invalid');
+  }
+  const artifactRun = requireObject(artifact.workflow_run, 'Qodana check artifact workflow run');
+  requireEqual(artifactRun.id, qodanaRun.id, 'Qodana check artifact workflow run id');
+  requireEqual(artifactRun.repository_id, repository.id, 'Qodana check artifact repository id');
+  requireEqual(artifactRun.head_repository_id, qodanaRun.head_repository?.id, 'Qodana check artifact head repository id');
+  requireEqual(artifactRun.head_branch, qodanaRun.head_branch, 'Qodana check artifact head branch');
+  requireEqual(artifactRun.head_sha, qodanaRun.head_sha, 'Qodana check artifact head SHA');
+  return { artifact, descriptor };
+}
+
+function validateQodanaCheckSource({ descriptor, source }) {
+  requireEqual(descriptor.sourceKind, source.sourceKind, 'Qodana check source kind');
+  requireEqual(descriptor.ciRunId, source.runId, 'Qodana check CI run id');
+  requireEqual(descriptor.ciRunAttempt, source.runAttempt, 'Qodana check CI run attempt');
+  requireEqual(descriptor.headSha, source.headSha, 'Qodana check head SHA');
+  requireEqual(descriptor.baseSha, source.baseSha, 'Qodana check base SHA');
 }
 
 function selectQodanaRunArtifact({ artifacts, qodanaRun, repository }) {
@@ -232,8 +278,10 @@ function validateQodanaSarif(value) {
 module.exports = {
   QodanaPublicationRejectedError,
   selectQodanaArtifact,
+  selectQodanaCheckArtifact,
   selectQodanaRunArtifact,
   validateQodanaArtifactSource,
+  validateQodanaCheckSource,
   validateQodanaSarif,
   validateQodanaWorkflowSource,
 };

--- a/.github/scripts/qodana-publisher-validation.js
+++ b/.github/scripts/qodana-publisher-validation.js
@@ -83,36 +83,74 @@ function validateQodanaWorkflowSource({ eventRun, run, workflow, repository }) {
   };
 }
 
-function selectQodanaCheckArtifact({ artifacts, qodanaRun, repository }) {
+function matchingRunArtifacts({ artifacts, qodanaRun, prefix, parse }) {
   if (!Array.isArray(artifacts)) {
     reject('workflow artifacts are missing');
   }
-  const candidates = artifacts
+  return artifacts
     .filter((artifact) => typeof artifact?.name === 'string'
-      && artifact.name.startsWith(QODANA_CHECK_ARTIFACT_PREFIX))
-    .map((artifact) => ({ artifact, descriptor: parseCheckArtifactName(artifact.name) }))
+      && artifact.name.startsWith(prefix))
+    .map((artifact) => ({ artifact, descriptor: parse(artifact.name) }))
     .filter(({ descriptor }) => descriptor?.qodanaRunId === qodanaRun.id
       && descriptor.qodanaRunAttempt === qodanaRun.run_attempt);
+}
+
+function selectRunArtifact({
+  artifacts,
+  qodanaRun,
+  repository,
+  prefix,
+  parse,
+  maximumBytes,
+  label,
+}) {
+  const candidates = matchingRunArtifacts({ artifacts, qodanaRun, prefix, parse });
   if (candidates.length !== 1) {
-    reject(`expected exactly one Qodana check artifact, found ${candidates.length}`);
+    reject(`expected exactly one ${label}, found ${candidates.length}`);
   }
   const [{ artifact, descriptor }] = candidates;
-  requirePositiveInteger(artifact.id, 'Qodana check artifact id');
+  requirePositiveInteger(artifact.id, `${label} id`);
   if (artifact.expired !== false) {
-    reject('Qodana check artifact is expired');
+    reject(`${label} is expired`);
   }
   if (!Number.isSafeInteger(artifact.size_in_bytes)
     || artifact.size_in_bytes < 1
-    || artifact.size_in_bytes > MAX_CHECK_ARTIFACT_BYTES) {
-    reject('Qodana check artifact size is invalid');
+    || artifact.size_in_bytes > maximumBytes) {
+    reject(`${label} size is invalid`);
   }
-  const artifactRun = requireObject(artifact.workflow_run, 'Qodana check artifact workflow run');
-  requireEqual(artifactRun.id, qodanaRun.id, 'Qodana check artifact workflow run id');
-  requireEqual(artifactRun.repository_id, repository.id, 'Qodana check artifact repository id');
-  requireEqual(artifactRun.head_repository_id, qodanaRun.head_repository?.id, 'Qodana check artifact head repository id');
-  requireEqual(artifactRun.head_branch, qodanaRun.head_branch, 'Qodana check artifact head branch');
-  requireEqual(artifactRun.head_sha, qodanaRun.head_sha, 'Qodana check artifact head SHA');
+  const artifactRun = requireObject(artifact.workflow_run, `${label} workflow run`);
+  requireEqual(artifactRun.id, qodanaRun.id, `${label} workflow run id`);
+  requireEqual(artifactRun.repository_id, repository.id, `${label} repository id`);
+  requireEqual(artifactRun.head_repository_id, qodanaRun.head_repository?.id, `${label} head repository id`);
+  requireEqual(artifactRun.head_branch, qodanaRun.head_branch, `${label} head branch`);
+  requireEqual(artifactRun.head_sha, qodanaRun.head_sha, `${label} head SHA`);
   return { artifact, descriptor };
+}
+
+function selectQodanaCheckArtifact({ artifacts, qodanaRun, repository }) {
+  return selectRunArtifact({
+    artifacts,
+    qodanaRun,
+    repository,
+    prefix: QODANA_CHECK_ARTIFACT_PREFIX,
+    parse: parseCheckArtifactName,
+    maximumBytes: MAX_CHECK_ARTIFACT_BYTES,
+    label: 'Qodana check artifact',
+  });
+}
+
+function recoverQodanaCheckDescriptor({ artifacts, qodanaRun }) {
+  const candidates = matchingRunArtifacts({
+    artifacts,
+    qodanaRun,
+    prefix: QODANA_CHECK_ARTIFACT_PREFIX,
+    parse: parseCheckArtifactName,
+  });
+  const descriptors = new Map();
+  for (const { descriptor } of candidates) {
+    descriptors.set(JSON.stringify(descriptor), descriptor);
+  }
+  return descriptors.size === 1 ? descriptors.values().next().value : null;
 }
 
 function validateQodanaCheckSource({ descriptor, source }) {
@@ -124,37 +162,15 @@ function validateQodanaCheckSource({ descriptor, source }) {
 }
 
 function selectQodanaRunArtifact({ artifacts, qodanaRun, repository }) {
-  if (!Array.isArray(artifacts)) {
-    reject('workflow artifacts are missing');
-  }
-  const candidates = artifacts
-    .filter((artifact) => typeof artifact?.name === 'string'
-      && artifact.name.startsWith(QODANA_ARTIFACT_PREFIX))
-    .map((artifact) => ({ artifact, descriptor: parseArtifactName(artifact.name) }))
-    .filter(({ descriptor }) => descriptor?.qodanaRunId === qodanaRun.id
-      && descriptor.qodanaRunAttempt === qodanaRun.run_attempt);
-  if (candidates.length !== 1) {
-    reject(`expected exactly one Qodana SARIF artifact, found ${candidates.length}`);
-  }
-  const [{ artifact, descriptor }] = candidates;
-  requireEqual(descriptor.qodanaRunId, qodanaRun.id, 'Qodana workflow run id');
-  requireEqual(descriptor.qodanaRunAttempt, qodanaRun.run_attempt, 'Qodana workflow run attempt');
-  requirePositiveInteger(artifact.id, 'Qodana artifact id');
-  if (artifact.expired !== false) {
-    reject('Qodana artifact is expired');
-  }
-  if (!Number.isSafeInteger(artifact.size_in_bytes)
-    || artifact.size_in_bytes < 1
-    || artifact.size_in_bytes > MAX_ARTIFACT_BYTES) {
-    reject('Qodana artifact size is invalid');
-  }
-  const artifactRun = requireObject(artifact.workflow_run, 'Qodana artifact workflow run');
-  requireEqual(artifactRun.id, qodanaRun.id, 'Qodana artifact workflow run id');
-  requireEqual(artifactRun.repository_id, repository.id, 'Qodana artifact repository id');
-  requireEqual(artifactRun.head_repository_id, qodanaRun.head_repository?.id, 'Qodana artifact head repository id');
-  requireEqual(artifactRun.head_branch, qodanaRun.head_branch, 'Qodana artifact head branch');
-  requireEqual(artifactRun.head_sha, qodanaRun.head_sha, 'Qodana artifact head SHA');
-  return { artifact, descriptor };
+  return selectRunArtifact({
+    artifacts,
+    qodanaRun,
+    repository,
+    prefix: QODANA_ARTIFACT_PREFIX,
+    parse: parseArtifactName,
+    maximumBytes: MAX_ARTIFACT_BYTES,
+    label: 'Qodana SARIF artifact',
+  });
 }
 
 function validateQodanaArtifactSource({ descriptor, source }) {
@@ -277,6 +293,7 @@ function validateQodanaSarif(value) {
 
 module.exports = {
   QodanaPublicationRejectedError,
+  recoverQodanaCheckDescriptor,
   selectQodanaArtifact,
   selectQodanaCheckArtifact,
   selectQodanaRunArtifact,

--- a/.github/scripts/qodana-publisher.js
+++ b/.github/scripts/qodana-publisher.js
@@ -3,6 +3,7 @@
 const { resolveCiRun, QodanaSourceRejectedError } = require('./qodana-source.js');
 const {
   QodanaPublicationRejectedError,
+  recoverQodanaCheckDescriptor,
   selectQodanaCheckArtifact,
   selectQodanaRunArtifact,
   validateQodanaArtifactSource,
@@ -16,6 +17,15 @@ function requireObject(value, label) {
     throw new QodanaPublicationRejectedError(`${label} is missing`);
   }
   return value;
+}
+
+function qodanaConclusionSummary(conclusion) {
+  const summaries = {
+    failure: 'Qodana analysis failed.',
+    cancelled: 'The Qodana analysis was cancelled.',
+    timed_out: 'Qodana analysis timed out.',
+  };
+  return summaries[conclusion] || null;
 }
 
 async function resolvePublication({ github, context }) {
@@ -55,8 +65,21 @@ async function resolvePublication({ github, context }) {
   if (!Array.isArray(artifacts)) {
     throw new QodanaPublicationRejectedError('Qodana workflow artifacts are missing');
   }
-  const checkSelection = selectQodanaCheckArtifact({ artifacts, qodanaRun, repository });
-  const { descriptor: checkDescriptor } = checkSelection;
+  let checkArtifactRejection = null;
+  let checkDescriptor;
+  try {
+    const selection = selectQodanaCheckArtifact({ artifacts, qodanaRun, repository });
+    checkDescriptor = selection.descriptor;
+  } catch (error) {
+    if (!(error instanceof QodanaPublicationRejectedError)) {
+      throw error;
+    }
+    checkDescriptor = recoverQodanaCheckDescriptor({ artifacts, qodanaRun });
+    if (!checkDescriptor) {
+      throw error;
+    }
+    checkArtifactRejection = error;
+  }
 
   let source;
   try {
@@ -82,6 +105,9 @@ async function resolvePublication({ github, context }) {
           headSha: checkDescriptor.headSha,
         }),
         checkRunId: checkDescriptor.checkRunId,
+        checkSummary: error.stale
+          ? 'Qodana publication stopped because the pull request changed.'
+          : 'Qodana source validation failed.',
         headSha: checkDescriptor.headSha,
         pullNumber: null,
         publish: false,
@@ -107,10 +133,21 @@ async function resolvePublication({ github, context }) {
       headSha: source.headSha,
     }),
     checkRunId: checkDescriptor.checkRunId,
+    checkSummary: qodanaConclusionSummary(trustedRun.conclusion),
     headSha: source.headSha,
     pullNumber: source.pullRequest,
     sourceKind: source.sourceKind,
   };
+  if (checkArtifactRejection) {
+    return {
+      ...common,
+      artifactId: null,
+      checkConclusion: 'failure',
+      checkSummary: 'Qodana check registration validation failed.',
+      publish: false,
+      rejection: checkArtifactRejection,
+    };
+  }
   if (trustedRun.conclusion !== 'success') {
     return {
       ...common,
@@ -141,6 +178,7 @@ async function resolvePublication({ github, context }) {
         ...common,
         artifactId: null,
         checkConclusion: 'failure',
+        checkSummary: 'Qodana result validation failed.',
         publish: false,
         rejection: error,
       };
@@ -170,6 +208,7 @@ async function writePublicationOutputs({ github, context, core }) {
     core.setOutput('check_run_id', String(publication.checkRunId));
     core.setOutput('check_external_id', publication.checkExternalId);
     core.setOutput('check_conclusion', publication.checkConclusion || '');
+    core.setOutput('check_summary', publication.checkSummary || '');
     if (publication.rejection) {
       core.setFailed(`Qodana publication rejected: ${publication.rejection.message}`);
     }

--- a/.github/scripts/qodana-publisher.js
+++ b/.github/scripts/qodana-publisher.js
@@ -3,10 +3,13 @@
 const { resolveCiRun, QodanaSourceRejectedError } = require('./qodana-source.js');
 const {
   QodanaPublicationRejectedError,
+  selectQodanaCheckArtifact,
   selectQodanaRunArtifact,
   validateQodanaArtifactSource,
+  validateQodanaCheckSource,
   validateQodanaWorkflowSource,
 } = require('./qodana-publisher-validation.js');
+const { buildCheckExternalId } = require('./workflow-run-check.js');
 
 function requireObject(value, label) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -36,7 +39,12 @@ async function resolvePublication({ github, context }) {
     workflow_id: qodanaRun.workflow_id,
   });
   const workflow = requireObject(workflowResponse.data, 'Qodana workflow');
-  validateQodanaWorkflowSource({ eventRun, run: qodanaRun, workflow, repository });
+  const trustedRun = validateQodanaWorkflowSource({
+    eventRun,
+    run: qodanaRun,
+    workflow,
+    repository,
+  });
 
   const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
     owner,
@@ -47,47 +55,124 @@ async function resolvePublication({ github, context }) {
   if (!Array.isArray(artifacts)) {
     throw new QodanaPublicationRejectedError('Qodana workflow artifacts are missing');
   }
-  const selection = selectQodanaRunArtifact({ artifacts, qodanaRun, repository });
-  const { descriptor } = selection;
+  const checkSelection = selectQodanaCheckArtifact({ artifacts, qodanaRun, repository });
+  const { descriptor: checkDescriptor } = checkSelection;
 
-  const source = await resolveCiRun({
-    github,
-    owner,
-    repo,
-    runId: descriptor.ciRunId,
-    expectedRunAttempt: descriptor.ciRunAttempt,
-    expectedHeadSha: descriptor.headSha,
-    expectedBaseSha: descriptor.baseSha,
-    waitForReleaseProvenance: false,
-  });
-  const delayedReleaseProvenance = source.sourceKind === 'release'
-    && source.pathClassification === 'release-candidate'
-    && descriptor.sourceKind === 'code';
-  if (source.sourceKind !== descriptor.sourceKind && !delayedReleaseProvenance) {
-    throw new QodanaPublicationRejectedError('Qodana source classification changed');
+  let source;
+  try {
+    source = await resolveCiRun({
+      github,
+      owner,
+      repo,
+      runId: checkDescriptor.ciRunId,
+      expectedRunAttempt: checkDescriptor.ciRunAttempt,
+      expectedHeadSha: checkDescriptor.headSha,
+      expectedBaseSha: checkDescriptor.baseSha,
+      waitForReleaseProvenance: false,
+    });
+  } catch (error) {
+    if (error instanceof QodanaSourceRejectedError) {
+      return {
+        artifactId: null,
+        checkConclusion: error.stale ? 'cancelled' : 'failure',
+        checkExternalId: buildCheckExternalId({
+          kind: 'qodana-pr',
+          runId: qodanaRun.id,
+          runAttempt: qodanaRun.run_attempt,
+          headSha: checkDescriptor.headSha,
+        }),
+        checkRunId: checkDescriptor.checkRunId,
+        headSha: checkDescriptor.headSha,
+        pullNumber: null,
+        publish: false,
+        rejection: error.stale ? null : error,
+        sourceKind: checkDescriptor.sourceKind,
+      };
+    }
+    throw error;
   }
-  const artifactSource = delayedReleaseProvenance
-    ? { ...source, sourceKind: descriptor.sourceKind }
+  const delayedCheckReleaseProvenance = source.sourceKind === 'release'
+    && source.pathClassification === 'release-candidate'
+    && checkDescriptor.sourceKind === 'code';
+  const checkSource = delayedCheckReleaseProvenance
+    ? { ...source, sourceKind: checkDescriptor.sourceKind }
     : source;
-
-  validateQodanaArtifactSource({ descriptor, source: artifactSource });
-  const { artifact } = selection;
-  return {
-    artifactId: artifact.id,
+  validateQodanaCheckSource({ descriptor: checkDescriptor, source: checkSource });
+  const common = {
+    checkConclusion: trustedRun.conclusion === 'success' ? null : trustedRun.conclusion,
+    checkExternalId: buildCheckExternalId({
+      kind: 'qodana-pr',
+      runId: qodanaRun.id,
+      runAttempt: qodanaRun.run_attempt,
+      headSha: source.headSha,
+    }),
+    checkRunId: checkDescriptor.checkRunId,
     headSha: source.headSha,
     pullNumber: source.pullRequest,
     sourceKind: source.sourceKind,
+  };
+  if (trustedRun.conclusion !== 'success') {
+    return {
+      ...common,
+      artifactId: null,
+      publish: false,
+      rejection: null,
+    };
+  }
+
+  let artifact;
+  try {
+    const selection = selectQodanaRunArtifact({ artifacts, qodanaRun, repository });
+    const { descriptor } = selection;
+    const delayedReleaseProvenance = source.sourceKind === 'release'
+      && source.pathClassification === 'release-candidate'
+      && descriptor.sourceKind === 'code';
+    if (source.sourceKind !== descriptor.sourceKind && !delayedReleaseProvenance) {
+      throw new QodanaPublicationRejectedError('Qodana source classification changed');
+    }
+    const artifactSource = delayedReleaseProvenance
+      ? { ...source, sourceKind: descriptor.sourceKind }
+      : source;
+    validateQodanaArtifactSource({ descriptor, source: artifactSource });
+    artifact = selection.artifact;
+  } catch (error) {
+    if (error instanceof QodanaPublicationRejectedError) {
+      return {
+        ...common,
+        artifactId: null,
+        checkConclusion: 'failure',
+        publish: false,
+        rejection: error,
+      };
+    }
+    throw error;
+  }
+  return {
+    ...common,
+    artifactId: artifact.id,
+    publish: true,
+    rejection: null,
   };
 }
 
 async function writePublicationOutputs({ github, context, core }) {
   try {
     const publication = await resolvePublication({ github, context });
-    core.setOutput('publish', 'true');
-    core.setOutput('artifact_id', String(publication.artifactId));
+    core.setOutput('publish', String(publication.publish));
+    if (publication.artifactId != null) {
+      core.setOutput('artifact_id', String(publication.artifactId));
+    }
     core.setOutput('head_sha', publication.headSha);
-    core.setOutput('pull_number', String(publication.pullNumber));
+    if (publication.pullNumber != null) {
+      core.setOutput('pull_number', String(publication.pullNumber));
+    }
     core.setOutput('source_kind', publication.sourceKind);
+    core.setOutput('check_run_id', String(publication.checkRunId));
+    core.setOutput('check_external_id', publication.checkExternalId);
+    core.setOutput('check_conclusion', publication.checkConclusion || '');
+    if (publication.rejection) {
+      core.setFailed(`Qodana publication rejected: ${publication.rejection.message}`);
+    }
     return publication;
   } catch (error) {
     if (error instanceof QodanaSourceRejectedError && error.stale) {

--- a/.github/scripts/qodana-security.test.js
+++ b/.github/scripts/qodana-security.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -351,6 +352,37 @@ test('classifies only approved documentation paths and release files', () => {
   assert.equal(classifyChangedFiles([{ filename: '.github/scripts/normalize-qodana-sarif.sh' }]), 'code');
   assert.equal(classifyChangedFiles([{ filename: 'docs/../.github/workflows/ci.yml' }]), 'code');
   assert.equal(classifyChangedFiles([]), 'code');
+});
+
+test('normalises Qodana metadata for a stable code-scanning category', (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'qodana-normalize-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const sarifPath = path.join(directory, 'qodana.sarif.json');
+  fs.writeFileSync(sarifPath, JSON.stringify({
+    version: '2.1.0',
+    runs: [{
+      automationDetails: {
+        id: 'Kotventure/qodana/2026-08-09',
+        guid: 'aaeed1dc-350f-44a8-870d-62f8cb2b1dd5',
+      },
+      results: [{
+        locations: [{
+          physicalLocation: {
+            region: { startLine: 0, startColumn: 0 },
+          },
+        }],
+      }],
+    }],
+  }));
+
+  execFileSync('bash', [path.join(__dirname, 'normalize-qodana-sarif.sh'), sarifPath]);
+
+  const document = JSON.parse(fs.readFileSync(sarifPath, 'utf8'));
+  assert.equal(document.runs[0].automationDetails, undefined);
+  assert.deepEqual(
+    document.runs[0].results[0].locations[0].physicalLocation.region,
+    { startLine: 1, startColumn: 1 },
+  );
 });
 
 test('binds Qodana artifacts to both run attempts and the source SHAs', () => {

--- a/.github/scripts/qodana-security.test.js
+++ b/.github/scripts/qodana-security.test.js
@@ -7,17 +7,23 @@ const path = require('node:path');
 const test = require('node:test');
 
 const {
+  MAX_CHECK_ARTIFACT_BYTES,
   buildArtifactName,
   buildCheckArtifactName,
   classifyChangedFiles,
   parseArtifactName,
   parseCheckArtifactName,
 } = require('./qodana-contract.js');
-const { registerQodanaCheck } = require('./qodana-check-registration.js');
+const {
+  createQodanaCheck,
+  writeQodanaCheckRegistration,
+} = require('./qodana-check-registration.js');
 const { createAttestation } = require('./qodana-attestation.js');
 const { extractQodanaSarifArchive } = require('./qodana-publisher-archive.js');
 const {
   selectQodanaArtifact,
+  selectQodanaCheckArtifact,
+  validateQodanaCheckSource,
   validateQodanaSarif,
 } = require('./qodana-publisher-validation.js');
 const { resolvePublication } = require('./qodana-publisher.js');
@@ -170,9 +176,13 @@ function makeStoredZip(content, fileName = 'qodana.sarif.json') {
 }
 
 function makePublicationGithub({
+  checkArtifactExpired = false,
+  checkArtifactSize = 200,
+  checkArtifacts = 1,
   delayedReleaseProvenance = false,
   includeSarif = true,
   qodanaConclusion = 'success',
+  staleSource = false,
 } = {}) {
   const qodanaRun = {
     id: QODANA_RUN_ID,
@@ -203,6 +213,7 @@ function makePublicationGithub({
     headRef: delayedReleaseProvenance
       ? 'release-please--branches--master'
       : 'feature/security',
+    headSha: staleSource ? 'd'.repeat(40) : HEAD_SHA,
   });
   if (delayedReleaseProvenance) {
     pullRequest.user = {
@@ -228,29 +239,32 @@ function makePublicationGithub({
     pull_requests: [{ number: pullRequest.number }],
     created_at: '2026-08-09T00:00:00Z',
   }];
-  const artifacts = [{
-      id: 699,
-      name: buildCheckArtifactName({
-        sourceKind: 'code',
-        runId: ciRun.id,
-        runAttempt: ciRun.run_attempt,
-        qodanaRunId: qodanaRun.id,
-        qodanaRunAttempt: qodanaRun.run_attempt,
-        checkRunId: 701,
-        headSha: ciRun.head_sha,
-        baseSha: BASE_SHA,
-      }),
-      expired: false,
-      size_in_bytes: 200,
-      workflow_run: {
-        id: qodanaRun.id,
-        repository_id: REPOSITORY.id,
-        head_repository_id: REPOSITORY.id,
-        head_branch: qodanaRun.head_branch,
-        head_sha: qodanaRun.head_sha,
-      },
+  const checkArtifact = {
+    id: 699,
+    name: buildCheckArtifactName({
+      sourceKind: 'code',
+      runId: ciRun.id,
+      runAttempt: ciRun.run_attempt,
+      qodanaRunId: qodanaRun.id,
+      qodanaRunAttempt: qodanaRun.run_attempt,
+      checkRunId: 701,
+      headSha: ciRun.head_sha,
+      baseSha: BASE_SHA,
+    }),
+    expired: checkArtifactExpired,
+    size_in_bytes: checkArtifactSize,
+    workflow_run: {
+      id: qodanaRun.id,
+      repository_id: REPOSITORY.id,
+      head_repository_id: REPOSITORY.id,
+      head_branch: qodanaRun.head_branch,
+      head_sha: qodanaRun.head_sha,
     },
-  ];
+  };
+  const artifacts = Array.from({ length: checkArtifacts }, (_, index) => ({
+    ...checkArtifact,
+    id: checkArtifact.id + index,
+  }));
   if (qodanaConclusion === 'success' && includeSarif) {
     artifacts.push({
       id: 700,
@@ -276,6 +290,7 @@ function makePublicationGithub({
   }
   const listArtifacts = async () => artifacts;
   return {
+    artifacts,
     context: {
       repo: { owner: 'LMLiam', repo: 'Kotventure' },
       payload: { workflow_run: qodanaEvent },
@@ -324,6 +339,7 @@ function makePublicationGithub({
         throw new Error('unexpected publication pagination method');
       },
     },
+    qodanaRun,
   };
 }
 
@@ -377,7 +393,7 @@ test('registers a source-bound Qodana check before pull-request analysis', async
     headSha: HEAD_SHA,
     baseSha: BASE_SHA,
   };
-  const registration = await registerQodanaCheck({
+  const check = await createQodanaCheck({
     github: {
       rest: {
         checks: {
@@ -400,11 +416,22 @@ test('registers a source-bound Qodana check before pull-request analysis', async
     source,
     qodanaRunId: QODANA_RUN_ID,
     qodanaRunAttempt: QODANA_RUN_ATTEMPT,
+  });
+  const registration = writeQodanaCheckRegistration({
+    check,
+    source,
+    qodanaRunId: QODANA_RUN_ID,
+    qodanaRunAttempt: QODANA_RUN_ATTEMPT,
     outputDirectory: directory,
   });
 
   assert.equal(calls[0].status, 'in_progress');
   assert.equal(calls[0].head_sha, HEAD_SHA);
+  assert.equal(
+    calls[0].external_id,
+    `workflow-run-check:qodana-pr:${QODANA_RUN_ID}:${QODANA_RUN_ATTEMPT}:${HEAD_SHA}`,
+  );
+  assert.equal(calls[0].name, 'Qodana / pull request');
   assert.deepEqual(parseCheckArtifactName(registration.artifactName), {
     sourceKind: 'code',
     ciRunId: 100,
@@ -422,19 +449,8 @@ test('registers a source-bound Qodana check before pull-request analysis', async
   assert.equal(descriptor.artifactName, registration.artifactName);
   assert.equal(descriptor.check.id, 701);
   assert.equal(descriptor.pullRequest, 42);
-
-  const parsed = parseCheckArtifactName(registration.artifactName);
-  const rebuilt = buildCheckArtifactName({
-    sourceKind: parsed.sourceKind,
-    runId: parsed.ciRunId,
-    runAttempt: parsed.ciRunAttempt,
-    qodanaRunId: parsed.qodanaRunId,
-    qodanaRunAttempt: parsed.qodanaRunAttempt,
-    checkRunId: parsed.checkRunId,
-    headSha: parsed.headSha,
-    baseSha: parsed.baseSha,
-  });
-  assert.equal(rebuilt, registration.artifactName);
+  const stats = fs.statSync(registration.filePath);
+  assert.equal(stats.mode & 0o777, 0o600);
 });
 
 test('creates valid zero-result attestations from trusted code', () => {
@@ -580,6 +596,46 @@ test('selects only the artifact bound to the trusted Qodana workflow run', () =>
   }).id, 700);
 });
 
+test('rejects missing, duplicate, expired, oversized, and source-mismatched check artifacts', () => {
+  const cases = [
+    [{ checkArtifacts: 0 }, /exactly one Qodana check artifact, found 0/],
+    [{ checkArtifacts: 2 }, /exactly one Qodana check artifact, found 2/],
+    [{ checkArtifactExpired: true }, /Qodana check artifact is expired/],
+    [{ checkArtifactSize: MAX_CHECK_ARTIFACT_BYTES + 1 }, /Qodana check artifact size is invalid/],
+  ];
+  for (const [options, expected] of cases) {
+    const inputs = makePublicationGithub(options);
+    assert.throws(
+      () => selectQodanaCheckArtifact({
+        artifacts: inputs.artifacts,
+        qodanaRun: inputs.qodanaRun,
+        repository: REPOSITORY,
+      }),
+      expected,
+    );
+  }
+
+  const inputs = makePublicationGithub();
+  const { descriptor } = selectQodanaCheckArtifact({
+    artifacts: inputs.artifacts,
+    qodanaRun: inputs.qodanaRun,
+    repository: REPOSITORY,
+  });
+  assert.throws(
+    () => validateQodanaCheckSource({
+      descriptor,
+      source: {
+        sourceKind: 'code',
+        runId: 100,
+        runAttempt: 2,
+        headSha: 'f'.repeat(40),
+        baseSha: BASE_SHA,
+      },
+    }),
+    /Qodana check head SHA does not match/,
+  );
+});
+
 test('publishes only a successful Qodana run for the current CI head', async () => {
   const inputs = makePublicationGithub();
   const publication = await resolvePublication({
@@ -591,6 +647,7 @@ test('publishes only a successful Qodana run for the current CI head', async () 
     checkConclusion: null,
     checkExternalId: `workflow-run-check:qodana-pr:${QODANA_RUN_ID}:${QODANA_RUN_ATTEMPT}:${HEAD_SHA}`,
     checkRunId: 701,
+    checkSummary: null,
     headSha: HEAD_SHA,
     pullNumber: 42,
     publish: true,
@@ -619,8 +676,60 @@ test('reports a failed Qodana analysis against its registered pull-request check
   assert.equal(publication.publish, false);
   assert.equal(publication.artifactId, null);
   assert.equal(publication.checkConclusion, 'failure');
+  assert.equal(publication.checkSummary, 'Qodana analysis failed.');
   assert.equal(publication.checkRunId, 701);
   assert.equal(publication.headSha, HEAD_SHA);
+});
+
+test('reports cancelled and timed-out Qodana analyses against the registered check', async () => {
+  const cases = [
+    ['cancelled', 'The Qodana analysis was cancelled.'],
+    ['timed_out', 'Qodana analysis timed out.'],
+  ];
+  for (const [conclusion, summary] of cases) {
+    const inputs = makePublicationGithub({ qodanaConclusion: conclusion });
+    const publication = await resolvePublication({
+      github: inputs.github,
+      context: inputs.context,
+    });
+    assert.equal(publication.publish, false);
+    assert.equal(publication.checkConclusion, conclusion);
+    assert.equal(publication.checkSummary, summary);
+    assert.equal(publication.rejection, null);
+  }
+});
+
+test('cancels the registered check when the pull-request source becomes stale', async () => {
+  const inputs = makePublicationGithub({ staleSource: true });
+  const publication = await resolvePublication({
+    github: inputs.github,
+    context: inputs.context,
+  });
+  assert.equal(publication.publish, false);
+  assert.equal(publication.checkConclusion, 'cancelled');
+  assert.equal(
+    publication.checkSummary,
+    'Qodana publication stopped because the pull request changed.',
+  );
+  assert.equal(publication.rejection, null);
+});
+
+test('recovers the check identity when registration artifact validation fails', async () => {
+  const cases = [
+    [{ checkArtifacts: 2 }, /exactly one Qodana check artifact, found 2/],
+    [{ checkArtifactExpired: true }, /Qodana check artifact is expired/],
+  ];
+  for (const [options, expected] of cases) {
+    const inputs = makePublicationGithub(options);
+    const publication = await resolvePublication({
+      github: inputs.github,
+      context: inputs.context,
+    });
+    assert.equal(publication.publish, false);
+    assert.equal(publication.checkRunId, 701);
+    assert.equal(publication.checkConclusion, 'failure');
+    assert.match(publication.rejection.message, expected);
+  }
 });
 
 test('reports a missing successful Qodana artifact as publication failure', async () => {

--- a/.github/scripts/qodana-security.test.js
+++ b/.github/scripts/qodana-security.test.js
@@ -8,9 +8,12 @@ const test = require('node:test');
 
 const {
   buildArtifactName,
+  buildCheckArtifactName,
   classifyChangedFiles,
   parseArtifactName,
+  parseCheckArtifactName,
 } = require('./qodana-contract.js');
+const { registerQodanaCheck } = require('./qodana-check-registration.js');
 const { createAttestation } = require('./qodana-attestation.js');
 const { extractQodanaSarifArchive } = require('./qodana-publisher-archive.js');
 const {
@@ -166,14 +169,18 @@ function makeStoredZip(content, fileName = 'qodana.sarif.json') {
   return Buffer.concat([localHeader, content, centralDirectory, end]);
 }
 
-function makePublicationGithub() {
+function makePublicationGithub({
+  delayedReleaseProvenance = false,
+  includeSarif = true,
+  qodanaConclusion = 'success',
+} = {}) {
   const qodanaRun = {
     id: QODANA_RUN_ID,
     run_attempt: QODANA_RUN_ATTEMPT,
     workflow_id: 77,
     event: 'workflow_run',
     status: 'completed',
-    conclusion: 'success',
+    conclusion: qodanaConclusion,
     repository: REPOSITORY,
     head_repository: REPOSITORY,
     head_branch: REPOSITORY.default_branch,
@@ -188,11 +195,64 @@ function makePublicationGithub() {
     conclusion: qodanaRun.conclusion,
   };
   const ciRun = makeCiRun();
-  const pullRequest = makePullRequest();
-  const files = [{ filename: 'src/Main.kt' }];
+  const files = delayedReleaseProvenance
+    ? [{ filename: 'CHANGELOG.md' }]
+    : [{ filename: 'src/Main.kt' }];
+  const pullRequest = makePullRequest({
+    files,
+    headRef: delayedReleaseProvenance
+      ? 'release-please--branches--master'
+      : 'feature/security',
+  });
+  if (delayedReleaseProvenance) {
+    pullRequest.user = {
+      login: 'release-please-kotventure[bot]',
+      type: 'Bot',
+    };
+    ciRun.head_branch = pullRequest.head.ref;
+  }
   const listFiles = async () => files;
-  const listArtifacts = async () => [
-    {
+  const listJobs = async () => [{
+    name: 'Trusted release provenance',
+    status: 'completed',
+    conclusion: 'success',
+  }];
+  const listReleaseRuns = async () => [{
+    id: 800,
+    event: 'pull_request_target',
+    status: 'completed',
+    conclusion: 'success',
+    repository: REPOSITORY,
+    head_branch: pullRequest.head.ref,
+    head_sha: pullRequest.head.sha,
+    pull_requests: [{ number: pullRequest.number }],
+    created_at: '2026-08-09T00:00:00Z',
+  }];
+  const artifacts = [{
+      id: 699,
+      name: buildCheckArtifactName({
+        sourceKind: 'code',
+        runId: ciRun.id,
+        runAttempt: ciRun.run_attempt,
+        qodanaRunId: qodanaRun.id,
+        qodanaRunAttempt: qodanaRun.run_attempt,
+        checkRunId: 701,
+        headSha: ciRun.head_sha,
+        baseSha: BASE_SHA,
+      }),
+      expired: false,
+      size_in_bytes: 200,
+      workflow_run: {
+        id: qodanaRun.id,
+        repository_id: REPOSITORY.id,
+        head_repository_id: REPOSITORY.id,
+        head_branch: qodanaRun.head_branch,
+        head_sha: qodanaRun.head_sha,
+      },
+    },
+  ];
+  if (qodanaConclusion === 'success' && includeSarif) {
+    artifacts.push({
       id: 700,
       name: buildArtifactName({
         sourceKind: 'code',
@@ -212,8 +272,9 @@ function makePublicationGithub() {
         head_branch: qodanaRun.head_branch,
         head_sha: qodanaRun.head_sha,
       },
-    },
-  ];
+    });
+  }
+  const listArtifacts = async () => artifacts;
   return {
     context: {
       repo: { owner: 'LMLiam', repo: 'Kotventure' },
@@ -234,8 +295,12 @@ function makePublicationGithub() {
           getWorkflow: async ({ workflow_id: workflowId }) => ({
             data: workflowId === qodanaRun.workflow_id
               ? { id: 77, name: 'Qodana', path: '.github/workflows/qodana.yml' }
-              : { id: 55, name: 'CI', path: '.github/workflows/ci.yml' },
+              : workflowId === 'release-provenance.yml'
+                ? { path: '.github/workflows/release-provenance.yml' }
+                : { id: 55, name: 'CI', path: '.github/workflows/ci.yml' },
           }),
+          listJobsForWorkflowRun: listJobs,
+          listWorkflowRuns: listReleaseRuns,
           listWorkflowRunArtifacts: listArtifacts,
         },
         pulls: {
@@ -249,6 +314,12 @@ function makePublicationGithub() {
         }
         if (method === listFiles) {
           return files;
+        }
+        if (method === listJobs) {
+          return listJobs();
+        }
+        if (method === listReleaseRuns) {
+          return listReleaseRuns();
         }
         throw new Error('unexpected publication pagination method');
       },
@@ -286,6 +357,84 @@ test('binds Qodana artifacts to both run attempts and the source SHAs', () => {
     baseSha: BASE_SHA,
   });
   assert.equal(parseArtifactName(`${name}-old`), null);
+});
+
+test('registers a source-bound Qodana check before pull-request analysis', async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'qodana-check-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const calls = [];
+  const context = {
+    repo: { owner: 'LMLiam', repo: 'Kotventure' },
+    runId: QODANA_RUN_ID,
+    runAttempt: QODANA_RUN_ATTEMPT,
+    serverUrl: 'https://github.com',
+  };
+  const source = {
+    sourceKind: 'code',
+    runId: 100,
+    runAttempt: 2,
+    pullRequest: 42,
+    headSha: HEAD_SHA,
+    baseSha: BASE_SHA,
+  };
+  const registration = await registerQodanaCheck({
+    github: {
+      rest: {
+        checks: {
+          create: async (parameters) => {
+            calls.push(parameters);
+            return {
+              data: {
+                id: 701,
+                name: parameters.name,
+                head_sha: parameters.head_sha,
+                external_id: parameters.external_id,
+                app: { slug: 'github-actions' },
+              },
+            };
+          },
+        },
+      },
+    },
+    context,
+    source,
+    qodanaRunId: QODANA_RUN_ID,
+    qodanaRunAttempt: QODANA_RUN_ATTEMPT,
+    outputDirectory: directory,
+  });
+
+  assert.equal(calls[0].status, 'in_progress');
+  assert.equal(calls[0].head_sha, HEAD_SHA);
+  assert.deepEqual(parseCheckArtifactName(registration.artifactName), {
+    sourceKind: 'code',
+    ciRunId: 100,
+    ciRunAttempt: 2,
+    qodanaRunId: QODANA_RUN_ID,
+    qodanaRunAttempt: QODANA_RUN_ATTEMPT,
+    checkRunId: 701,
+    headSha: HEAD_SHA,
+    baseSha: BASE_SHA,
+  });
+  const descriptor = JSON.parse(fs.readFileSync(
+    path.join(directory, 'qodana-check.json'),
+    'utf8',
+  ));
+  assert.equal(descriptor.artifactName, registration.artifactName);
+  assert.equal(descriptor.check.id, 701);
+  assert.equal(descriptor.pullRequest, 42);
+
+  const parsed = parseCheckArtifactName(registration.artifactName);
+  const rebuilt = buildCheckArtifactName({
+    sourceKind: parsed.sourceKind,
+    runId: parsed.ciRunId,
+    runAttempt: parsed.ciRunAttempt,
+    qodanaRunId: parsed.qodanaRunId,
+    qodanaRunAttempt: parsed.qodanaRunAttempt,
+    checkRunId: parsed.checkRunId,
+    headSha: parsed.headSha,
+    baseSha: parsed.baseSha,
+  });
+  assert.equal(rebuilt, registration.artifactName);
 });
 
 test('creates valid zero-result attestations from trusted code', () => {
@@ -439,10 +588,50 @@ test('publishes only a successful Qodana run for the current CI head', async () 
   });
   assert.deepEqual(publication, {
     artifactId: 700,
+    checkConclusion: null,
+    checkExternalId: `workflow-run-check:qodana-pr:${QODANA_RUN_ID}:${QODANA_RUN_ATTEMPT}:${HEAD_SHA}`,
+    checkRunId: 701,
     headSha: HEAD_SHA,
     pullNumber: 42,
+    publish: true,
+    rejection: null,
     sourceKind: 'code',
   });
+});
+
+test('completes a check registered before delayed release provenance', async () => {
+  const inputs = makePublicationGithub({ delayedReleaseProvenance: true });
+  const publication = await resolvePublication({
+    github: inputs.github,
+    context: inputs.context,
+  });
+  assert.equal(publication.publish, true);
+  assert.equal(publication.checkRunId, 701);
+  assert.equal(publication.sourceKind, 'release');
+});
+
+test('reports a failed Qodana analysis against its registered pull-request check', async () => {
+  const inputs = makePublicationGithub({ qodanaConclusion: 'failure' });
+  const publication = await resolvePublication({
+    github: inputs.github,
+    context: inputs.context,
+  });
+  assert.equal(publication.publish, false);
+  assert.equal(publication.artifactId, null);
+  assert.equal(publication.checkConclusion, 'failure');
+  assert.equal(publication.checkRunId, 701);
+  assert.equal(publication.headSha, HEAD_SHA);
+});
+
+test('reports a missing successful Qodana artifact as publication failure', async () => {
+  const inputs = makePublicationGithub({ includeSarif: false });
+  const publication = await resolvePublication({
+    github: inputs.github,
+    context: inputs.context,
+  });
+  assert.equal(publication.publish, false);
+  assert.equal(publication.checkConclusion, 'failure');
+  assert.match(publication.rejection.message, /exactly one Qodana SARIF artifact/);
 });
 
 test('resolves a successful CI source and computes its merge base', async () => {

--- a/.github/scripts/qodana-workflow-security.test.js
+++ b/.github/scripts/qodana-workflow-security.test.js
@@ -13,10 +13,13 @@ function readRepositoryFile(relativePath) {
 
 function readJob(workflow, name, nextName) {
   const start = workflow.indexOf(`  ${name}:\n`);
-  const end = nextName == null ? workflow.length : workflow.indexOf(`  ${nextName}:\n`, start);
   assert.notEqual(start, -1, `job ${name} is missing`);
+  const end = nextName == null ? workflow.length : workflow.indexOf(`  ${nextName}:\n`, start);
   assert.notEqual(end, -1, `job ${nextName} is missing`);
-  return workflow.slice(start, end);
+  assert.ok(end > start, `job ${name} must precede job ${nextName}`);
+  const section = workflow.slice(start, end);
+  assert.ok(section.trim().length > 0, `job ${name} is empty`);
+  return section;
 }
 
 test('the pull-request CI workflow does not run or publish Qodana results', () => {
@@ -37,8 +40,14 @@ test('the Qodana scan workflow is read-only and disables GitHub side effects', (
   assert.doesNotMatch(workflow, /QODANA_TOKEN/);
   assert.match(register, /checks:\s*write/);
   assert.doesNotMatch(analyse, /(?:actions|checks|contents|pull-requests|security-events):\s*write/);
-  assert.match(register, /registerQodanaCheck/);
+  assert.match(register, /createQodanaCheck/);
+  assert.ok(
+    register.indexOf("core.setOutput('check_run_id'")
+      < register.indexOf('const registration = writeQodanaCheckRegistration'),
+    'the workflow must export the check identity before registration persistence',
+  );
   assert.match(register, /Upload the Qodana check registration/);
+  assert.match(register, /path: \$\{\{ steps\.source\.outputs\.check_file_path \}\}/);
   assert.match(registrationFailure, /needs\.register\.result != 'success'/);
   assert.match(registrationFailure, /Complete the failed Qodana registration check/);
   assert.match(workflow, /upload-result:\s*false/);
@@ -81,6 +90,8 @@ test('trusted Qodana runs are limited to trusted CI events', () => {
   assert.match(register, /checks:\s*write/);
   assert.doesNotMatch(analyse, /checks:\s*write/);
   assert.match(report, /checks:\s*write/);
+  assert.match(report, /needs\.register\.outputs\.check_run_id != ''/);
+  assert.match(report, /REGISTER_RESULT: \$\{\{ needs\.register\.result \}\}/);
   assert.doesNotMatch(workflow, /QODANA_TOKEN/);
   assert.match(workflow, /resolveTrustedCiRun/);
   assert.match(workflow, /ref:\s*\$\{\{ needs\.register\.outputs\.head_sha \}\}/);

--- a/.github/scripts/qodana-workflow-security.test.js
+++ b/.github/scripts/qodana-workflow-security.test.js
@@ -72,8 +72,14 @@ test('only the trusted publication workflow can upload Qodana SARIF', () => {
   assert.match(workflow, /actions\/checkout@/);
   assert.match(workflow, /ref:\s*\$\{\{ github\.sha \}\}/);
   assert.match(workflow, /group: qodana-publication-\$\{\{ github\.event\.workflow_run\.id \}\}-\$\{\{ github\.event\.workflow_run\.run_attempt \}\}/);
-  assert.match(workflow, /github\/codeql-action\/upload-sarif@/);
+  assert.match(workflow, /github\/codeql-action\/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38/);
+  assert.match(workflow, /Verify the SARIF upload root is not a Git worktree/);
+  assert.match(workflow, /git -C "\$UPLOAD_ROOT" rev-parse --is-inside-work-tree/);
+  assert.match(workflow, /checkout_path:\s*\$\{\{ runner\.temp \}\}\/qodana-publication/);
+  assert.match(workflow, /ref:\s*refs\/pull\/\$\{\{ steps\.publication\.outputs\.pull_number \}\}\/head/);
+  assert.match(workflow, /sha:\s*\$\{\{ steps\.publication\.outputs\.head_sha \}\}/);
   assert.match(workflow, /CODEQL_ACTION_ANALYSIS_KEY: .github\/workflows\/ci\.yml:qodana/);
+  assert.doesNotMatch(workflow, /Checkout pull-request code/);
   assert.match(workflow, /Complete the pull-request Qodana check/);
 });
 

--- a/.github/scripts/qodana-workflow-security.test.js
+++ b/.github/scripts/qodana-workflow-security.test.js
@@ -11,6 +11,14 @@ function readRepositoryFile(relativePath) {
   return fs.readFileSync(path.join(repositoryRoot, relativePath), 'utf8');
 }
 
+function readJob(workflow, name, nextName) {
+  const start = workflow.indexOf(`  ${name}:\n`);
+  const end = nextName == null ? workflow.length : workflow.indexOf(`  ${nextName}:\n`, start);
+  assert.notEqual(start, -1, `job ${name} is missing`);
+  assert.notEqual(end, -1, `job ${nextName} is missing`);
+  return workflow.slice(start, end);
+}
+
 test('the pull-request CI workflow does not run or publish Qodana results', () => {
   const workflow = readRepositoryFile('.github/workflows/ci.yml');
 
@@ -21,10 +29,18 @@ test('the pull-request CI workflow does not run or publish Qodana results', () =
 
 test('the Qodana scan workflow is read-only and disables GitHub side effects', () => {
   const workflow = readRepositoryFile('.github/workflows/qodana.yml');
+  const register = readJob(workflow, 'register', 'analyse');
+  const analyse = readJob(workflow, 'analyse', 'report-registration-failure');
+  const registrationFailure = readJob(workflow, 'report-registration-failure');
 
   assert.match(workflow, /workflow_run:/);
   assert.doesNotMatch(workflow, /QODANA_TOKEN/);
-  assert.doesNotMatch(workflow, /(?:actions|checks|contents|pull-requests|security-events):\s*write/);
+  assert.match(register, /checks:\s*write/);
+  assert.doesNotMatch(analyse, /(?:actions|checks|contents|pull-requests|security-events):\s*write/);
+  assert.match(register, /registerQodanaCheck/);
+  assert.match(register, /Upload the Qodana check registration/);
+  assert.match(registrationFailure, /needs\.register\.result != 'success'/);
+  assert.match(registrationFailure, /Complete the failed Qodana registration check/);
   assert.match(workflow, /upload-result:\s*false/);
   assert.match(workflow, /use-annotations:\s*false/);
   assert.match(workflow, /post-pr-comment:\s*false/);
@@ -33,6 +49,7 @@ test('the Qodana scan workflow is read-only and disables GitHub side effects', (
   assert.doesNotMatch(workflow, /--config source\/qodana\.yaml/);
   assert.match(workflow, /ref:\s*\$\{\{ github\.sha \}\}/);
   assert.match(workflow, /git -C source rev-parse HEAD/);
+  assert.match(analyse, /ref:\s*\$\{\{ needs\.register\.outputs\.head_sha \}\}/);
   assert.match(workflow, /cp --remove-destination -- qodana\.yaml source\/qodana\.yaml/);
   assert.doesNotMatch(workflow, /normalize-qodana-sarif\.sh/);
 });
@@ -42,26 +59,45 @@ test('only the trusted publication workflow can upload Qodana SARIF', () => {
 
   assert.match(workflow, /workflow_run:/);
   assert.match(workflow, /security-events:\s*write/);
+  assert.match(workflow, /checks:\s*write/);
   assert.match(workflow, /actions\/checkout@/);
   assert.match(workflow, /ref:\s*\$\{\{ github\.sha \}\}/);
   assert.match(workflow, /group: qodana-publication-\$\{\{ github\.event\.workflow_run\.id \}\}-\$\{\{ github\.event\.workflow_run\.run_attempt \}\}/);
   assert.match(workflow, /github\/codeql-action\/upload-sarif@/);
   assert.match(workflow, /CODEQL_ACTION_ANALYSIS_KEY: .github\/workflows\/ci\.yml:qodana/);
+  assert.match(workflow, /Complete the pull-request Qodana check/);
 });
 
 test('trusted Qodana runs are limited to trusted CI events', () => {
   const workflow = readRepositoryFile('.github/workflows/qodana-trusted.yml');
+  const register = readJob(workflow, 'register', 'analyse');
+  const analyse = readJob(workflow, 'analyse', 'report');
+  const report = readJob(workflow, 'report');
 
   assert.match(workflow, /workflow_run:/);
   assert.match(workflow, /event == 'push'/);
   assert.doesNotMatch(workflow, /merge_group/);
   assert.match(workflow, /security-events:\s*write/);
+  assert.match(register, /checks:\s*write/);
+  assert.doesNotMatch(analyse, /checks:\s*write/);
+  assert.match(report, /checks:\s*write/);
   assert.doesNotMatch(workflow, /QODANA_TOKEN/);
   assert.match(workflow, /resolveTrustedCiRun/);
-  assert.match(workflow, /ref:\s*\$\{\{ steps\.source\.outputs\.head_sha \}\}/);
+  assert.match(workflow, /ref:\s*\$\{\{ needs\.register\.outputs\.head_sha \}\}/);
   assert.match(workflow, /--project-dir source\s+--config qodana\.yaml/);
   assert.doesNotMatch(workflow, /--config source\/qodana\.yaml/);
   assert.match(workflow, /ref:\s*refs\/heads\/\$\{\{ github\.event\.repository\.default_branch \}\}/);
-  assert.match(workflow, /sha:\s*\$\{\{ steps\.source\.outputs\.head_sha \}\}/);
+  assert.match(workflow, /sha:\s*\$\{\{ needs\.register\.outputs\.head_sha \}\}/);
   assert.match(workflow, /checkout_path:\s*source/);
+  assert.match(report, /Complete the trusted Qodana check/);
+});
+
+test('trusted metrics publication reports its result against the pull-request head', () => {
+  const workflow = readRepositoryFile('.github/workflows/pr-metrics-publish.yml');
+
+  assert.match(workflow, /workflow_run:/);
+  assert.match(workflow, /checks:\s*write/);
+  assert.match(workflow, /Register the metrics publication check/);
+  assert.match(workflow, /HEAD_SHA: \$\{\{ steps\.source\.outputs\.head_sha \}\}/);
+  assert.match(workflow, /Complete the metrics publication check/);
 });

--- a/.github/scripts/workflow-run-check.js
+++ b/.github/scripts/workflow-run-check.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const KIND_PATTERN = /^[a-z0-9-]{1,48}$/;
+const EXTERNAL_ID_PREFIX = 'workflow-run-check';
+const CHECK_APP_SLUG = 'github-actions';
+const WORKFLOW_RESULTS = new Set([
+  'success',
+  'failure',
+  'cancelled',
+  'skipped',
+  'timed_out',
+]);
+
+function requireObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} is missing`);
+  }
+  return value;
+}
+
+function requirePositiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function requireSha(value, label) {
+  if (typeof value !== 'string' || !SHA_PATTERN.test(value)) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function requireText(value, label, maximumLength) {
+  if (typeof value !== 'string' || value.length < 1 || value.length > maximumLength) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function requireEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label} does not match the trusted value`);
+  }
+}
+
+function workflowRunUrl(context) {
+  const serverUrl = requireText(context?.serverUrl, 'GitHub server URL', 512);
+  const repository = `${requireText(context?.repo?.owner, 'repository owner', 100)}/${requireText(context?.repo?.repo, 'repository name', 100)}`;
+  const runId = requirePositiveInteger(context?.runId, 'workflow run id');
+  const runAttempt = requirePositiveInteger(context?.runAttempt, 'workflow run attempt');
+  return `${serverUrl}/${repository}/actions/runs/${runId}/attempts/${runAttempt}`;
+}
+
+function buildCheckExternalId({ kind, runId, runAttempt, headSha }) {
+  if (typeof kind !== 'string' || !KIND_PATTERN.test(kind)) {
+    throw new Error('check kind is invalid');
+  }
+  return `${EXTERNAL_ID_PREFIX}:${kind}:${requirePositiveInteger(runId, 'workflow run id')}:${requirePositiveInteger(runAttempt, 'workflow run attempt')}:${requireSha(headSha, 'check head SHA')}`;
+}
+
+function validateCreatedCheck(check, expected) {
+  requireObject(check, 'created check');
+  requirePositiveInteger(check.id, 'created check id');
+  requireEqual(check.name, expected.name, 'created check name');
+  requireEqual(check.head_sha, expected.headSha, 'created check head SHA');
+  requireEqual(check.external_id, expected.externalId, 'created check external id');
+  requireEqual(check.app?.slug, CHECK_APP_SLUG, 'created check application');
+}
+
+async function createWorkflowCheck({
+  github,
+  context,
+  name,
+  headSha,
+  externalId,
+  summary,
+}) {
+  const owner = requireText(context?.repo?.owner, 'repository owner', 100);
+  const repo = requireText(context?.repo?.repo, 'repository name', 100);
+  const trustedName = requireText(name, 'check name', 100);
+  const trustedHeadSha = requireSha(headSha, 'check head SHA');
+  const trustedExternalId = requireText(externalId, 'check external id', 256);
+  const trustedSummary = requireText(summary, 'check summary', 65_535);
+  const response = await github.rest.checks.create({
+    owner,
+    repo,
+    name: trustedName,
+    head_sha: trustedHeadSha,
+    status: 'in_progress',
+    external_id: trustedExternalId,
+    details_url: workflowRunUrl(context),
+    started_at: new Date().toISOString(),
+    output: {
+      title: trustedName,
+      summary: trustedSummary,
+    },
+  });
+  const check = response?.data;
+  validateCreatedCheck(check, {
+    name: trustedName,
+    headSha: trustedHeadSha,
+    externalId: trustedExternalId,
+  });
+  return {
+    id: check.id,
+    externalId: trustedExternalId,
+    headSha: trustedHeadSha,
+    name: trustedName,
+  };
+}
+
+function workflowResultConclusion(result) {
+  if (typeof result !== 'string' || !WORKFLOW_RESULTS.has(result)) {
+    throw new Error('workflow result is invalid');
+  }
+  return result;
+}
+
+async function completeWorkflowCheck({
+  github,
+  context,
+  checkId,
+  name,
+  headSha,
+  externalId,
+  conclusion,
+  summary,
+}) {
+  const owner = requireText(context?.repo?.owner, 'repository owner', 100);
+  const repo = requireText(context?.repo?.repo, 'repository name', 100);
+  const trustedCheckId = requirePositiveInteger(checkId, 'check id');
+  const trustedName = requireText(name, 'check name', 100);
+  const trustedHeadSha = requireSha(headSha, 'check head SHA');
+  const trustedExternalId = requireText(externalId, 'check external id', 256);
+  const trustedConclusion = workflowResultConclusion(conclusion);
+  const trustedSummary = requireText(summary, 'check summary', 65_535);
+  const response = await github.rest.checks.get({
+    owner,
+    repo,
+    check_run_id: trustedCheckId,
+  });
+  const check = requireObject(response?.data, 'registered check');
+  requireEqual(check.id, trustedCheckId, 'check id');
+  requireEqual(check.name, trustedName, 'check name');
+  requireEqual(check.head_sha, trustedHeadSha, 'check head SHA');
+  requireEqual(check.external_id, trustedExternalId, 'check external id');
+  requireEqual(check.app?.slug, CHECK_APP_SLUG, 'check application');
+
+  await github.rest.checks.update({
+    owner,
+    repo,
+    check_run_id: trustedCheckId,
+    status: 'completed',
+    conclusion: trustedConclusion,
+    completed_at: new Date().toISOString(),
+    details_url: workflowRunUrl(context),
+    output: {
+      title: trustedName,
+      summary: trustedSummary,
+    },
+  });
+}
+
+module.exports = {
+  buildCheckExternalId,
+  completeWorkflowCheck,
+  createWorkflowCheck,
+  workflowResultConclusion,
+};

--- a/.github/scripts/workflow-run-check.test.js
+++ b/.github/scripts/workflow-run-check.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  buildCheckExternalId,
+  completeWorkflowCheck,
+  createWorkflowCheck,
+  workflowResultConclusion,
+} = require('./workflow-run-check.js');
+
+const HEAD_SHA = 'a'.repeat(40);
+const CONTEXT = {
+  repo: { owner: 'LMLiam', repo: 'Kotventure' },
+  runId: 123,
+  runAttempt: 2,
+  serverUrl: 'https://github.com',
+};
+
+function makeGithub() {
+  const calls = [];
+  const check = {
+    id: 700,
+    name: 'Qodana / trusted ref',
+    head_sha: HEAD_SHA,
+    external_id: 'workflow-run-check:qodana-trusted:123:2:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    app: { slug: 'github-actions' },
+  };
+  return {
+    calls,
+    check,
+    github: {
+      rest: {
+        checks: {
+          create: async (parameters) => {
+            calls.push(['create', parameters]);
+            return { data: check };
+          },
+          get: async (parameters) => {
+            calls.push(['get', parameters]);
+            return { data: check };
+          },
+          update: async (parameters) => {
+            calls.push(['update', parameters]);
+            return { data: { ...check, ...parameters } };
+          },
+        },
+      },
+    },
+  };
+}
+
+test('creates an in-progress check against the validated source SHA', async () => {
+  const fixture = makeGithub();
+  const externalId = buildCheckExternalId({
+    kind: 'qodana-trusted',
+    runId: CONTEXT.runId,
+    runAttempt: CONTEXT.runAttempt,
+    headSha: HEAD_SHA,
+  });
+  const result = await createWorkflowCheck({
+    github: fixture.github,
+    context: CONTEXT,
+    name: fixture.check.name,
+    headSha: HEAD_SHA,
+    externalId,
+    summary: 'Qodana is analysing the validated trusted source.',
+  });
+
+  assert.deepEqual(result, {
+    id: fixture.check.id,
+    externalId,
+    headSha: HEAD_SHA,
+    name: fixture.check.name,
+  });
+  const [operation, parameters] = fixture.calls[0];
+  assert.equal(operation, 'create');
+  assert.deepEqual({ ...parameters, started_at: '<timestamp>' }, {
+    owner: 'LMLiam',
+    repo: 'Kotventure',
+    name: fixture.check.name,
+    head_sha: HEAD_SHA,
+    status: 'in_progress',
+    external_id: externalId,
+    details_url: 'https://github.com/LMLiam/Kotventure/actions/runs/123/attempts/2',
+    started_at: '<timestamp>',
+    output: {
+      title: fixture.check.name,
+      summary: 'Qodana is analysing the validated trusted source.',
+    },
+  });
+  assert.doesNotThrow(() => new Date(parameters.started_at).toISOString());
+});
+
+test('validates and completes the registered check', async () => {
+  const fixture = makeGithub();
+  await completeWorkflowCheck({
+    github: fixture.github,
+    context: CONTEXT,
+    checkId: fixture.check.id,
+    name: fixture.check.name,
+    headSha: HEAD_SHA,
+    externalId: fixture.check.external_id,
+    conclusion: 'success',
+    summary: 'Qodana analysed the validated trusted source.',
+  });
+
+  assert.deepEqual(fixture.calls[0], ['get', {
+    owner: 'LMLiam',
+    repo: 'Kotventure',
+    check_run_id: fixture.check.id,
+  }]);
+  const [operation, parameters] = fixture.calls[1];
+  assert.equal(operation, 'update');
+  assert.deepEqual({ ...parameters, completed_at: '<timestamp>' }, {
+    owner: 'LMLiam',
+    repo: 'Kotventure',
+    check_run_id: fixture.check.id,
+    status: 'completed',
+    conclusion: 'success',
+    completed_at: '<timestamp>',
+    details_url: 'https://github.com/LMLiam/Kotventure/actions/runs/123/attempts/2',
+    output: {
+      title: fixture.check.name,
+      summary: 'Qodana analysed the validated trusted source.',
+    },
+  });
+  assert.doesNotThrow(() => new Date(parameters.completed_at).toISOString());
+});
+
+test('rejects a check that is not bound to the expected source', async () => {
+  const fixture = makeGithub();
+  fixture.check.head_sha = 'b'.repeat(40);
+
+  await assert.rejects(
+    () => completeWorkflowCheck({
+      github: fixture.github,
+      context: CONTEXT,
+      checkId: fixture.check.id,
+      name: fixture.check.name,
+      headSha: HEAD_SHA,
+      externalId: fixture.check.external_id,
+      conclusion: 'failure',
+      summary: 'Qodana failed.',
+    }),
+    /check head SHA does not match/,
+  );
+  assert.equal(fixture.calls.length, 1);
+});
+
+test('maps workflow results to supported check conclusions', () => {
+  assert.equal(workflowResultConclusion('success'), 'success');
+  assert.equal(workflowResultConclusion('failure'), 'failure');
+  assert.equal(workflowResultConclusion('cancelled'), 'cancelled');
+  assert.equal(workflowResultConclusion('skipped'), 'skipped');
+  assert.equal(workflowResultConclusion('timed_out'), 'timed_out');
+  assert.throws(() => workflowResultConclusion('pending'), /workflow result is invalid/);
+});

--- a/.github/scripts/workflow-run-check.test.js
+++ b/.github/scripts/workflow-run-check.test.js
@@ -93,6 +93,67 @@ test('creates an in-progress check against the validated source SHA', async () =
   assert.doesNotThrow(() => new Date(parameters.started_at).toISOString());
 });
 
+test('rejects a created check from a foreign application', async () => {
+  const fixture = makeGithub();
+  fixture.check.app.slug = 'other-app';
+  await assert.rejects(
+    () => createWorkflowCheck({
+      github: fixture.github,
+      context: CONTEXT,
+      name: fixture.check.name,
+      headSha: HEAD_SHA,
+      externalId: fixture.check.external_id,
+      summary: 'Qodana is analysing the validated trusted source.',
+    }),
+    /created check application does not match/,
+  );
+});
+
+test('rejects a created check bound to a foreign external id', async () => {
+  const fixture = makeGithub();
+  const externalId = fixture.check.external_id;
+  fixture.check.external_id = `workflow-run-check:qodana-trusted:1:1:${'b'.repeat(40)}`;
+  await assert.rejects(
+    () => createWorkflowCheck({
+      github: fixture.github,
+      context: CONTEXT,
+      name: fixture.check.name,
+      headSha: HEAD_SHA,
+      externalId,
+      summary: 'Qodana is analysing the validated trusted source.',
+    }),
+    /created check external id does not match/,
+  );
+});
+
+test('rejects a created check bound to a foreign source SHA', async () => {
+  const fixture = makeGithub();
+  fixture.check.head_sha = 'b'.repeat(40);
+  await assert.rejects(
+    () => createWorkflowCheck({
+      github: fixture.github,
+      context: CONTEXT,
+      name: fixture.check.name,
+      headSha: HEAD_SHA,
+      externalId: fixture.check.external_id,
+      summary: 'Qodana is analysing the validated trusted source.',
+    }),
+    /created check head SHA does not match/,
+  );
+});
+
+test('rejects an invalid check kind', () => {
+  assert.throws(
+    () => buildCheckExternalId({
+      kind: 'Qodana PR',
+      runId: 1,
+      runAttempt: 1,
+      headSha: HEAD_SHA,
+    }),
+    /check kind is invalid/,
+  );
+});
+
 test('validates and completes the registered check', async () => {
   const fixture = makeGithub();
   await completeWorkflowCheck({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
         run: bash .github/scripts/check-one-declaration-per-file.sh
 
       - name: Test pr-metrics-comment action
-        run: node --test .github/actions/pr-metrics-comment/test/*.test.js .github/scripts/pr-metrics-publisher.test.js .github/scripts/qodana-*.test.js
+        run: node --test .github/actions/pr-metrics-comment/test/*.test.js .github/scripts/pr-metrics-publisher.test.js .github/scripts/qodana-*.test.js .github/scripts/workflow-run-check.test.js
 
       - name: Run linters
         uses: ./.github/actions/gradle-job

--- a/.github/workflows/pr-metrics-publish.yml
+++ b/.github/workflows/pr-metrics-publish.yml
@@ -24,6 +24,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       actions: read
+      checks: write
       contents: read
       pull-requests: write
     steps:
@@ -40,6 +41,35 @@ jobs:
           script: |
             const { validateSource } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-metrics-publisher.js`);
             await validateSource({ github, context, core });
+
+      - name: Register the metrics publication check
+        id: check
+        if: steps.source.outputs.publish == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          HEAD_SHA: ${{ steps.source.outputs.head_sha }}
+        with:
+          script: |
+            const {
+              buildCheckExternalId,
+              createWorkflowCheck,
+            } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/workflow-run-check.js`);
+            const externalId = buildCheckExternalId({
+              kind: 'pr-metrics',
+              runId: context.runId,
+              runAttempt: context.runAttempt,
+              headSha: process.env.HEAD_SHA,
+            });
+            const check = await createWorkflowCheck({
+              github,
+              context,
+              name: 'PR metrics publication',
+              headSha: process.env.HEAD_SHA,
+              externalId,
+              summary: 'GitHub is publishing the validated pull-request metrics.',
+            });
+            core.setOutput('check_run_id', String(check.id));
+            core.setOutput('check_external_id', check.externalId);
 
       - name: Download and validate metrics result
         if: steps.source.outputs.publish == 'true'
@@ -59,6 +89,7 @@ jobs:
             });
 
       - name: Publish metrics comment
+        id: publish
         if: steps.source.outputs.publish == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
@@ -66,9 +97,45 @@ jobs:
         with:
           script: |
             const { publishMetrics } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-metrics-publisher.js`);
-            await publishMetrics({
+            const published = await publishMetrics({
               github,
               context,
               core,
               artifactDirectory: process.env.ARTIFACT_DIRECTORY,
+            });
+            core.setOutput('published', String(published));
+
+      - name: Complete the metrics publication check
+        if: always() && steps.check.outputs.check_run_id != ''
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          CHECK_EXTERNAL_ID: ${{ steps.check.outputs.check_external_id }}
+          CHECK_RUN_ID: ${{ steps.check.outputs.check_run_id }}
+          HEAD_SHA: ${{ steps.source.outputs.head_sha }}
+          JOB_STATUS: ${{ job.status }}
+          PUBLISHED: ${{ steps.publish.outputs.published }}
+        with:
+          script: |
+            const {
+              completeWorkflowCheck,
+              workflowResultConclusion,
+            } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/workflow-run-check.js`);
+            const conclusion = process.env.PUBLISHED === 'false'
+              ? 'cancelled'
+              : workflowResultConclusion(process.env.JOB_STATUS);
+            const summaries = {
+              success: 'GitHub published the validated pull-request metrics.',
+              failure: 'Pull-request metrics publication failed.',
+              cancelled: 'Metrics publication stopped because the pull request changed.',
+              skipped: 'Pull-request metrics publication was skipped.',
+            };
+            await completeWorkflowCheck({
+              github,
+              context,
+              checkId: Number(process.env.CHECK_RUN_ID),
+              name: 'PR metrics publication',
+              headSha: process.env.HEAD_SHA,
+              externalId: process.env.CHECK_EXTERNAL_ID,
+              conclusion,
+              summary: summaries[conclusion],
             });

--- a/.github/workflows/qodana-publish.yml
+++ b/.github/workflows/qodana-publish.yml
@@ -65,6 +65,22 @@ jobs:
           SARIF_PATH: ${{ steps.download.outputs.path }}
         run: bash .github/scripts/normalize-qodana-sarif.sh "$SARIF_PATH"
 
+      - name: Verify the SARIF upload root is not a Git worktree
+        if: steps.publication.outputs.publish == 'true'
+        shell: bash
+        env:
+          UPLOAD_ROOT: ${{ runner.temp }}/qodana-publication
+        run: |
+          set -euo pipefail
+          if [[ ! -d $UPLOAD_ROOT ]]; then
+            printf 'SARIF upload root does not exist: %s\n' "$UPLOAD_ROOT" >&2
+            exit 1
+          fi
+          if git -C "$UPLOAD_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            printf 'SARIF upload root must not be in a Git worktree: %s\n' "$UPLOAD_ROOT" >&2
+            exit 1
+          fi
+
       - name: Upload Qodana results to code scanning
         if: steps.publication.outputs.publish == 'true'
         uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
@@ -72,6 +88,7 @@ jobs:
           CODEQL_ACTION_ANALYSIS_KEY: .github/workflows/ci.yml:qodana
         with:
           sarif_file: ${{ steps.download.outputs.path }}
+          checkout_path: ${{ runner.temp }}/qodana-publication
           ref: refs/pull/${{ steps.publication.outputs.pull_number }}/head
           sha: ${{ steps.publication.outputs.head_sha }}
           category: Kotventure/qodana

--- a/.github/workflows/qodana-publish.yml
+++ b/.github/workflows/qodana-publish.yml
@@ -14,11 +14,12 @@ concurrency:
 jobs:
   publish:
     name: Publish Qodana result
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       actions: read
+      checks: write
       contents: read
       pull-requests: read
       security-events: write
@@ -74,3 +75,38 @@ jobs:
           ref: refs/pull/${{ steps.publication.outputs.pull_number }}/head
           sha: ${{ steps.publication.outputs.head_sha }}
           category: Kotventure/qodana
+
+      - name: Complete the pull-request Qodana check
+        if: always() && steps.publication.outputs.check_run_id != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CHECK_CONCLUSION: ${{ steps.publication.outputs.check_conclusion }}
+          CHECK_EXTERNAL_ID: ${{ steps.publication.outputs.check_external_id }}
+          CHECK_RUN_ID: ${{ steps.publication.outputs.check_run_id }}
+          HEAD_SHA: ${{ steps.publication.outputs.head_sha }}
+          JOB_STATUS: ${{ job.status }}
+        with:
+          script: |
+            const {
+              completeWorkflowCheck,
+              workflowResultConclusion,
+            } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/workflow-run-check.js`);
+            const conclusion = process.env.CHECK_CONCLUSION
+              || workflowResultConclusion(process.env.JOB_STATUS);
+            const summaries = {
+              success: 'Qodana analysed and published the validated pull-request source.',
+              failure: 'Qodana analysis or publication failed.',
+              cancelled: 'Qodana publication stopped because the pull request changed.',
+              skipped: 'Qodana publication was skipped.',
+              timed_out: 'Qodana analysis timed out.',
+            };
+            await completeWorkflowCheck({
+              github,
+              context,
+              checkId: Number(process.env.CHECK_RUN_ID),
+              name: 'Qodana / pull request',
+              headSha: process.env.HEAD_SHA,
+              externalId: process.env.CHECK_EXTERNAL_ID,
+              conclusion,
+              summary: summaries[conclusion],
+            });

--- a/.github/workflows/qodana-publish.yml
+++ b/.github/workflows/qodana-publish.yml
@@ -83,6 +83,7 @@ jobs:
           CHECK_CONCLUSION: ${{ steps.publication.outputs.check_conclusion }}
           CHECK_EXTERNAL_ID: ${{ steps.publication.outputs.check_external_id }}
           CHECK_RUN_ID: ${{ steps.publication.outputs.check_run_id }}
+          CHECK_SUMMARY: ${{ steps.publication.outputs.check_summary }}
           HEAD_SHA: ${{ steps.publication.outputs.head_sha }}
           JOB_STATUS: ${{ job.status }}
         with:
@@ -96,7 +97,7 @@ jobs:
             const summaries = {
               success: 'Qodana analysed and published the validated pull-request source.',
               failure: 'Qodana analysis or publication failed.',
-              cancelled: 'Qodana publication stopped because the pull request changed.',
+              cancelled: 'Qodana analysis or publication was cancelled.',
               skipped: 'Qodana publication was skipped.',
               timed_out: 'Qodana analysis timed out.',
             };
@@ -108,5 +109,5 @@ jobs:
               headSha: process.env.HEAD_SHA,
               externalId: process.env.CHECK_EXTERNAL_ID,
               conclusion,
-              summary: summaries[conclusion],
+              summary: process.env.CHECK_SUMMARY || summaries[conclusion],
             });

--- a/.github/workflows/qodana-trusted.yml
+++ b/.github/workflows/qodana-trusted.yml
@@ -131,7 +131,7 @@ jobs:
   report:
     name: Report trusted Qodana check
     needs: [register, analyse]
-    if: always() && needs.register.result == 'success'
+    if: always() && needs.register.outputs.check_run_id != ''
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -151,18 +151,22 @@ jobs:
           CHECK_EXTERNAL_ID: ${{ needs.register.outputs.check_external_id }}
           CHECK_RUN_ID: ${{ needs.register.outputs.check_run_id }}
           HEAD_SHA: ${{ needs.register.outputs.head_sha }}
+          REGISTER_RESULT: ${{ needs.register.result }}
         with:
           script: |
             const {
               completeWorkflowCheck,
               workflowResultConclusion,
             } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/workflow-run-check.js`);
-            const conclusion = workflowResultConclusion(process.env.ANALYSE_RESULT);
+            const result = process.env.REGISTER_RESULT === 'success'
+              ? process.env.ANALYSE_RESULT
+              : process.env.REGISTER_RESULT;
+            const conclusion = workflowResultConclusion(result);
             const summaries = {
               success: 'Qodana analysed and published the validated trusted source.',
               failure: 'Qodana analysis or publication failed.',
-              cancelled: 'The trusted Qodana analysis was cancelled.',
-              skipped: 'The trusted Qodana analysis was skipped.',
+              cancelled: 'The trusted Qodana workflow was cancelled.',
+              skipped: 'The trusted Qodana workflow was skipped.',
             };
             await completeWorkflowCheck({
               github,

--- a/.github/workflows/qodana-trusted.yml
+++ b/.github/workflows/qodana-trusted.yml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  analyse:
-    name: Qodana trusted ref
+  register:
+    name: Register trusted Qodana check
     if: >-
       (
         github.event.workflow_run.event == 'push'
@@ -22,11 +22,15 @@ jobs:
       )
       && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     permissions:
       actions: read
+      checks: write
       contents: read
-      security-events: write
+    outputs:
+      check_external_id: ${{ steps.source.outputs.check_external_id }}
+      check_run_id: ${{ steps.source.outputs.check_run_id }}
+      head_sha: ${{ steps.source.outputs.head_sha }}
     steps:
       - name: Checkout trusted workflow code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -48,12 +52,48 @@ jobs:
               eventRun: context.payload.workflow_run,
             });
             core.setOutput('head_sha', source.headSha);
+            const {
+              buildCheckExternalId,
+              createWorkflowCheck,
+            } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/workflow-run-check.js`);
+            const externalId = buildCheckExternalId({
+              kind: 'qodana-trusted',
+              runId: context.runId,
+              runAttempt: context.runAttempt,
+              headSha: source.headSha,
+            });
+            const check = await createWorkflowCheck({
+              github,
+              context,
+              name: 'Qodana / trusted ref',
+              headSha: source.headSha,
+              externalId,
+              summary: 'Qodana is analysing the validated trusted source.',
+            });
+            core.setOutput('check_run_id', String(check.id));
+            core.setOutput('check_external_id', check.externalId);
+
+  analyse:
+    name: Qodana trusted ref
+    needs: register
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout trusted workflow code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: Checkout the validated trusted source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.repository }}
-          ref: ${{ steps.source.outputs.head_sha }}
+          ref: ${{ needs.register.outputs.head_sha }}
           path: source
           persist-credentials: false
 
@@ -71,7 +111,7 @@ jobs:
           push-fixes: none
           use-caches: false
         env:
-          QODANA_REVISION: ${{ steps.source.outputs.head_sha }}
+          QODANA_REVISION: ${{ needs.register.outputs.head_sha }}
 
       - name: Normalize Qodana SARIF regions
         shell: bash
@@ -85,5 +125,52 @@ jobs:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
           checkout_path: source
           ref: refs/heads/${{ github.event.repository.default_branch }}
-          sha: ${{ steps.source.outputs.head_sha }}
+          sha: ${{ needs.register.outputs.head_sha }}
           category: Kotventure/qodana
+
+  report:
+    name: Report trusted Qodana check
+    needs: [register, analyse]
+    if: always() && needs.register.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - name: Checkout trusted workflow code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Complete the trusted Qodana check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ANALYSE_RESULT: ${{ needs.analyse.result }}
+          CHECK_EXTERNAL_ID: ${{ needs.register.outputs.check_external_id }}
+          CHECK_RUN_ID: ${{ needs.register.outputs.check_run_id }}
+          HEAD_SHA: ${{ needs.register.outputs.head_sha }}
+        with:
+          script: |
+            const {
+              completeWorkflowCheck,
+              workflowResultConclusion,
+            } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/workflow-run-check.js`);
+            const conclusion = workflowResultConclusion(process.env.ANALYSE_RESULT);
+            const summaries = {
+              success: 'Qodana analysed and published the validated trusted source.',
+              failure: 'Qodana analysis or publication failed.',
+              cancelled: 'The trusted Qodana analysis was cancelled.',
+              skipped: 'The trusted Qodana analysis was skipped.',
+            };
+            await completeWorkflowCheck({
+              github,
+              context,
+              checkId: Number(process.env.CHECK_RUN_ID),
+              name: 'Qodana / trusted ref',
+              headSha: process.env.HEAD_SHA,
+              externalId: process.env.CHECK_EXTERNAL_ID,
+              conclusion,
+              summary: summaries[conclusion],
+            });

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -12,11 +12,81 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  analyse:
-    name: Qodana analysis
+  register:
+    name: Register Qodana check
     if: >-
       github.event.workflow_run.event == 'pull_request'
       && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      pull-requests: read
+    outputs:
+      artifact_name: ${{ steps.source.outputs.artifact_name }}
+      base_ref: ${{ steps.source.outputs.base_ref }}
+      check_artifact_name: ${{ steps.source.outputs.check_artifact_name }}
+      check_external_id: ${{ steps.source.outputs.check_external_id }}
+      check_run_id: ${{ steps.source.outputs.check_run_id }}
+      head_sha: ${{ steps.source.outputs.head_sha }}
+      merge_base_sha: ${{ steps.source.outputs.merge_base_sha }}
+      pull_number: ${{ steps.source.outputs.pull_number }}
+      source_kind: ${{ steps.source.outputs.source_kind }}
+    steps:
+      - name: Checkout trusted workflow code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Resolve the completed CI source
+        id: source
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          OUTPUT_DIRECTORY: ${{ runner.temp }}/qodana-check
+          QODANA_RUN_ID: ${{ github.run_id }}
+          QODANA_RUN_ATTEMPT: ${{ github.run_attempt }}
+        with:
+          script: |
+            const { resolveSource } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-source.js`);
+            const { registerQodanaCheck } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-check-registration.js`);
+            const source = await resolveSource({
+              github,
+              context,
+              qodanaRunId: Number(process.env.QODANA_RUN_ID),
+              qodanaRunAttempt: Number(process.env.QODANA_RUN_ATTEMPT),
+            });
+            core.setOutput('source_kind', source.sourceKind);
+            core.setOutput('artifact_name', source.artifactName);
+            core.setOutput('pull_number', String(source.pullRequest));
+            core.setOutput('head_sha', source.headSha);
+            core.setOutput('base_ref', source.baseRef);
+            core.setOutput('merge_base_sha', source.mergeBaseSha || '');
+            const registration = await registerQodanaCheck({
+              github,
+              context,
+              source,
+              qodanaRunId: Number(process.env.QODANA_RUN_ID),
+              qodanaRunAttempt: Number(process.env.QODANA_RUN_ATTEMPT),
+              outputDirectory: process.env.OUTPUT_DIRECTORY,
+            });
+            core.setOutput('check_artifact_name', registration.artifactName);
+            core.setOutput('check_run_id', String(registration.check.id));
+            core.setOutput('check_external_id', registration.check.externalId);
+
+      - name: Upload the Qodana check registration
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.source.outputs.check_artifact_name }}
+          path: ${{ runner.temp }}/qodana-check/qodana-check.json
+          if-no-files-found: error
+          retention-days: 7
+
+  analyse:
+    name: Qodana analysis
+    needs: register
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -30,43 +100,21 @@ jobs:
           ref: ${{ github.sha }}
           persist-credentials: false
 
-      - name: Resolve the completed CI source
-        id: source
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          QODANA_RUN_ID: ${{ github.run_id }}
-          QODANA_RUN_ATTEMPT: ${{ github.run_attempt }}
-        with:
-          script: |
-            const { resolveSource } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-source.js`);
-            const source = await resolveSource({
-              github,
-              context,
-              qodanaRunId: Number(process.env.QODANA_RUN_ID),
-              qodanaRunAttempt: Number(process.env.QODANA_RUN_ATTEMPT),
-            });
-            core.setOutput('source_kind', source.sourceKind);
-            core.setOutput('artifact_name', source.artifactName);
-            core.setOutput('pull_number', String(source.pullRequest));
-            core.setOutput('head_sha', source.headSha);
-            core.setOutput('base_ref', source.baseRef);
-            core.setOutput('merge_base_sha', source.mergeBaseSha || '');
-
       - name: Checkout pull-request code
-        if: steps.source.outputs.source_kind == 'code'
+        if: needs.register.outputs.source_kind == 'code'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.repository }}
-          ref: refs/pull/${{ steps.source.outputs.pull_number }}/head
+          ref: ${{ needs.register.outputs.head_sha }}
           path: source
           fetch-depth: 0
           persist-credentials: false
 
       - name: Verify the pull-request checkout
-        if: steps.source.outputs.source_kind == 'code'
+        if: needs.register.outputs.source_kind == 'code'
         shell: bash
         env:
-          EXPECTED_HEAD_SHA: ${{ steps.source.outputs.head_sha }}
+          EXPECTED_HEAD_SHA: ${{ needs.register.outputs.head_sha }}
         run: |
           set -euo pipefail
           actual_head_sha="$(git -C source rev-parse HEAD)"
@@ -76,12 +124,12 @@ jobs:
           fi
 
       - name: Apply the trusted Qodana configuration
-        if: steps.source.outputs.source_kind == 'code'
+        if: needs.register.outputs.source_kind == 'code'
         shell: bash
         run: cp --remove-destination -- qodana.yaml source/qodana.yaml
 
       - name: Scan pull-request code with Qodana
-        if: steps.source.outputs.source_kind == 'code'
+        if: needs.register.outputs.source_kind == 'code'
         uses: JetBrains/qodana-action@b588768b6e7e6da579e518bc584f79de0d243692 # v2026.2.0
         with:
           args: >-
@@ -95,15 +143,15 @@ jobs:
           push-fixes: none
           use-caches: false
         env:
-          QODANA_PR_SHA: ${{ steps.source.outputs.merge_base_sha }}
-          QODANA_REVISION: ${{ steps.source.outputs.head_sha }}
+          QODANA_PR_SHA: ${{ needs.register.outputs.merge_base_sha }}
+          QODANA_REVISION: ${{ needs.register.outputs.head_sha }}
 
       - name: Create trusted QDJVM attestation
-        if: steps.source.outputs.source_kind != 'code'
+        if: needs.register.outputs.source_kind != 'code'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          SOURCE_KIND: ${{ steps.source.outputs.source_kind }}
-          HEAD_SHA: ${{ steps.source.outputs.head_sha }}
+          SOURCE_KIND: ${{ needs.register.outputs.source_kind }}
+          HEAD_SHA: ${{ needs.register.outputs.head_sha }}
           OUTPUT_PATH: ${{ runner.temp }}/qodana-attestation/qodana.sarif.json
         with:
           script: |
@@ -115,19 +163,68 @@ jobs:
             });
 
       - name: Upload Qodana scan result
-        if: success() && steps.source.outputs.source_kind == 'code'
+        if: success() && needs.register.outputs.source_kind == 'code'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ steps.source.outputs.artifact_name }}
+          name: ${{ needs.register.outputs.artifact_name }}
           path: ${{ runner.temp }}/qodana/results/qodana.sarif.json
           if-no-files-found: error
           retention-days: 7
 
       - name: Upload trusted QDJVM attestation
-        if: success() && steps.source.outputs.source_kind != 'code'
+        if: success() && needs.register.outputs.source_kind != 'code'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ steps.source.outputs.artifact_name }}
+          name: ${{ needs.register.outputs.artifact_name }}
           path: ${{ runner.temp }}/qodana-attestation/qodana.sarif.json
           if-no-files-found: error
           retention-days: 7
+
+  report-registration-failure:
+    name: Report Qodana registration failure
+    needs: register
+    if: >-
+      always()
+      && needs.register.result != 'success'
+      && needs.register.outputs.check_run_id != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - name: Checkout trusted workflow code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Complete the failed Qodana registration check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CHECK_EXTERNAL_ID: ${{ needs.register.outputs.check_external_id }}
+          CHECK_RUN_ID: ${{ needs.register.outputs.check_run_id }}
+          HEAD_SHA: ${{ needs.register.outputs.head_sha }}
+          REGISTER_RESULT: ${{ needs.register.result }}
+        with:
+          script: |
+            const {
+              completeWorkflowCheck,
+              workflowResultConclusion,
+            } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/workflow-run-check.js`);
+            const conclusion = workflowResultConclusion(process.env.REGISTER_RESULT);
+            const summaries = {
+              failure: 'Qodana check registration failed.',
+              cancelled: 'Qodana check registration was cancelled.',
+              skipped: 'Qodana check registration was skipped.',
+            };
+            await completeWorkflowCheck({
+              github,
+              context,
+              checkId: Number(process.env.CHECK_RUN_ID),
+              name: 'Qodana / pull request',
+              headSha: process.env.HEAD_SHA,
+              externalId: process.env.CHECK_EXTERNAL_ID,
+              conclusion,
+              summary: summaries[conclusion],
+            });

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -51,7 +51,10 @@ jobs:
         with:
           script: |
             const { resolveSource } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-source.js`);
-            const { registerQodanaCheck } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-check-registration.js`);
+            const {
+              createQodanaCheck,
+              writeQodanaCheckRegistration,
+            } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-check-registration.js`);
             const source = await resolveSource({
               github,
               context,
@@ -64,23 +67,30 @@ jobs:
             core.setOutput('head_sha', source.headSha);
             core.setOutput('base_ref', source.baseRef);
             core.setOutput('merge_base_sha', source.mergeBaseSha || '');
-            const registration = await registerQodanaCheck({
+            const check = await createQodanaCheck({
               github,
               context,
+              source,
+              qodanaRunId: Number(process.env.QODANA_RUN_ID),
+              qodanaRunAttempt: Number(process.env.QODANA_RUN_ATTEMPT),
+            });
+            core.setOutput('check_run_id', String(check.id));
+            core.setOutput('check_external_id', check.externalId);
+            const registration = writeQodanaCheckRegistration({
+              check,
               source,
               qodanaRunId: Number(process.env.QODANA_RUN_ID),
               qodanaRunAttempt: Number(process.env.QODANA_RUN_ATTEMPT),
               outputDirectory: process.env.OUTPUT_DIRECTORY,
             });
             core.setOutput('check_artifact_name', registration.artifactName);
-            core.setOutput('check_run_id', String(registration.check.id));
-            core.setOutput('check_external_id', registration.check.externalId);
+            core.setOutput('check_file_path', registration.filePath);
 
       - name: Upload the Qodana check registration
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.source.outputs.check_artifact_name }}
-          path: ${{ runner.temp }}/qodana-check/qodana-check.json
+          path: ${{ steps.source.outputs.check_file_path }}
           if-no-files-found: error
           retention-days: 7
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -194,16 +194,25 @@ permissions. It does not receive `QODANA_TOKEN`. It disables Qodana annotations,
 pull-request comments, fix pushes, and result upload. It stores one SARIF file
 as a bounded artefact.
 
+A separate registration job creates the `Qodana / pull request` check on the
+validated pull-request head. The check starts with `in_progress`. The read-only
+scan job cannot update it. The registration artefact binds the check to the CI
+run, Qodana run, run attempts, and source commits.
+
 The `Qodana publication` workflow checks out the default branch. It validates
 the CI run, current pull request, changed paths, run attempt, head SHA, base
 SHA, artefact name, artefact archive, and SARIF structure. It then normalises
 the SARIF with default-branch code and uploads one result with the stable
 `.github/workflows/ci.yml:qodana` analysis key and `Kotventure/qodana` category.
-No pull-request code runs in the publication workflow.
+No pull-request code runs in the publication workflow. The workflow completes
+the registered check with the publication result. It reports an upstream scan
+failure when no SARIF artefact can exist.
 
 The `Qodana trusted` workflow handles push, schedule, and manual-dispatch CI.
 It checks out the trusted source commit and uploads its result directly. Its
-write permission does not apply to pull-request or merge-group analysis.
+write permission does not apply to pull-request or merge-group analysis. A
+registration job creates the `Qodana / trusted ref` check on the validated
+source commit. A separate report job completes the check after analysis.
 
 The `Master` ruleset requires one applicable QDJVM result for each pull request:
 documentation-only pull requests use the documentation attestation, code pull
@@ -232,7 +241,8 @@ When the account supports the feature, enable the queue in the **Master** rulese
 
 After Build, the **PR feedback** job computes one bounded JSON result. The separate **PR metrics publication** workflow
 validates that result and posts **one** bot comment (`<!-- pr-metrics -->`) with code from the default branch. The
-publication workflow does not execute pull-request code.
+publication workflow does not execute pull-request code. It also creates the `PR metrics publication` check on the
+validated pull-request head. It completes the check with the publication result.
 
 The comment contains:
 
@@ -281,13 +291,13 @@ For an occasional diagnostic scan, give `build-scan: true` to `gradle-job`. The 
 | Default workflow permissions | Set the repository default to `contents: read` |
 | Release provenance workflow | Uses `contents: read` and `pull-requests: read`. Does not check out pull-request code |
 | CI gate | Uses `actions: read`, `contents: read`, and `pull-requests: read` |
-| Qodana scan | Uses `actions: read`, `contents: read`, and `pull-requests: read`. It has no `security-events: write` permission, no `QODANA_TOKEN`, and no Qodana GitHub side effects |
-| Qodana publication | Uses `actions: read`, `contents: read`, `pull-requests: read`, and `security-events: write`. It runs default-branch code and validates the artefact before upload |
-| Qodana trusted | Uses `actions: read`, `contents: read`, and `security-events: write` only for push, schedule, and manual-dispatch refs |
+| Qodana scan | The registration job adds `checks: write` and creates the source-bound check. The analysis job uses only `actions: read`, `contents: read`, and `pull-requests: read`. It has no write permission, no `QODANA_TOKEN`, and no Qodana GitHub side effects |
+| Qodana publication | Uses `actions: read`, `checks: write`, `contents: read`, `pull-requests: read`, and `security-events: write`. It runs default-branch code, validates the artefacts, uploads SARIF, and completes the source-bound check |
+| Qodana trusted | The registration and report jobs use `checks: write`. The analysis job uses `actions: read`, `contents: read`, and `security-events: write` only for push, schedule, and manual-dispatch refs |
 | Release workflow | Uses an installation token from `release-please-kotventure`. Its `GITHUB_TOKEN` has no permissions |
 | Build job | Uses `checks: write` and `contents: read`. Cannot write to pull requests. Clears `GITHUB_TOKEN` for Gradle |
 | PR feedback job | Uses `actions: read`, `pull-requests: read`, and `contents: read`. Computes a bounded result artefact and cannot write to pull requests. Uses the cache or artefacts before a base JAR-only build. Clears `GITHUB_TOKEN` for Gradle |
-| PR metrics publication | Runs default-branch code after CI. Uses `actions: read`, `contents: read`, and `pull-requests: write`. Validates the source workflow, run attempt, current PR head and base, exact artefact, and result provenance before it posts |
+| PR metrics publication | Runs default-branch code after CI. Uses `actions: read`, `checks: write`, `contents: read`, and `pull-requests: write`. Validates the source workflow, run attempt, current PR head and base, exact artefact, and result provenance before it creates the check or posts the comment |
 | Build scans | Off by default. Enable with `build-scan: true` |
 | Dokka preview artefact | Contains untrusted HTML from the pull request. Retain for 14 days. Do not publish as Pages |
 
@@ -331,9 +341,11 @@ repository automation tests use `node --test`.
 | `collect-ci-metrics.sh` | Build: test/skipped counts + build duration → `ci-metrics.json` |
 | `pr-metrics-publisher.js` | Trusted workflow_run publisher: validates the source run and renders the metrics comment |
 | `qodana-source.js` | Trusted workflow_run source and path classification for Qodana |
+| `qodana-check-registration.js` | Creates and records the source-bound pull-request Qodana check |
 | `qodana-publisher.js` | Trusted Qodana publication source validation |
 | `qodana-publisher-archive.js` | Bounded single-file SARIF archive extraction |
 | `qodana-publisher-storage.js` | Bounded artifact download and SARIF validation |
+| `workflow-run-check.js` | Creates, validates, and completes source-bound workflow checks |
 
 ## Action pins and Dependabot
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -202,8 +202,10 @@ run, Qodana run, run attempts, and source commits.
 The `Qodana publication` workflow checks out the default branch. It validates
 the CI run, current pull request, changed paths, run attempt, head SHA, base
 SHA, artefact name, artefact archive, and SARIF structure. It then normalises
-the SARIF with default-branch code and uploads one result with the stable
-`.github/workflows/ci.yml:qodana` analysis key and `Kotventure/qodana` category.
+the SARIF with default-branch code. The upload uses a verified non-Git artefact
+directory, the validated pull-request head SHA, the stable
+`.github/workflows/ci.yml:qodana` analysis key, and the `Kotventure/qodana`
+category.
 No pull-request code runs in the publication workflow. The workflow completes
 the registered check with the publication result. It reports an upstream scan
 failure when no SARIF artefact can exist.
@@ -333,7 +335,7 @@ repository automation tests use `node --test`.
 |--------|------|
 | `validate-conventional-title.sh` | Title/commit subject format |
 | `check-one-declaration-per-file.sh` | One top-level class/interface/object per main-source file |
-| `normalize-qodana-sarif.sh` | Fix 0-based SARIF regions for GitHub code scanning |
+| `normalize-qodana-sarif.sh` | Fix 0-based SARIF regions and remove scanner-owned automation metadata before upload |
 | `write-gradle-job-summary.sh` | Job summary: Java/Gradle/Kotlin versions + failed tasks |
 | `vanilla-fixture-cache-key.sh` | Compute MC fixture cache key |
 | `download-base-metrics.sh` | PR feedback: fetch base coverage/jars/metrics from the base commit's CI run |


### PR DESCRIPTION
## Summary

- Add explicit check runs for all four `workflow_run` workflows.
- Bind each check to the validated source commit instead of the default-branch workflow commit.
- Keep Qodana pull-request analysis read-only. Give `checks: write` only to trusted registration and publication jobs.
- Record the pull-request Qodana check in a bounded artefact so the later publisher can complete it after success, failure, cancellation, or timeout.
- Complete PR metrics and trusted Qodana checks with their real result.

## Check lifecycle

Each custom check starts as `in_progress`. It becomes `completed` with a supported conclusion.

The workflows do not create `queued`, `requested`, `waiting`, or `pending` states. GitHub owns those scheduler states, and the trusted workflow cannot create the check until its run starts.

## Security

The pull-request Qodana analysis job still has read permissions only. It does not receive `QODANA_TOKEN`, `checks: write`, or `security-events: write`. Trusted default-branch code validates the workflow, repository, run attempt, pull request, source commits, artefact identity, and check identity before publication.

## Verification

- `node --test .github/actions/pr-metrics-comment/test/*.test.js .github/scripts/pr-metrics-publisher.test.js .github/scripts/qodana-*.test.js .github/scripts/workflow-run-check.test.js` — 105 passed
- `actionlint`
- `node --check` for all `.github/scripts/*.js`
- `bash -n .github/scripts/normalize-qodana-sarif.sh`
- `git diff --check`
- `./gradlew ktlintCheck spotlessCheck`

## Live validation

GitHub loads `workflow_run` workflow definitions from the default branch. Therefore, this pull request cannot exercise the changed cross-workflow lifecycle before merge. After merge, verify one pull-request run, one trusted-ref run, and the commit check rollup in the GitHub interface.
