### PR TITLE
fix(ci): trust system CA and retry Qodana check API

### DIFF
--- a/.github/scripts/workflow-run-check.js
+++ b/.github/scripts/workflow-run-check.js
@@ -49,8 +49,8 @@ function requireEqual(actual, expected, label) {
 function workflowRunUrl(context) {
   const serverUrl = requireText(context?.serverUrl, 'GitHub server URL', 512);
   const repository = `${requireText(context?.repo?.owner, 'repository owner', 100)}/${requireText(context?.repo?.repo, 'repository name', 100)}`;
-  const runId = requirePositiveInteger(context?.runId, 'workflow run id');
-  const runAttempt = requirePositiveInteger(context?.runAttempt, 'workflow run attempt');
+  const runId = requirePositiveInteger(Number(context?.runId), 'workflow run id');
+  const runAttempt = requirePositiveInteger(Number(context?.runAttempt), 'workflow run attempt');
   return `${serverUrl}/${repository}/actions/runs/${runId}/attempts/${runAttempt}`;
 }
 
@@ -58,7 +58,7 @@ function buildCheckExternalId({ kind, runId, runAttempt, headSha }) {
   if (typeof kind !== 'string' || !KIND_PATTERN.test(kind)) {
     throw new Error('check kind is invalid');
   }
-  return `${EXTERNAL_ID_PREFIX}:${kind}:${requirePositiveInteger(runId, 'workflow run id')}:${requirePositiveInteger(runAttempt, 'workflow run attempt')}:${requireSha(headSha, 'check head SHA')}`;
+  return `${EXTERNAL_ID_PREFIX}:${kind}:${requirePositiveInteger(Number(runId), 'workflow run id')}:${requirePositiveInteger(Number(runAttempt), 'workflow run attempt')}:${requireSha(headSha, 'check head SHA')}`;
 }
 
 function validateCreatedCheck(check, expected) {

--- a/.github/workflows/pr-metrics-publish.yml
+++ b/.github/workflows/pr-metrics-publish.yml
@@ -16,6 +16,9 @@ concurrency:
 
 permissions: {}
 
+env:
+  NODE_OPTIONS: --use-system-ca
+
 jobs:
   publish:
     name: Publish PR metrics
@@ -36,8 +39,10 @@ jobs:
 
       - name: Validate source run
         id: source
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const { validateSource } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-metrics-publisher.js`);
             await validateSource({ github, context, core });
@@ -45,10 +50,12 @@ jobs:
       - name: Register the metrics publication check
         id: check
         if: steps.source.outputs.publish == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           HEAD_SHA: ${{ steps.source.outputs.head_sha }}
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const {
               buildCheckExternalId,
@@ -73,12 +80,14 @@ jobs:
 
       - name: Download and validate metrics result
         if: steps.source.outputs.publish == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ARTIFACT_ID: ${{ steps.source.outputs.artifact_id }}
           ARTIFACT_DIRECTORY: ${{ runner.temp }}/pr-metrics-result
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const { downloadMetricsArtifact } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-metrics-publisher-storage.js`);
             await downloadMetricsArtifact({
@@ -91,10 +100,12 @@ jobs:
       - name: Publish metrics comment
         id: publish
         if: steps.source.outputs.publish == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ARTIFACT_DIRECTORY: ${{ runner.temp }}/pr-metrics-result
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const { publishMetrics } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-metrics-publisher.js`);
             const published = await publishMetrics({
@@ -107,7 +118,7 @@ jobs:
 
       - name: Complete the metrics publication check
         if: always() && steps.check.outputs.check_run_id != ''
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           CHECK_EXTERNAL_ID: ${{ steps.check.outputs.check_external_id }}
           CHECK_RUN_ID: ${{ steps.check.outputs.check_run_id }}
@@ -115,6 +126,8 @@ jobs:
           JOB_STATUS: ${{ job.status }}
           PUBLISHED: ${{ steps.publish.outputs.published }}
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const {
               completeWorkflowCheck,

--- a/.github/workflows/qodana-publish.yml
+++ b/.github/workflows/qodana-publish.yml
@@ -11,6 +11,9 @@ concurrency:
   group: qodana-publication-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
   cancel-in-progress: true
 
+env:
+  NODE_OPTIONS: --use-system-ca
+
 jobs:
   publish:
     name: Publish Qodana result
@@ -34,6 +37,8 @@ jobs:
         id: publication
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const { writePublicationOutputs } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-publisher.js`);
             await writePublicationOutputs({ github, context, core });
@@ -47,6 +52,8 @@ jobs:
           OUTPUT_DIRECTORY: ${{ runner.temp }}/qodana-publication
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const { downloadQodanaArtifact } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-publisher-storage.js`);
             const filePath = await downloadQodanaArtifact({
@@ -104,6 +111,8 @@ jobs:
           HEAD_SHA: ${{ steps.publication.outputs.head_sha }}
           JOB_STATUS: ${{ job.status }}
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const {
               completeWorkflowCheck,

--- a/.github/workflows/qodana-trusted.yml
+++ b/.github/workflows/qodana-trusted.yml
@@ -11,6 +11,9 @@ concurrency:
   group: qodana-trusted-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
   cancel-in-progress: true
 
+env:
+  NODE_OPTIONS: --use-system-ca
+
 jobs:
   register:
     name: Register trusted Qodana check
@@ -42,6 +45,8 @@ jobs:
         id: source
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const { resolveTrustedCiRun } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-source.js`);
             const source = await resolveTrustedCiRun({
@@ -153,6 +158,8 @@ jobs:
           HEAD_SHA: ${{ needs.register.outputs.head_sha }}
           REGISTER_RESULT: ${{ needs.register.result }}
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const {
               completeWorkflowCheck,

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -11,6 +11,9 @@ concurrency:
   group: qodana-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
   cancel-in-progress: true
 
+env:
+  NODE_OPTIONS: --use-system-ca
+
 jobs:
   register:
     name: Register Qodana check
@@ -49,6 +52,8 @@ jobs:
           QODANA_RUN_ID: ${{ github.run_id }}
           QODANA_RUN_ATTEMPT: ${{ github.run_attempt }}
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const { resolveSource } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-source.js`);
             const {
@@ -164,6 +169,8 @@ jobs:
           HEAD_SHA: ${{ needs.register.outputs.head_sha }}
           OUTPUT_PATH: ${{ runner.temp }}/qodana-attestation/qodana.sarif.json
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const { writeAttestation } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-attestation.js`);
             writeAttestation({
@@ -217,6 +224,8 @@ jobs:
           HEAD_SHA: ${{ needs.register.outputs.head_sha }}
           REGISTER_RESULT: ${{ needs.register.result }}
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const {
               completeWorkflowCheck,


### PR DESCRIPTION
Fixes:
- https://github.com/LMLiam/Kotventure/actions/runs/31410568882/job/93528722311 — `Qodana trusted / Report` failed with `DEPTH_ZERO_SELF_SIGNED_CERT` (Node 24 + `retries:0`)
- https://github.com/LMLiam/Kotventure/actions/runs/31414460667/job/93540052064 — `PR metrics publication / Register` failed with `workflow run attempt is invalid` (`context.runAttempt` string via v8)

**Root causes:**
1. Node 24 no longer trusts system CA without `--use-system-ca` (error hint); workflows used `retries:0` so transient 500/TLS aborted.
2. `pr-metrics-publish.yml` used `actions/github-script@v8` where `context.runAttempt` can be string/undefined; `workflow-run-check.js` required strict `Number.isSafeInteger`.

**Fix (same branch `fix/ci-qodana-trusted-retry`):**
- Add `env: NODE_OPTIONS: --use-system-ca` to `qodana-trusted.yml`, `qodana.yml`, `qodana-publish.yml`, `pr-metrics-publish.yml`.
- Set `retries: 3` + `retry-exempt-status-codes: 400,401,403,404,422` on every `actions/github-script` step (8 in Qodana workflows + 5 in pr-metrics; Octokit retry, no custom JS).
- Upgrade `pr-metrics-publish.yml` from `v8 (ed59741)` to `v9 (3a2844b)` and coerce `runId/Attempt: Number(context.*)` in both workflow and `workflow-run-check.js` (`workflowRunUrl` + `buildCheckExternalId`).
- No custom `withCheckRetry` in JS (removed — Octokit handles it).

Verified: `node --test .github/scripts/*.test.js` 32 pass, string runAttempt coercion now succeeds.

