### PR TITLE
perf(ci): minimize wall-clock via Triage, parallel Dokka and Kover binary

### DIFF
--- a/.github/scripts/collect-ci-metrics.sh
+++ b/.github/scripts/collect-ci-metrics.sh
@@ -25,11 +25,28 @@ for file in modules/*/build/test-results/test/TEST-*.xml; do
 done
 
 duration=null
+max_duration=0
+found_duration=false
 
-if [[ -f $DURATION_FILE ]]; then
-    read -r duration < "$DURATION_FILE"
+# Check per-shard duration files (gradle-duration-*.txt) and aggregate duration (gradle-duration.txt).
+# Duration represents the wall-clock indicative time for the longest shard, which is the
+# critical-path build time in the parallel CI (max of shards). If only a single file exists,
+# it is used directly.
+for dfile in gradle-duration-*.txt "$DURATION_FILE"; do
+    [[ -f $dfile ]] || continue
+    read -r val < "$dfile"
+    if [[ $val =~ ^[0-9]+$ ]]; then
+        found_duration=true
+        if (( val > max_duration )); then
+            max_duration=$val
+        fi
+    fi
+done
 
-    [[ $duration =~ ^[0-9]+$ ]] || duration=null
+if [[ $found_duration == true ]]; then
+    duration=$max_duration
+else
+    duration=null
 fi
 
 printf '{"tests": %d, "skipped": %d, "durationSeconds": %s}\n' "$tests" "$skipped" "$duration" > "$METRICS_FILE"

--- a/.github/scripts/collect-ci-metrics.sh
+++ b/.github/scripts/collect-ci-metrics.sh
@@ -10,9 +10,6 @@ readonly METRICS_FILE='ci-metrics.json'
 tests=0
 skipped=0
 
-# Test results land in `*/build/test-results/test/` after the Aggregate job downloads the
-# per-shard `gradle-test-results-*` artifacts. `find` tolerates the `modules/` prefix that
-# upload-artifact may or may not preserve in the stored paths.
 while IFS= read -r file; do
     xml=$(<"$file")
 
@@ -27,12 +24,6 @@ done < <(find . -type f -name 'TEST-*.xml' -path '*/build/test-results/test/*' 2
 
 duration=null
 
-# Each build shard writes gradle-duration-<shard>.txt and the Aggregate coverage build writes
-# gradle-duration.txt (both measured by the gradle-job action). The reported duration is the
-# sequential build time on the critical path: the longest shard build plus the Aggregate
-# coverage build, which can only start after every shard completes. When only one source
-# exists (single-invocation builds), that value is used; when neither is valid, the field
-# stays null.
 max_shard_duration=0
 aggregate_duration=0
 has_shard=false

--- a/.github/scripts/collect-ci-metrics.sh
+++ b/.github/scripts/collect-ci-metrics.sh
@@ -27,24 +27,42 @@ done < <(find . -type f -name 'TEST-*.xml' -path '*/build/test-results/test/*' 2
 
 duration=null
 
-# Each build shard writes gradle-duration-<shard>.txt (measured by the gradle-job action).
-# The reported duration is the maximum shard build duration, i.e. the critical-path build
-# time in the parallel CI. When no per-shard files exist (single-invocation build), the
-# plain gradle-duration.txt is used instead.
-shard_files=(gradle-duration-*.txt)
-if [[ -n "${shard_files[0]:-}" && -f "${shard_files[0]}" ]]; then
-    max_duration=0
-    for dfile in "${shard_files[@]}"; do
-        [[ -f $dfile ]] || continue
-        read -r val < "$dfile"
-        if [[ $val =~ ^[0-9]+$ ]] && (( val > max_duration )); then
-            max_duration=$val
+# Each build shard writes gradle-duration-<shard>.txt and the Aggregate coverage build writes
+# gradle-duration.txt (both measured by the gradle-job action). The reported duration is the
+# sequential build time on the critical path: the longest shard build plus the Aggregate
+# coverage build, which can only start after every shard completes. When only one source
+# exists (single-invocation builds), that value is used; when neither is valid, the field
+# stays null.
+max_shard_duration=0
+aggregate_duration=0
+has_shard=false
+has_aggregate=false
+
+for dfile in gradle-duration-*.txt; do
+    [[ -f $dfile ]] || continue
+    read -r val < "$dfile"
+    if [[ $val =~ ^[0-9]+$ ]]; then
+        has_shard=true
+        if (( val > max_shard_duration )); then
+            max_shard_duration=$val
         fi
-    done
-    duration=$max_duration
-elif [[ -f gradle-duration.txt ]]; then
+    fi
+done
+
+if [[ -f gradle-duration.txt ]]; then
     read -r val < gradle-duration.txt
-    [[ $val =~ ^[0-9]+$ ]] && duration=$val
+    if [[ $val =~ ^[0-9]+$ ]]; then
+        has_aggregate=true
+        aggregate_duration=$val
+    fi
+fi
+
+if [[ $has_shard == true && $has_aggregate == true ]]; then
+    duration=$((max_shard_duration + aggregate_duration))
+elif [[ $has_shard == true ]]; then
+    duration=$max_shard_duration
+elif [[ $has_aggregate == true ]]; then
+    duration=$aggregate_duration
 fi
 
 printf '{"tests": %d, "skipped": %d, "durationSeconds": %s}\n' "$tests" "$skipped" "$duration" > "$METRICS_FILE"

--- a/.github/scripts/collect-ci-metrics.sh
+++ b/.github/scripts/collect-ci-metrics.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-shopt -s nullglob
 
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd -- "$repo_root"
 
 readonly METRICS_FILE='ci-metrics.json'
-readonly DURATION_FILE='gradle-duration.txt'
 
 tests=0
 skipped=0
 
-for file in modules/*/build/test-results/test/TEST-*.xml; do
+# Test results land in `*/build/test-results/test/` after the Aggregate job downloads the
+# per-shard `gradle-test-results-*` artifacts. `find` tolerates the `modules/` prefix that
+# upload-artifact may or may not preserve in the stored paths.
+while IFS= read -r file; do
     xml=$(<"$file")
 
     if [[ $xml =~ tests=\"([0-9]+)\" ]]; then
@@ -22,31 +23,28 @@ for file in modules/*/build/test-results/test/TEST-*.xml; do
     if [[ $xml =~ skipped=\"([0-9]+)\" ]]; then
         skipped=$((skipped + 10#${BASH_REMATCH[1]}))
     fi
-done
+done < <(find . -type f -name 'TEST-*.xml' -path '*/build/test-results/test/*' 2>/dev/null)
 
 duration=null
-max_duration=0
-found_duration=false
 
-# Check per-shard duration files (gradle-duration-*.txt) and aggregate duration (gradle-duration.txt).
-# Duration represents the wall-clock indicative time for the longest shard, which is the
-# critical-path build time in the parallel CI (max of shards). If only a single file exists,
-# it is used directly.
-for dfile in gradle-duration-*.txt "$DURATION_FILE"; do
-    [[ -f $dfile ]] || continue
-    read -r val < "$dfile"
-    if [[ $val =~ ^[0-9]+$ ]]; then
-        found_duration=true
-        if (( val > max_duration )); then
+# Each build shard writes gradle-duration-<shard>.txt (measured by the gradle-job action).
+# The reported duration is the maximum shard build duration, i.e. the critical-path build
+# time in the parallel CI. When no per-shard files exist (single-invocation build), the
+# plain gradle-duration.txt is used instead.
+shard_files=(gradle-duration-*.txt)
+if [[ -n "${shard_files[0]:-}" && -f "${shard_files[0]}" ]]; then
+    max_duration=0
+    for dfile in "${shard_files[@]}"; do
+        [[ -f $dfile ]] || continue
+        read -r val < "$dfile"
+        if [[ $val =~ ^[0-9]+$ ]] && (( val > max_duration )); then
             max_duration=$val
         fi
-    fi
-done
-
-if [[ $found_duration == true ]]; then
+    done
     duration=$max_duration
-else
-    duration=null
+elif [[ -f gradle-duration.txt ]]; then
+    read -r val < gradle-duration.txt
+    [[ $val =~ ^[0-9]+$ ]] && duration=$val
 fi
 
 printf '{"tests": %d, "skipped": %d, "durationSeconds": %s}\n' "$tests" "$skipped" "$duration" > "$METRICS_FILE"

--- a/.github/scripts/qodana-check-registration.js
+++ b/.github/scripts/qodana-check-registration.js
@@ -45,8 +45,6 @@ function writeQodanaCheckRegistration({
 }) {
   const artifactName = buildCheckArtifactName({
     sourceKind: source.sourceKind,
-    runId: source.runId,
-    runAttempt: source.runAttempt,
     qodanaRunId,
     qodanaRunAttempt,
     checkRunId: check.id,

--- a/.github/scripts/qodana-contract.js
+++ b/.github/scripts/qodana-contract.js
@@ -98,8 +98,6 @@ function requirePositiveInteger(value, label) {
 
 function buildArtifactName({
   sourceKind,
-  runId,
-  runAttempt,
   qodanaRunId,
   qodanaRunAttempt,
   headSha,
@@ -108,7 +106,7 @@ function buildArtifactName({
   if (!['code', 'documentation', 'release'].includes(sourceKind)) {
     throw new Error('Qodana source kind is invalid');
   }
-  return `${QODANA_ARTIFACT_PREFIX}${sourceKind}-${requirePositiveInteger(runId, 'CI workflow run id')}-${requirePositiveInteger(runAttempt, 'CI workflow run attempt')}-${requirePositiveInteger(qodanaRunId, 'Qodana workflow run id')}-${requirePositiveInteger(qodanaRunAttempt, 'Qodana workflow run attempt')}-${requireSha(headSha, 'head SHA')}-${requireSha(baseSha, 'base SHA')}`;
+  return `${QODANA_ARTIFACT_PREFIX}${sourceKind}-${requirePositiveInteger(qodanaRunId, 'Qodana workflow run id')}-${requirePositiveInteger(qodanaRunAttempt, 'Qodana workflow run attempt')}-${requireSha(headSha, 'head SHA')}-${requireSha(baseSha, 'base SHA')}`;
 }
 
 function parseArtifactName(name) {
@@ -116,36 +114,28 @@ function parseArtifactName(name) {
     return null;
   }
   const match = name.match(
-    new RegExp(`^${QODANA_ARTIFACT_PREFIX}(code|documentation|release)-(\\d+)-(\\d+)-(\\d+)-(\\d+)-([0-9a-f]{40})-([0-9a-f]{40})$`),
+    new RegExp(`^${QODANA_ARTIFACT_PREFIX}(code|documentation|release)-(\\d+)-(\\d+)-([0-9a-f]{40})-([0-9a-f]{40})$`),
   );
   if (!match) {
     return null;
   }
-  const runId = Number(match[2]);
-  const runAttempt = Number(match[3]);
-  const qodanaRunId = Number(match[4]);
-  const qodanaRunAttempt = Number(match[5]);
-  if (!Number.isSafeInteger(runId) || runId < 1
-    || !Number.isSafeInteger(runAttempt) || runAttempt < 1
-    || !Number.isSafeInteger(qodanaRunId) || qodanaRunId < 1
+  const qodanaRunId = Number(match[2]);
+  const qodanaRunAttempt = Number(match[3]);
+  if (!Number.isSafeInteger(qodanaRunId) || qodanaRunId < 1
     || !Number.isSafeInteger(qodanaRunAttempt) || qodanaRunAttempt < 1) {
     return null;
   }
   return {
     sourceKind: match[1],
-    ciRunId: runId,
-    ciRunAttempt: runAttempt,
     qodanaRunId,
     qodanaRunAttempt,
-    headSha: match[6],
-    baseSha: match[7],
+    headSha: match[4],
+    baseSha: match[5],
   };
 }
 
 function buildCheckArtifactName({
   sourceKind,
-  runId,
-  runAttempt,
   qodanaRunId,
   qodanaRunAttempt,
   checkRunId,
@@ -155,7 +145,7 @@ function buildCheckArtifactName({
   if (!['code', 'documentation', 'release'].includes(sourceKind)) {
     throw new Error('Qodana source kind is invalid');
   }
-  return `${QODANA_CHECK_ARTIFACT_PREFIX}${sourceKind}-${requirePositiveInteger(runId, 'CI workflow run id')}-${requirePositiveInteger(runAttempt, 'CI workflow run attempt')}-${requirePositiveInteger(qodanaRunId, 'Qodana workflow run id')}-${requirePositiveInteger(qodanaRunAttempt, 'Qodana workflow run attempt')}-${requirePositiveInteger(checkRunId, 'check run id')}-${requireSha(headSha, 'head SHA')}-${requireSha(baseSha, 'base SHA')}`;
+  return `${QODANA_CHECK_ARTIFACT_PREFIX}${sourceKind}-${requirePositiveInteger(qodanaRunId, 'Qodana workflow run id')}-${requirePositiveInteger(qodanaRunAttempt, 'Qodana workflow run attempt')}-${requirePositiveInteger(checkRunId, 'check run id')}-${requireSha(headSha, 'head SHA')}-${requireSha(baseSha, 'base SHA')}`;
 }
 
 function parseCheckArtifactName(name) {
@@ -163,24 +153,22 @@ function parseCheckArtifactName(name) {
     return null;
   }
   const match = name.match(
-    new RegExp(`^${QODANA_CHECK_ARTIFACT_PREFIX}(code|documentation|release)-(\\d+)-(\\d+)-(\\d+)-(\\d+)-(\\d+)-([0-9a-f]{40})-([0-9a-f]{40})$`),
+    new RegExp(`^${QODANA_CHECK_ARTIFACT_PREFIX}(code|documentation|release)-(\\d+)-(\\d+)-(\\d+)-([0-9a-f]{40})-([0-9a-f]{40})$`),
   );
   if (!match) {
     return null;
   }
-  const integers = match.slice(2, 7).map(Number);
+  const integers = match.slice(2, 5).map(Number);
   if (integers.some((value) => !Number.isSafeInteger(value) || value < 1)) {
     return null;
   }
   return {
     sourceKind: match[1],
-    ciRunId: integers[0],
-    ciRunAttempt: integers[1],
-    qodanaRunId: integers[2],
-    qodanaRunAttempt: integers[3],
-    checkRunId: integers[4],
-    headSha: match[7],
-    baseSha: match[8],
+    qodanaRunId: integers[0],
+    qodanaRunAttempt: integers[1],
+    checkRunId: integers[2],
+    headSha: match[5],
+    baseSha: match[6],
   };
 }
 

--- a/.github/scripts/qodana-publisher-validation.js
+++ b/.github/scripts/qodana-publisher-validation.js
@@ -60,7 +60,7 @@ function validateQodanaWorkflowSource({ eventRun, run, workflow, repository }) {
   requireEqual(eventRun.event, 'workflow_run', 'workflow run event');
   requireEqual(eventRun.status, 'completed', 'workflow run event status');
   requireEqual(eventRun.conclusion, run.conclusion, 'workflow run event conclusion');
-  requireEqual(run.event, 'workflow_run', 'workflow run event');
+  requireEqual(run.event, 'pull_request_target', 'workflow run event');
   requireEqual(run.status, 'completed', 'workflow run status');
   if (!['success', 'failure', 'cancelled', 'timed_out'].includes(run.conclusion)) {
     reject('workflow run conclusion is invalid');
@@ -69,7 +69,9 @@ function validateQodanaWorkflowSource({ eventRun, run, workflow, repository }) {
   requireEqual(run.repository?.id, repository.id, 'workflow run repository id');
   requireEqual(run.head_repository?.full_name, repository.full_name, 'workflow head repository');
   requireEqual(run.head_repository?.id, repository.id, 'workflow head repository id');
-  requireEqual(run.head_branch, repository.default_branch, 'workflow run default branch');
+  if (typeof run.head_branch !== 'string' || run.head_branch.length === 0) {
+    reject('workflow run head branch is invalid');
+  }
   requireSha(run.head_sha, 'workflow run head SHA');
   requireEqual(workflow.id, run.workflow_id, 'workflow identity');
   requireEqual(workflow.name, QODANA_WORKFLOW_NAME, 'workflow name');
@@ -155,8 +157,6 @@ function recoverQodanaCheckDescriptor({ artifacts, qodanaRun }) {
 
 function validateQodanaCheckSource({ descriptor, source }) {
   requireEqual(descriptor.sourceKind, source.sourceKind, 'Qodana check source kind');
-  requireEqual(descriptor.ciRunId, source.runId, 'Qodana check CI run id');
-  requireEqual(descriptor.ciRunAttempt, source.runAttempt, 'Qodana check CI run attempt');
   requireEqual(descriptor.headSha, source.headSha, 'Qodana check head SHA');
   requireEqual(descriptor.baseSha, source.baseSha, 'Qodana check base SHA');
 }
@@ -175,8 +175,6 @@ function selectQodanaRunArtifact({ artifacts, qodanaRun, repository }) {
 
 function validateQodanaArtifactSource({ descriptor, source }) {
   requireEqual(descriptor.sourceKind, source.sourceKind, 'Qodana source kind');
-  requireEqual(descriptor.ciRunId, source.runId, 'CI workflow run id');
-  requireEqual(descriptor.ciRunAttempt, source.runAttempt, 'CI workflow run attempt');
   requireEqual(descriptor.headSha, source.headSha, 'Qodana artifact head SHA');
   requireEqual(descriptor.baseSha, source.baseSha, 'Qodana artifact base SHA');
 }

--- a/.github/scripts/qodana-publisher.js
+++ b/.github/scripts/qodana-publisher.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { resolveCiRun, QodanaSourceRejectedError } = require('./qodana-source.js');
+const { resolvePullRequestSource, QodanaSourceRejectedError } = require('./qodana-source.js');
 const {
   QodanaPublicationRejectedError,
   recoverQodanaCheckDescriptor,
@@ -83,13 +83,11 @@ async function resolvePublication({ github, context }) {
 
   let source;
   try {
-    source = await resolveCiRun({
+    source = await resolvePullRequestSource({
       github,
       owner,
       repo,
-      runId: checkDescriptor.ciRunId,
-      expectedRunAttempt: checkDescriptor.ciRunAttempt,
-      expectedHeadSha: checkDescriptor.headSha,
+      headSha: checkDescriptor.headSha,
       expectedBaseSha: checkDescriptor.baseSha,
       waitForReleaseProvenance: false,
     });

--- a/.github/scripts/qodana-security.test.js
+++ b/.github/scripts/qodana-security.test.js
@@ -30,7 +30,8 @@ const {
 const { resolvePublication } = require('./qodana-publisher.js');
 const { downloadQodanaArtifact } = require('./qodana-publisher-storage.js');
 const {
-  resolveCiRun,
+  resolvePullRequestEventSource,
+  resolvePullRequestSource,
   resolveTrustedCiRun,
   QodanaSourceRejectedError,
 } = require('./qodana-source.js');
@@ -80,11 +81,9 @@ function makePullRequest({
 }
 
 function makeCiRun({
-  event = 'pull_request',
-  headRepository = HEAD_REPOSITORY,
-  headBranch = 'feature/security',
+  event = 'workflow_dispatch',
+  headBranch = REPOSITORY.default_branch,
   headSha = HEAD_SHA,
-  pullRequests = [{ number: 42 }],
 } = {}) {
   return {
     id: 100,
@@ -94,38 +93,57 @@ function makeCiRun({
     status: 'completed',
     conclusion: 'success',
     repository: REPOSITORY,
-    head_repository: headRepository,
+    head_repository: REPOSITORY,
     head_branch: headBranch,
     head_sha: headSha,
-    pull_requests: pullRequests,
+    pull_requests: [],
   };
 }
 
 function makeGithub({
-  run = makeCiRun(),
+  run,
   pullRequest = makePullRequest(),
   files,
-  associatedPullRequests = [],
+  associatedPullRequests,
+  releaseProvenance = 'success',
 } = {}) {
   const changedFiles = files || [{ filename: 'src/Main.kt' }];
   const listFiles = async () => changedFiles;
-  const listAssociatedPullRequests = async () => associatedPullRequests;
+  const listAssociatedPullRequests = async () => associatedPullRequests ?? [pullRequest];
+  const listJobs = async () => [{
+    name: 'Trusted release provenance',
+    status: 'completed',
+    conclusion: releaseProvenance,
+  }];
+  const listReleaseRuns = async () => [{
+    id: 800,
+    event: 'pull_request_target',
+    status: 'completed',
+    conclusion: releaseProvenance,
+    repository: REPOSITORY,
+    head_branch: pullRequest.head.ref,
+    head_sha: pullRequest.head.sha,
+    pull_requests: [{ number: pullRequest.number }],
+    created_at: '2026-08-09T00:00:00Z',
+  }];
   return {
     rest: {
       repos: {
         get: async () => ({ data: REPOSITORY }),
         listPullRequestsAssociatedWithCommit: listAssociatedPullRequests,
-        compareCommitsWithBasehead: async () => ({ data: { merge_base_commit: { sha: MERGE_BASE_SHA } } }),
+        compareCommitsWithBasehead: async () => ({
+          data: { merge_base_commit: { sha: MERGE_BASE_SHA } },
+        }),
       },
       actions: {
-        getWorkflowRun: async () => ({ data: run }),
-        getWorkflow: async () => ({
-          data: {
-            id: 55,
-            name: 'CI',
-            path: '.github/workflows/ci.yml',
-          },
+        getWorkflowRun: async () => ({ data: run ?? makeCiRun() }),
+        getWorkflow: async ({ workflow_id: workflowId }) => ({
+          data: workflowId === 'release-provenance.yml'
+            ? { path: '.github/workflows/release-provenance.yml' }
+            : { id: 55, name: 'CI', path: '.github/workflows/ci.yml' },
         }),
+        listJobsForWorkflowRun: listJobs,
+        listWorkflowRuns: listReleaseRuns,
       },
       pulls: {
         get: async () => ({ data: pullRequest }),
@@ -137,7 +155,13 @@ function makeGithub({
         return changedFiles;
       }
       if (method === listAssociatedPullRequests) {
-        return associatedPullRequests;
+        return listAssociatedPullRequests();
+      }
+      if (method === listJobs) {
+        return listJobs();
+      }
+      if (method === listReleaseRuns) {
+        return listReleaseRuns();
       }
       throw new Error('unexpected pagination method');
     },
@@ -189,23 +213,25 @@ function makePublicationGithub({
     id: QODANA_RUN_ID,
     run_attempt: QODANA_RUN_ATTEMPT,
     workflow_id: 77,
-    event: 'workflow_run',
+    event: 'pull_request_target',
     status: 'completed',
     conclusion: qodanaConclusion,
     repository: REPOSITORY,
     head_repository: REPOSITORY,
-    head_branch: REPOSITORY.default_branch,
-    head_sha: 'e'.repeat(40),
+    head_branch: delayedReleaseProvenance
+      ? 'release-please--branches--master'
+      : 'feature/security',
+    head_sha: HEAD_SHA,
+    pull_requests: [{ number: 42 }],
   };
   const qodanaEvent = {
     id: qodanaRun.id,
     run_attempt: qodanaRun.run_attempt,
     workflow_id: qodanaRun.workflow_id,
-    event: qodanaRun.event,
+    event: 'workflow_run',
     status: qodanaRun.status,
     conclusion: qodanaRun.conclusion,
   };
-  const ciRun = makeCiRun();
   const files = delayedReleaseProvenance
     ? [{ filename: 'CHANGELOG.md' }]
     : [{ filename: 'src/Main.kt' }];
@@ -214,16 +240,15 @@ function makePublicationGithub({
     headRef: delayedReleaseProvenance
       ? 'release-please--branches--master'
       : 'feature/security',
-    headSha: staleSource ? 'd'.repeat(40) : HEAD_SHA,
   });
   if (delayedReleaseProvenance) {
     pullRequest.user = {
       login: 'release-please-kotventure[bot]',
       type: 'Bot',
     };
-    ciRun.head_branch = pullRequest.head.ref;
   }
   const listFiles = async () => files;
+  const listAssociatedPullRequests = async () => (staleSource ? [] : [pullRequest]);
   const listJobs = async () => [{
     name: 'Trusted release provenance',
     status: 'completed',
@@ -244,12 +269,10 @@ function makePublicationGithub({
     id: 699,
     name: buildCheckArtifactName({
       sourceKind: 'code',
-      runId: ciRun.id,
-      runAttempt: ciRun.run_attempt,
       qodanaRunId: qodanaRun.id,
       qodanaRunAttempt: qodanaRun.run_attempt,
       checkRunId: 701,
-      headSha: ciRun.head_sha,
+      headSha: HEAD_SHA,
       baseSha: BASE_SHA,
     }),
     expired: checkArtifactExpired,
@@ -271,11 +294,9 @@ function makePublicationGithub({
       id: 700,
       name: buildArtifactName({
         sourceKind: 'code',
-        runId: ciRun.id,
-        runAttempt: ciRun.run_attempt,
         qodanaRunId: qodanaRun.id,
         qodanaRunAttempt: qodanaRun.run_attempt,
-        headSha: ciRun.head_sha,
+        headSha: HEAD_SHA,
         baseSha: BASE_SHA,
       }),
       expired: false,
@@ -300,14 +321,13 @@ function makePublicationGithub({
       rest: {
         repos: {
           get: async () => ({ data: REPOSITORY }),
+          listPullRequestsAssociatedWithCommit: listAssociatedPullRequests,
           compareCommitsWithBasehead: async () => ({
             data: { merge_base_commit: { sha: MERGE_BASE_SHA } },
           }),
         },
         actions: {
-          getWorkflowRun: async ({ run_id: runId }) => ({
-            data: runId === qodanaRun.id ? qodanaRun : ciRun,
-          }),
+          getWorkflowRun: async () => ({ data: qodanaRun }),
           getWorkflow: async ({ workflow_id: workflowId }) => ({
             data: workflowId === qodanaRun.workflow_id
               ? { id: 77, name: 'Qodana', path: '.github/workflows/qodana.yml' }
@@ -336,6 +356,9 @@ function makePublicationGithub({
         }
         if (method === listReleaseRuns) {
           return listReleaseRuns();
+        }
+        if (method === listAssociatedPullRequests) {
+          return listAssociatedPullRequests();
         }
         throw new Error('unexpected publication pagination method');
       },
@@ -385,11 +408,9 @@ test('normalises Qodana metadata for a stable code-scanning category', (t) => {
   );
 });
 
-test('binds Qodana artifacts to both run attempts and the source SHAs', () => {
+test('binds Qodana artifacts to the Qodana run and the source SHAs', () => {
   const name = buildArtifactName({
     sourceKind: 'code',
-    runId: 100,
-    runAttempt: 2,
     qodanaRunId: QODANA_RUN_ID,
     qodanaRunAttempt: QODANA_RUN_ATTEMPT,
     headSha: HEAD_SHA,
@@ -397,14 +418,15 @@ test('binds Qodana artifacts to both run attempts and the source SHAs', () => {
   });
   assert.deepEqual(parseArtifactName(name), {
     sourceKind: 'code',
-    ciRunId: 100,
-    ciRunAttempt: 2,
     qodanaRunId: QODANA_RUN_ID,
     qodanaRunAttempt: QODANA_RUN_ATTEMPT,
     headSha: HEAD_SHA,
     baseSha: BASE_SHA,
   });
   assert.equal(parseArtifactName(`${name}-old`), null);
+  assert.equal(parseArtifactName(
+    `qodana-sarif-code-100-2-${QODANA_RUN_ID}-${QODANA_RUN_ATTEMPT}-${HEAD_SHA}-${BASE_SHA}`,
+  ), null);
 });
 
 test('registers a source-bound Qodana check before pull-request analysis', async (t) => {
@@ -419,8 +441,6 @@ test('registers a source-bound Qodana check before pull-request analysis', async
   };
   const source = {
     sourceKind: 'code',
-    runId: 100,
-    runAttempt: 2,
     pullRequest: 42,
     headSha: HEAD_SHA,
     baseSha: BASE_SHA,
@@ -466,8 +486,6 @@ test('registers a source-bound Qodana check before pull-request analysis', async
   assert.equal(calls[0].name, 'Qodana / pull request');
   assert.deepEqual(parseCheckArtifactName(registration.artifactName), {
     sourceKind: 'code',
-    ciRunId: 100,
-    ciRunAttempt: 2,
     qodanaRunId: QODANA_RUN_ID,
     qodanaRunAttempt: QODANA_RUN_ATTEMPT,
     checkRunId: 701,
@@ -558,8 +576,6 @@ test('rejects malformed SARIF and every standard project traversal location', ()
 test('selects only the artifact bound to the trusted Qodana workflow run', () => {
   const source = {
     sourceKind: 'code',
-    runId: 100,
-    runAttempt: 2,
     headSha: HEAD_SHA,
     baseSha: BASE_SHA,
   };
@@ -576,32 +592,27 @@ test('selects only the artifact bound to the trusted Qodana workflow run', () =>
       id: QODANA_RUN_ID,
       repository_id: REPOSITORY.id,
       head_repository_id: REPOSITORY.id,
-      head_branch: REPOSITORY.default_branch,
-      head_sha: 'e'.repeat(40),
+      head_branch: 'feature/security',
+      head_sha: HEAD_SHA,
     },
+  };
+  const qodanaRun = {
+    id: QODANA_RUN_ID,
+    run_attempt: QODANA_RUN_ATTEMPT,
+    head_repository: REPOSITORY,
+    head_branch: 'feature/security',
+    head_sha: HEAD_SHA,
   };
   assert.equal(selectQodanaArtifact({
     artifacts: [artifact],
-    qodanaRun: {
-      id: QODANA_RUN_ID,
-      run_attempt: QODANA_RUN_ATTEMPT,
-      head_repository: REPOSITORY,
-      head_branch: REPOSITORY.default_branch,
-      head_sha: 'e'.repeat(40),
-    },
+    qodanaRun,
     source,
     repository: REPOSITORY,
   }).id, 700);
   assert.throws(
     () => selectQodanaArtifact({
       artifacts: [artifact, structuredClone(artifact)],
-      qodanaRun: {
-        id: QODANA_RUN_ID,
-        run_attempt: QODANA_RUN_ATTEMPT,
-        head_repository: REPOSITORY,
-        head_branch: REPOSITORY.default_branch,
-        head_sha: 'e'.repeat(40),
-      },
+      qodanaRun,
       source,
       repository: REPOSITORY,
     }),
@@ -616,13 +627,7 @@ test('selects only the artifact bound to the trusted Qodana workflow run', () =>
   });
   assert.equal(selectQodanaArtifact({
     artifacts: [priorAttempt, artifact],
-    qodanaRun: {
-      id: QODANA_RUN_ID,
-      run_attempt: QODANA_RUN_ATTEMPT,
-      head_repository: REPOSITORY,
-      head_branch: REPOSITORY.default_branch,
-      head_sha: 'e'.repeat(40),
-    },
+    qodanaRun,
     source,
     repository: REPOSITORY,
   }).id, 700);
@@ -658,8 +663,6 @@ test('rejects missing, duplicate, expired, oversized, and source-mismatched chec
       descriptor,
       source: {
         sourceKind: 'code',
-        runId: 100,
-        runAttempt: 2,
         headSha: 'f'.repeat(40),
         baseSha: BASE_SHA,
       },
@@ -668,7 +671,7 @@ test('rejects missing, duplicate, expired, oversized, and source-mismatched chec
   );
 });
 
-test('publishes only a successful Qodana run for the current CI head', async () => {
+test('publishes only a successful Qodana run for the current PR head', async () => {
   const inputs = makePublicationGithub();
   const publication = await resolvePublication({
     github: inputs.github,
@@ -775,16 +778,17 @@ test('reports a missing successful Qodana artifact as publication failure', asyn
   assert.match(publication.rejection.message, /exactly one Qodana SARIF artifact/);
 });
 
-test('resolves a successful CI source and computes its merge base', async () => {
-  const source = await resolveCiRun({
+test('resolves a pull-request source by head SHA and computes its merge base', async () => {
+  const source = await resolvePullRequestSource({
     github: makeGithub(),
     owner: 'LMLiam',
     repo: 'Kotventure',
-    runId: 100,
+    headSha: HEAD_SHA,
   });
   assert.equal(source.sourceKind, 'code');
   assert.equal(source.mergeBaseSha, MERGE_BASE_SHA);
   assert.equal(source.pullRequest, 42);
+  assert.equal(source.runId, undefined);
 });
 
 test('resolves same-repository and fork pull-request heads', async () => {
@@ -793,41 +797,60 @@ test('resolves same-repository and fork pull-request heads', async () => {
     id: 2,
   };
   const pullRequest = makePullRequest({ headRepository: forkRepository });
-  const run = makeCiRun({ headRepository: forkRepository });
-  const source = await resolveCiRun({
-    github: makeGithub({ run, pullRequest }),
+  const source = await resolvePullRequestSource({
+    github: makeGithub({ pullRequest }),
     owner: 'LMLiam',
     repo: 'Kotventure',
-    runId: 100,
+    headSha: HEAD_SHA,
   });
   assert.equal(source.headRepository, forkRepository.full_name);
   assert.equal(source.headSha, HEAD_SHA);
 });
 
-test('filters commit-associated pull requests before selecting the fallback', async () => {
-  const run = makeCiRun({ pullRequests: [] });
+test('filters commit-associated pull requests before selecting the source', async () => {
   const pullRequest = makePullRequest();
-  const unrelatedPullRequest = makePullRequest({ headRef: 'unrelated' });
+  const unrelatedPullRequest = makePullRequest({
+    headRef: 'unrelated',
+    headSha: 'e'.repeat(40),
+  });
   unrelatedPullRequest.number = 99;
-  const source = await resolveCiRun({
+  const source = await resolvePullRequestSource({
     github: makeGithub({
-      run,
       pullRequest,
       associatedPullRequests: [unrelatedPullRequest, pullRequest],
     }),
     owner: 'LMLiam',
     repo: 'Kotventure',
-    runId: 100,
+    headSha: HEAD_SHA,
   });
   assert.equal(source.pullRequest, 42);
 });
 
-test('accepts trusted CI only from the current repository default branch', async () => {
-  const run = makeCiRun({
-    event: 'workflow_dispatch',
-    headBranch: REPOSITORY.default_branch,
-    pullRequests: [],
+test('resolves the pull_request_target event source for the register job', async () => {
+  const pullRequest = makePullRequest();
+  const source = await resolvePullRequestEventSource({
+    github: makeGithub({ pullRequest }),
+    context: {
+      repo: { owner: 'LMLiam', repo: 'Kotventure' },
+      payload: { pull_request: pullRequest },
+    },
+    qodanaRunId: QODANA_RUN_ID,
+    qodanaRunAttempt: QODANA_RUN_ATTEMPT,
   });
+  assert.equal(source.sourceKind, 'code');
+  assert.equal(source.pullRequest, 42);
+  assert.equal(source.headSha, HEAD_SHA);
+  assert.equal(source.artifactName, buildArtifactName({
+    sourceKind: 'code',
+    qodanaRunId: QODANA_RUN_ID,
+    qodanaRunAttempt: QODANA_RUN_ATTEMPT,
+    headSha: HEAD_SHA,
+    baseSha: BASE_SHA,
+  }));
+});
+
+test('accepts trusted CI only from the current repository default branch', async () => {
+  const run = makeCiRun();
   const source = await resolveTrustedCiRun({
     github: makeGithub({ run }),
     owner: 'LMLiam',
@@ -854,11 +877,11 @@ test('accepts trusted CI only from the current repository default branch', async
 test('uses the documentation attestation path without computing a merge base', async () => {
   const files = [{ filename: 'docs/CI.md' }];
   const pullRequest = makePullRequest({ files });
-  const source = await resolveCiRun({
+  const source = await resolvePullRequestSource({
     github: makeGithub({ pullRequest, files }),
     owner: 'LMLiam',
     repo: 'Kotventure',
-    runId: 100,
+    headSha: HEAD_SHA,
   });
   assert.equal(source.sourceKind, 'documentation');
   assert.equal(source.mergeBaseSha, undefined);
@@ -902,40 +925,65 @@ test('downloads, bounds, and validates the single SARIF artifact', async () => {
   }
 });
 
-test('marks a pull request that advanced after CI as stale', async () => {
-  const pullRequest = makePullRequest();
-  pullRequest.head.sha = 'd'.repeat(40);
+test('marks a pull request that advanced after registration as stale', async () => {
+  const advanced = makePullRequest({ headSha: 'd'.repeat(40) });
   await assert.rejects(
-    resolveCiRun({
-      github: makeGithub({ pullRequest }),
+    resolvePullRequestSource({
+      github: makeGithub({ pullRequest: advanced }),
       owner: 'LMLiam',
       repo: 'Kotventure',
-      runId: 100,
+      headSha: HEAD_SHA,
     }),
     (error) => error instanceof QodanaSourceRejectedError && error.stale,
   );
 });
 
-test('marks a changed base or closed pull request as stale', async () => {
-  const changedBase = makePullRequest({ baseSha: 'd'.repeat(40) });
+test('marks a missing head-SHA association or closed pull request as stale', async () => {
   await assert.rejects(
-    resolveCiRun({
-      github: makeGithub({ pullRequest: changedBase }),
+    resolvePullRequestSource({
+      github: makeGithub({ associatedPullRequests: [] }),
       owner: 'LMLiam',
       repo: 'Kotventure',
-      runId: 100,
-      expectedBaseSha: BASE_SHA,
+      headSha: HEAD_SHA,
     }),
     (error) => error instanceof QodanaSourceRejectedError && error.stale,
   );
 
   const closedPullRequest = makePullRequest({ state: 'closed' });
   await assert.rejects(
-    resolveCiRun({
+    resolvePullRequestSource({
       github: makeGithub({ pullRequest: closedPullRequest }),
       owner: 'LMLiam',
       repo: 'Kotventure',
-      runId: 100,
+      headSha: HEAD_SHA,
+    }),
+    (error) => error instanceof QodanaSourceRejectedError && error.stale,
+  );
+});
+
+test('marks a changed base or advanced event head as stale', async () => {
+  const changedBase = makePullRequest({ baseSha: 'd'.repeat(40) });
+  await assert.rejects(
+    resolvePullRequestSource({
+      github: makeGithub({ pullRequest: changedBase }),
+      owner: 'LMLiam',
+      repo: 'Kotventure',
+      headSha: HEAD_SHA,
+      expectedBaseSha: BASE_SHA,
+    }),
+    (error) => error instanceof QodanaSourceRejectedError && error.stale,
+  );
+
+  const current = makePullRequest({ headSha: 'd'.repeat(40) });
+  await assert.rejects(
+    resolvePullRequestEventSource({
+      github: makeGithub({ pullRequest: current }),
+      context: {
+        repo: { owner: 'LMLiam', repo: 'Kotventure' },
+        payload: { pull_request: makePullRequest() },
+      },
+      qodanaRunId: QODANA_RUN_ID,
+      qodanaRunAttempt: QODANA_RUN_ATTEMPT,
     }),
     (error) => error instanceof QodanaSourceRejectedError && error.stale,
   );

--- a/.github/scripts/qodana-source.js
+++ b/.github/scripts/qodana-source.js
@@ -54,45 +54,11 @@ function repositoryName(repository) {
   return repository.full_name;
 }
 
-async function getPullRequest({ github, owner, repo, repository, run }) {
-  const listedPullRequests = Array.isArray(run.pull_requests) ? run.pull_requests : [];
-  if (listedPullRequests.length > 1) {
-    reject('workflow run identifies more than one pull request');
-  }
-
-  let pullNumber = listedPullRequests[0]?.number;
-  if (pullNumber == null) {
-    const associatedPullRequests = await github.paginate(
-      github.rest.repos.listPullRequestsAssociatedWithCommit,
-      {
-        owner,
-        repo,
-        commit_sha: run.head_sha,
-        per_page: 100,
-      },
-    );
-    const matchingPullRequests = Array.isArray(associatedPullRequests)
-      ? associatedPullRequests.filter((pullRequest) => pullRequest?.state === 'open'
-        && pullRequest.base?.repo?.full_name === repository.full_name
-        && pullRequest.base?.repo?.id === repository.id
-        && pullRequest.base?.ref === repository.default_branch
-        && pullRequest.head?.repo?.full_name === run.head_repository?.full_name
-        && pullRequest.head?.repo?.id === run.head_repository?.id
-        && pullRequest.head?.ref === run.head_branch
-        && pullRequest.head?.sha === run.head_sha)
-      : [];
-    if (matchingPullRequests.length !== 1) {
-      reject('workflow run does not identify exactly one pull request');
-    }
-    pullNumber = matchingPullRequests[0]?.number;
-  }
-  requirePositiveInteger(pullNumber, 'pull request number');
-  const response = await github.rest.pulls.get({
-    owner,
-    repo,
-    pull_number: pullNumber,
-  });
-  return requireObject(response.data, 'pull request');
+async function fetchRepository({ github, owner, repo }) {
+  const repositoryResponse = await github.rest.repos.get({ owner, repo });
+  const repository = requireObject(repositoryResponse.data, 'repository');
+  requireEqual(repository.full_name, `${owner}/${repo}`, 'repository identity');
+  return repository;
 }
 
 async function getChangedFiles({ github, owner, repo, pullRequest }) {
@@ -227,63 +193,34 @@ function validateEventRun({ eventRun, run }) {
   }
 }
 
-async function resolveCiRun({
-  github,
-  owner,
-  repo,
-  runId,
-  eventRun,
-  expectedRunAttempt,
-  expectedHeadSha,
-  expectedBaseSha,
-  waitForReleaseProvenance = true,
+function validatePullRequestState({
+  pullRequest,
+  repository,
+  expectedHeadSha = null,
+  expectedBaseSha = null,
 }) {
-  requirePositiveInteger(runId, 'workflow run id');
-  const repositoryResponse = await github.rest.repos.get({ owner, repo });
-  const repository = requireObject(repositoryResponse.data, 'repository');
-  requireEqual(repository.full_name, `${owner}/${repo}`, 'repository identity');
-  const runResponse = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
-  const run = requireObject(runResponse.data, 'workflow run');
-  const workflowResponse = await github.rest.actions.getWorkflow({
-    owner,
-    repo,
-    workflow_id: run.workflow_id,
-  });
-  const workflow = requireObject(workflowResponse.data, 'workflow');
-
-  if (eventRun) {
-    validateEventRun({ eventRun, run });
-  }
-  requireEqual(run.event, 'pull_request', 'workflow run event');
-  requireEqual(run.status, 'completed', 'workflow run status');
-  requireEqual(run.conclusion, 'success', 'workflow run conclusion');
-  requireEqual(run.repository?.full_name, repositoryName(repository), 'workflow run repository');
-  requireEqual(run.repository?.id, repository.id, 'workflow run repository id');
-  requireEqual(workflow.id, run.workflow_id, 'workflow identity');
-  requireEqual(workflow.name, CI_WORKFLOW_NAME, 'workflow name');
-  requireEqual(workflow.path, CI_WORKFLOW_PATH, 'workflow path');
-  if (expectedRunAttempt != null) {
-    requireEqual(run.run_attempt, expectedRunAttempt, 'workflow run attempt');
-  }
-  if (expectedHeadSha != null) {
-    requireEqual(run.head_sha, expectedHeadSha, 'workflow run head SHA');
-  }
-
-  const pullRequest = await getPullRequest({ github, owner, repo, repository, run });
   requireEqual(pullRequest.state, 'open', 'pull request state', true);
   requireEqual(pullRequest.base?.repo?.full_name, repository.full_name, 'pull request base repository', true);
   requireEqual(pullRequest.base?.repo?.id, repository.id, 'pull request base repository id', true);
   requireEqual(pullRequest.base?.ref, repository.default_branch, 'pull request base branch', true);
   requireSha(pullRequest.base?.sha, 'pull request base SHA');
-  const headRepository = requireObject(pullRequest.head?.repo, 'pull request head repository');
-  requireEqual(run.head_repository?.full_name, headRepository.full_name, 'workflow head repository', true);
-  requireEqual(run.head_repository?.id, headRepository.id, 'workflow head repository id', true);
-  requireEqual(run.head_branch, pullRequest.head?.ref, 'workflow head branch', true);
-  requireEqual(run.head_sha, pullRequest.head?.sha, 'pull request head SHA', true);
+  requireSha(pullRequest.head?.sha, 'pull request head SHA');
+  if (expectedHeadSha != null) {
+    requireEqual(pullRequest.head?.sha, expectedHeadSha, 'pull request head SHA', true);
+  }
   if (expectedBaseSha != null) {
     requireEqual(pullRequest.base.sha, expectedBaseSha, 'pull request base SHA', true);
   }
+}
 
+async function completePullRequestSource({
+  github,
+  owner,
+  repo,
+  repository,
+  pullRequest,
+  waitForReleaseProvenance = true,
+}) {
   const files = await getChangedFiles({ github, owner, repo, pullRequest });
   const pathClassification = classifyChangedFiles(files);
   let sourceKind = pathClassification;
@@ -299,11 +236,9 @@ async function resolveCiRun({
       });
     sourceKind = trusted ? 'release' : 'code';
   }
-
+  const headRepository = requireObject(pullRequest.head?.repo, 'pull request head repository');
   const source = {
     repository: repository.full_name,
-    runId: requirePositiveInteger(run.id, 'workflow run id'),
-    runAttempt: requirePositiveInteger(run.run_attempt, 'workflow run attempt'),
     pullRequest: requirePositiveInteger(pullRequest.number, 'pull request number'),
     pathClassification,
     sourceKind,
@@ -316,7 +251,6 @@ async function resolveCiRun({
     headRef: pullRequest.head.ref,
     headSha: pullRequest.head.sha,
   };
-
   if (sourceKind === 'code') {
     source.mergeBaseSha = await resolveMergeBase({
       github,
@@ -329,21 +263,83 @@ async function resolveCiRun({
   return source;
 }
 
-async function resolveSource({ github, context, qodanaRunId, qodanaRunAttempt }) {
-  const eventRun = requireObject(context.payload?.workflow_run, 'workflow_run event');
-  const source = await resolveCiRun({
+async function findPullRequestForHeadSha({ github, owner, repo, repository, headSha }) {
+  const associatedPullRequests = await github.paginate(
+    github.rest.repos.listPullRequestsAssociatedWithCommit,
+    {
+      owner,
+      repo,
+      commit_sha: headSha,
+      per_page: 100,
+    },
+  );
+  const matchingPullRequests = Array.isArray(associatedPullRequests)
+    ? associatedPullRequests.filter((pullRequest) => pullRequest?.state === 'open'
+      && pullRequest.base?.repo?.full_name === repository.full_name
+      && pullRequest.base?.repo?.id === repository.id
+      && pullRequest.base?.ref === repository.default_branch
+      && pullRequest.head?.sha === headSha)
+    : [];
+  if (matchingPullRequests.length !== 1) {
+    reject('pull request head SHA does not identify exactly one open pull request', true);
+  }
+  return matchingPullRequests[0].number;
+}
+
+async function resolvePullRequestSource({
+  github,
+  owner,
+  repo,
+  headSha,
+  expectedBaseSha = null,
+  waitForReleaseProvenance = true,
+}) {
+  requireSha(headSha, 'pull request head SHA');
+  const repository = await fetchRepository({ github, owner, repo });
+  const pullNumber = await findPullRequestForHeadSha({ github, owner, repo, repository, headSha });
+  const response = await github.rest.pulls.get({ owner, repo, pull_number: pullNumber });
+  const pullRequest = requireObject(response.data, 'pull request');
+  validatePullRequestState({
+    pullRequest,
+    repository,
+    expectedHeadSha: headSha,
+    expectedBaseSha,
+  });
+  return completePullRequestSource({
     github,
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    runId: requirePositiveInteger(eventRun.id, 'workflow run id'),
-    eventRun,
+    owner,
+    repo,
+    repository,
+    pullRequest,
+    waitForReleaseProvenance,
+  });
+}
+
+async function resolvePullRequestEventSource({ github, context, qodanaRunId, qodanaRunAttempt }) {
+  const pullRequestEvent = requireObject(context.payload?.pull_request, 'pull_request event');
+  const eventHeadSha = requireSha(pullRequestEvent.head?.sha, 'pull request event head SHA');
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const repository = await fetchRepository({ github, owner, repo });
+  requireEqual(pullRequestEvent.base?.repo?.full_name, repository.full_name, 'pull request base repository');
+  requireEqual(pullRequestEvent.base?.repo?.id, repository.id, 'pull request base repository id');
+  requireEqual(pullRequestEvent.base?.ref, repository.default_branch, 'pull request base branch');
+  const pullNumber = requirePositiveInteger(pullRequestEvent.number, 'pull request number');
+  const response = await github.rest.pulls.get({ owner, repo, pull_number: pullNumber });
+  const pullRequest = requireObject(response.data, 'pull request');
+  validatePullRequestState({ pullRequest, repository, expectedHeadSha: eventHeadSha });
+  const source = await completePullRequestSource({
+    github,
+    owner,
+    repo,
+    repository,
+    pullRequest,
+    waitForReleaseProvenance: true,
   });
   return {
     ...source,
     artifactName: buildArtifactName({
       sourceKind: source.sourceKind,
-      runId: source.runId,
-      runAttempt: source.runAttempt,
       qodanaRunId: requirePositiveInteger(qodanaRunId, 'Qodana workflow run id'),
       qodanaRunAttempt: requirePositiveInteger(qodanaRunAttempt, 'Qodana workflow run attempt'),
       headSha: source.headSha,
@@ -393,7 +389,7 @@ module.exports = {
   QodanaSourceRejectedError,
   hasTrustedReleaseMetadata,
   hasTrustedReleaseProvenance,
-  resolveCiRun,
-  resolveSource,
+  resolvePullRequestEventSource,
+  resolvePullRequestSource,
   resolveTrustedCiRun,
 };

--- a/.github/scripts/qodana-workflow-security.test.js
+++ b/.github/scripts/qodana-workflow-security.test.js
@@ -36,10 +36,15 @@ test('the Qodana scan workflow is read-only and disables GitHub side effects', (
   const analyse = readJob(workflow, 'analyse', 'report-registration-failure');
   const registrationFailure = readJob(workflow, 'report-registration-failure');
 
-  assert.match(workflow, /workflow_run:/);
+  assert.match(workflow, /pull_request_target:/);
+  assert.match(workflow, /branches: \[master\]/);
+  assert.match(workflow, /types: \[opened, synchronize, reopened\]/);
+  assert.match(workflow, /group: qodana-\$\{\{ github\.event\.pull_request\.number \}\}/);
+  assert.doesNotMatch(workflow, /workflow_run:/);
   assert.doesNotMatch(workflow, /QODANA_TOKEN/);
   assert.match(register, /checks:\s*write/);
   assert.doesNotMatch(analyse, /(?:actions|checks|contents|pull-requests|security-events):\s*write/);
+  assert.match(register, /resolvePullRequestEventSource/);
   assert.match(register, /createQodanaCheck/);
   assert.ok(
     register.indexOf("core.setOutput('check_run_id'")
@@ -58,6 +63,7 @@ test('the Qodana scan workflow is read-only and disables GitHub side effects', (
   assert.doesNotMatch(workflow, /--config source\/qodana\.yaml/);
   assert.match(workflow, /ref:\s*\$\{\{ github\.sha \}\}/);
   assert.match(workflow, /git -C source rev-parse HEAD/);
+  assert.match(analyse, /repository:\s*\$\{\{ needs\.register\.outputs\.head_repository \}\}/);
   assert.match(analyse, /ref:\s*\$\{\{ needs\.register\.outputs\.head_sha \}\}/);
   assert.match(workflow, /cp --remove-destination -- qodana\.yaml source\/qodana\.yaml/);
   assert.doesNotMatch(workflow, /normalize-qodana-sarif\.sh/);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,12 +361,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: kover-handoff-*
-          path: .
+          path: kover-handoff
           merge-multiple: true
 
       - name: Restore Kover data layout
         run: |
           set -euo pipefail
+          # upload-artifact stores the contents of `kover-handoff/` at the artifact root,
+          # so downloading into `kover-handoff/` reproduces the staged layout below.
           for module in kover-handoff/*; do
             [ -d "$module" ] || continue
             name=$(basename "$module")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,21 +29,7 @@ concurrency:
 permissions:
   contents: read
 
-# ╔══════════════════════════════════════════════════════════════════════════════╗
-# ║  CI Pipeline                                                               ║
-# ║                                                                            ║
-# ║  Triage ─ Gate+Changes (fast, always runs)                                 ║
-# ║  Tier 1 ─ Parallel: Lint ┤ Build (sharded) ┤ Vanilla ┤ Dokka               ║
-# ║  Tier 2 ─ Aggregate after Build (coverage, metrics, baseline)               ║
-# ║  Policy ─ Independent: Dependencies │ Commits │ Release attestation        ║
-# ║  Status ─ Aggregator (required check for merge gate and merge queue)       ║
-# ╚══════════════════════════════════════════════════════════════════════════════╝
-
 jobs:
-
-  # ╭──────────────────────────────────────────────────────────────────────────╮
-  # │ Tier 0: Triage                                                           │
-  # ╰──────────────────────────────────────────────────────────────────────────╯
 
   triage:
     name: Triage
@@ -157,10 +143,6 @@ jobs:
               echo "documentation_only=false"
             } >> "$GITHUB_OUTPUT"
           fi
-
-  # ╭──────────────────────────────────────────────────────────────────────────╮
-  # │ Tier 1: Core (fast feedback — lint and build in parallel)                │
-  # ╰──────────────────────────────────────────────────────────────────────────╯
 
   lint-kotlin:
     name: Lint (Kotlin)
@@ -367,8 +349,6 @@ jobs:
       - name: Restore Kover data layout
         run: |
           set -euo pipefail
-          # upload-artifact stores the contents of `kover-handoff/` at the artifact root,
-          # so downloading into `kover-handoff/` reproduces the staged layout below.
           for module in kover-handoff/*; do
             [ -d "$module" ] || continue
             name=$(basename "$module")
@@ -613,10 +593,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
 
-  # ╭──────────────────────────────────────────────────────────────────────────╮
-  # │ Tier 2: Vanilla (parallel with Tier 1)                                   │
-  # ╰──────────────────────────────────────────────────────────────────────────╯
-
   vanilla:
     name: Vanilla conformance
     needs: [triage]
@@ -673,11 +649,6 @@ jobs:
           check_name: Vanilla Conformance Report
           report_paths: modules/core/build/test-results/vanillaConformanceTest/TEST-*.xml
 
-
-  # ╭──────────────────────────────────────────────────────────────────────────╮
-  # │ Policy (independent of tiers)                                            │
-  # ╰──────────────────────────────────────────────────────────────────────────╯
-
   dependencies:
     name: Dependencies
     if: github.event_name == 'pull_request'
@@ -723,10 +694,6 @@ jobs:
 
       - name: Validate commit subjects
         run: bash .github/scripts/validate-conventional-title.sh --stdin < commit-subjects.txt
-
-  # ╭──────────────────────────────────────────────────────────────────────────╮
-  # │ Status (required merge-gate check)                                       │
-  # ╰──────────────────────────────────────────────────────────────────────────╯
 
   status:
     name: Status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ permissions:
 # ╔══════════════════════════════════════════════════════════════════════════════╗
 # ║  CI Pipeline                                                               ║
 # ║                                                                            ║
-# ║  Tier 0 ─ Triage        Gate → Changes (fast, always runs)                ║
-# ║  Tier 1 ─ Core          Lint ┤ Build (parallel, first feedback)            ║
-# ║  Tier 2 ─ Analysis      Vanilla (parallel with Tier 1)                      ║
-# ║  Policy ─ Independent   Dependencies │ Commits │ Release attestation       ║
-# ║  Status ─ Aggregator    Required check (merge gate + merge queue)          ║
+# ║  Triage ─ Gate+Changes (fast, always runs)                                 ║
+# ║  Tier 1 ─ Parallel: Lint ┤ Build (sharded) ┤ Vanilla ┤ Dokka               ║
+# ║  Tier 2 ─ Aggregate after Build (coverage, metrics, baseline)               ║
+# ║  Policy ─ Independent: Dependencies │ Commits │ Release attestation        ║
+# ║  Status ─ Aggregator (required check for merge gate and merge queue)       ║
 # ╚══════════════════════════════════════════════════════════════════════════════╝
 
 jobs:
@@ -79,7 +79,9 @@ jobs:
 
       - name: Path filter
         id: filter
-        if: steps.decide.outputs.run == 'true'
+        if: >-
+          steps.decide.outputs.run == 'true' &&
+          (github.event_name == 'pull_request' || github.event_name == 'push')
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           filters: |
@@ -188,7 +190,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Check one type declaration per file
@@ -251,7 +252,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Run build
@@ -289,6 +289,25 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      - name: Prepare duration artifact
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ -f gradle-duration.txt ]]; then
+            cp gradle-duration.txt gradle-duration-${{ matrix.shard }}.txt
+          else
+            echo "0" > gradle-duration-${{ matrix.shard }}.txt
+          fi
+
+      - name: Upload duration
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gradle-duration-${{ matrix.shard }}
+          path: gradle-duration-${{ matrix.shard }}.txt
+          if-no-files-found: ignore
+          retention-days: 7
+
 
   aggregate:
     name: Aggregate
@@ -321,8 +340,17 @@ jobs:
           path: .
           merge-multiple: true
 
+      - name: Download durations
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: gradle-duration-*
+          path: .
+          merge-multiple: true
+
       - name: Generate coverage reports
-        run: ./gradlew koverXmlReport koverHtmlReport koverVerify
+        uses: ./.github/actions/gradle-job
+        with:
+          tasks: koverXmlReport koverHtmlReport koverVerify -x test -x vanillaConformanceTest
 
       - name: Collect CI metrics
         run: bash .github/scripts/collect-ci-metrics.sh
@@ -372,15 +400,6 @@ jobs:
           path: .ci-baseline
           key: ci-baseline-${{ github.sha }}
 
-      - name: Upload Dokka preview
-        if: success() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: dokka-preview
-          path: modules/*/build/dokka/html
-          if-no-files-found: warn
-          retention-days: 14
-
       - name: Upload build artifacts
         if: failure() || (github.event_name == 'push' && github.ref == 'refs/heads/master')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -424,8 +443,8 @@ jobs:
     if: >-
       always()
       && github.event_name == 'pull_request'
-      && needs.build.result != 'cancelled'
-      && needs.build.result != 'skipped'
+      && needs.aggregate.result != 'cancelled'
+      && needs.aggregate.result != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -661,9 +680,7 @@ jobs:
     steps:
       - name: Evaluate
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          GATE_RESULT: ${{ needs.triage.result }}
-          CHANGES_RESULT: ${{ needs.triage.result }}
+          TRIAGE_RESULT: ${{ needs.triage.result }}
           LINT_KOTLIN_RESULT: ${{ needs.lint-kotlin.result }}
           LINT_ACTIONS_RESULT: ${{ needs.lint-actions.result }}
           BUILD_RESULT: ${{ needs.build.result }}
@@ -671,12 +688,11 @@ jobs:
           DOKKA_RESULT: ${{ needs.dokka.result }}
           VANILLA_RESULT: ${{ needs.vanilla.result }}
           DEPS_RESULT: ${{ needs.dependencies.result }}
-          GATE_RUN: ${{ needs.triage.outputs.run }}
+          TRIAGE_RUN: ${{ needs.triage.outputs.run }}
           CODE_CHANGED: ${{ needs.triage.outputs.code }}
         run: |
           set -euo pipefail
-          gate="$GATE_RESULT"
-          changes="$CHANGES_RESULT"
+          triage="$TRIAGE_RESULT"
           lint_kotlin="$LINT_KOTLIN_RESULT"
           lint_actions="$LINT_ACTIONS_RESULT"
           build="$BUILD_RESULT"
@@ -684,22 +700,17 @@ jobs:
           dokka="$DOKKA_RESULT"
           vanilla="$VANILLA_RESULT"
           deps="$DEPS_RESULT"
-          run="$GATE_RUN"
+          run="$TRIAGE_RUN"
           code="$CODE_CHANGED"
 
-          if [[ "$gate" == "failure" || "$gate" == "cancelled" ]]; then
-            echo "::error::Gate failed ($gate)"
+          if [[ "$triage" == "failure" || "$triage" == "cancelled" ]]; then
+            echo "::error::Triage failed ($triage)"
             exit 1
           fi
 
           if [[ "$run" != "true" ]]; then
             echo "::notice::Skipped (trusted pure Release Please PR)."
             exit 0
-          fi
-
-          if [[ "$changes" == "failure" || "$changes" == "cancelled" ]]; then
-            echo "::error::Change detection failed ($changes)"
-            exit 1
           fi
 
           if [[ "$code" != "true" ]]; then
@@ -732,12 +743,12 @@ jobs:
             exit 1
           fi
 
-          if [[ "$vanilla" == "failure" ]]; then
+          if [[ "$vanilla" != "success" && "$vanilla" != "skipped" ]]; then
             echo "::error::Vanilla conformance: $vanilla"
             exit 1
           fi
 
-          if [[ "$deps" == "failure" ]]; then
+          if [[ "$deps" != "success" && "$deps" != "skipped" ]]; then
             echo "::error::Dependencies: $deps"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,11 +207,11 @@ jobs:
       matrix:
         include:
           - shard: core
-            tasks: :core:koverBinaryReport
+            tasks: :core:koverBinaryReport :core:jar
           - shard: text
-            tasks: :minimessage:koverBinaryReport :serializer:koverBinaryReport
+            tasks: :minimessage:koverBinaryReport :serializer:koverBinaryReport :minimessage:jar :serializer:jar
           - shard: runtime
-            tasks: :coroutines:koverBinaryReport :paper:koverBinaryReport :test:koverBinaryReport :bom:build
+            tasks: :coroutines:koverBinaryReport :paper:koverBinaryReport :test:koverBinaryReport :test-snapshot:koverBinaryReport :bom:build :coroutines:jar :paper:jar :test:jar :test-snapshot:jar
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -240,7 +240,7 @@ jobs:
             echo "tasks=$tasks" >> "$GITHUB_OUTPUT"
             echo "Resolved Gradle tasks: $tasks (from input)"
           elif [[ -n "$module" ]]; then
-            tasks=":${module}:build koverVerify verifyBomConsumerVersionlessDependencies verifyReleaseVersionConsistency koverXmlReport koverHtmlReport dokkaGenerate"
+            tasks=":${module}:build :koverVerify verifyBomConsumerVersionlessDependencies verifyReleaseVersionConsistency :koverXmlReport :koverHtmlReport dokkaGenerate"
             echo "tasks=$tasks" >> "$GITHUB_OUTPUT"
             echo "Resolved Gradle tasks: $tasks (from module)"
           else
@@ -277,15 +277,39 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      - name: Upload Kover binary
+      - name: Stage Kover hand-off
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -rf kover-handoff
+          for module in modules/*; do
+            [ -d "$module/build/kover" ] || continue
+            name=$(basename "$module")
+            dir="kover-handoff/$name"
+            mkdir -p "$dir"
+            cp "$module/build/kover/jvm.artifact" "$dir/" 2>/dev/null || true
+            cp -R "$module/build/kover/bin-reports" "$dir/" 2>/dev/null || true
+            cp -R "$module/build/classes/kotlin/main" "$dir/classes-kotlin-main" 2>/dev/null || true
+            cp -R "$module/build/classes/java/main" "$dir/classes-java-main" 2>/dev/null || true
+            cp -R "$module/build/classes/kotlin/vanillaConformanceTest" "$dir/classes-kotlin-vanillaConformanceTest" 2>/dev/null || true
+            cp -R "$module/build/classes/java/vanillaConformanceTest" "$dir/classes-java-vanillaConformanceTest" 2>/dev/null || true
+          done
+
+      - name: Upload Kover hand-off
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: kover-binary-${{ matrix.shard }}
-          path: |
-            build/kover
-            modules/*/build/kover
-            modules/*/build/tmp/kover
+          name: kover-handoff-${{ matrix.shard }}
+          path: kover-handoff
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload module jars
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: module-jars-${{ matrix.shard }}
+          path: build/libs/kotventure-*.jar
           if-no-files-found: ignore
           retention-days: 7
 
@@ -333,12 +357,44 @@ jobs:
           path: .
           merge-multiple: true
 
-      - name: Download Kover binary
+      - name: Download Kover hand-off
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: kover-binary-*
+          pattern: kover-handoff-*
           path: .
           merge-multiple: true
+
+      - name: Restore Kover data layout
+        run: |
+          set -euo pipefail
+          for module in kover-handoff/*; do
+            [ -d "$module" ] || continue
+            name=$(basename "$module")
+            mkdir -p "modules/$name/build/kover/bin-reports" \
+              "modules/$name/build/classes/kotlin" \
+              "modules/$name/build/classes/java"
+            cp "$module/jvm.artifact" "modules/$name/build/kover/jvm.artifact"
+            if [ -d "$module/bin-reports" ]; then
+              cp -R "$module/bin-reports/." "modules/$name/build/kover/bin-reports/"
+            fi
+            if [ -d "$module/classes-kotlin-main" ]; then
+              mkdir -p "modules/$name/build/classes/kotlin/main"
+              cp -R "$module/classes-kotlin-main/." "modules/$name/build/classes/kotlin/main/"
+            fi
+            if [ -d "$module/classes-java-main" ]; then
+              mkdir -p "modules/$name/build/classes/java/main"
+              cp -R "$module/classes-java-main/." "modules/$name/build/classes/java/main/"
+            fi
+            if [ -d "$module/classes-kotlin-vanillaConformanceTest" ]; then
+              mkdir -p "modules/$name/build/classes/kotlin/vanillaConformanceTest"
+              cp -R "$module/classes-kotlin-vanillaConformanceTest/." "modules/$name/build/classes/kotlin/vanillaConformanceTest/"
+            fi
+            if [ -d "$module/classes-java-vanillaConformanceTest" ]; then
+              mkdir -p "modules/$name/build/classes/java/vanillaConformanceTest"
+              cp -R "$module/classes-java-vanillaConformanceTest/." "modules/$name/build/classes/java/vanillaConformanceTest/"
+            fi
+          done
+          rm -rf kover-handoff
 
       - name: Download durations
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -350,7 +406,7 @@ jobs:
       - name: Generate coverage reports
         uses: ./.github/actions/gradle-job
         with:
-          tasks: koverXmlReport koverHtmlReport koverVerify -x test -x vanillaConformanceTest
+          tasks: :koverXmlReport :koverHtmlReport :koverVerify -Pkover.externalBinariesDir=modules
 
       - name: Collect CI metrics
         run: bash .github/scripts/collect-ci-metrics.sh
@@ -371,11 +427,18 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Download module jars
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: module-jars-*
+          path: module-jars
+          merge-multiple: true
+
       - name: Upload module jars
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: module-jars
-          path: build/libs/kotventure-*.jar
+          path: module-jars/*.jar
           if-no-files-found: ignore
           retention-days: 14
 
@@ -392,6 +455,7 @@ jobs:
             cp ci-metrics.json .ci-baseline/ci-metrics.json
           fi
           cp build/libs/kotventure-*.jar .ci-baseline/libs/ 2>/dev/null || true
+          cp module-jars/kotventure-*.jar .ci-baseline/libs/ 2>/dev/null || true
 
       - name: Cache baseline coverage and jars for PRs
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -399,15 +463,6 @@ jobs:
         with:
           path: .ci-baseline
           key: ci-baseline-${{ github.sha }}
-
-      - name: Upload build artifacts
-        if: failure() || (github.event_name == 'push' && github.ref == 'refs/heads/master')
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: gradle-build-artifacts
-          path: build/libs
-          if-no-files-found: ignore
-          retention-days: 7
 
   dokka:
     name: Dokka

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
   # │ Tier 0: Triage                                                           │
   # ╰──────────────────────────────────────────────────────────────────────────╯
 
-  gate:
-    name: Gate
+  triage:
+    name: Triage
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -58,6 +58,9 @@ jobs:
       release_only: ${{ steps.decide.outputs.release_only }}
       release_candidate: ${{ steps.decide.outputs.release_candidate }}
       documentation_only: ${{ steps.decide.outputs.documentation_only }}
+      code: ${{ steps.resolve.outputs.code }}
+      vanilla: ${{ steps.resolve.outputs.vanilla }}
+      docs_only: ${{ steps.resolve.outputs.documentation_only }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -74,26 +77,9 @@ jobs:
             const { decideGate } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/ci-gate.js`);
             await decideGate({ github, context, core });
 
-  changes:
-    name: Detect changes
-    needs: gate
-    if: needs.gate.outputs.run == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      code: ${{ steps.resolve.outputs.code }}
-      vanilla: ${{ steps.resolve.outputs.vanilla }}
-      documentation_only: ${{ steps.resolve.outputs.documentation_only }}
-    steps:
-      - name: Checkout
-        if: github.event_name == 'pull_request' || github.event_name == 'push'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Path filter
         id: filter
-        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        if: steps.decide.outputs.run == 'true'
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           filters: |
@@ -127,12 +113,13 @@ jobs:
 
       - name: Resolve flags
         id: resolve
+        if: steps.decide.outputs.run == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           FILTER_CODE: ${{ steps.filter.outputs.code }}
           FILTER_VANILLA: ${{ steps.filter.outputs.vanilla }}
-          RELEASE_CANDIDATE: ${{ needs.gate.outputs.release_candidate }}
-          DOCUMENTATION_ONLY: ${{ needs.gate.outputs.documentation_only }}
+          RELEASE_CANDIDATE: ${{ steps.decide.outputs.release_candidate }}
+          DOCUMENTATION_ONLY: ${{ steps.decide.outputs.documentation_only }}
         run: |
           set -euo pipefail
           if [[ "$EVENT_NAME" == "pull_request" && "$RELEASE_CANDIDATE" == "true" ]]; then
@@ -175,8 +162,8 @@ jobs:
 
   lint-kotlin:
     name: Lint (Kotlin)
-    needs: [gate, changes]
-    if: needs.gate.outputs.run == 'true' && needs.changes.outputs.code == 'true'
+    needs: [triage]
+    if: needs.triage.outputs.run == 'true' && needs.triage.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -193,8 +180,8 @@ jobs:
 
   lint-actions:
     name: Lint (Actions)
-    needs: [gate, changes]
-    if: needs.gate.outputs.run == 'true' && needs.changes.outputs.code == 'true'
+    needs: [triage]
+    if: needs.triage.outputs.run == 'true' && needs.triage.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -212,18 +199,18 @@ jobs:
 
   build:
     name: Build (${{ matrix.shard }})
-    needs: [gate, changes]
-    if: needs.gate.outputs.run == 'true' && needs.changes.outputs.code == 'true'
+    needs: [triage]
+    if: needs.triage.outputs.run == 'true' && needs.triage.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
         include:
           - shard: core
-            tasks: :core:test
+            tasks: :core:koverBinaryReport
           - shard: text
-            tasks: :minimessage:test :serializer:test
+            tasks: :minimessage:koverBinaryReport :serializer:koverBinaryReport
           - shard: runtime
-            tasks: :coroutines:test :paper:test :test:test :bom:build
+            tasks: :coroutines:koverBinaryReport :paper:koverBinaryReport :test:koverBinaryReport :bom:build
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -290,11 +277,23 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      - name: Upload Kover binary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kover-binary-${{ matrix.shard }}
+          path: |
+            build/kover
+            modules/*/build/kover
+            modules/*/build/tmp/kover
+          if-no-files-found: ignore
+          retention-days: 7
+
 
   aggregate:
     name: Aggregate
     needs: [build]
-    if: always() && needs.build.result != 'cancelled' && needs.build.result != 'skipped'
+    if: needs.build.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -303,7 +302,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up JDK and Gradle
@@ -316,8 +314,15 @@ jobs:
           path: .
           merge-multiple: true
 
-      - name: Generate coverage and reports
-        run: ./gradlew koverXmlReport koverHtmlReport dokkaGenerate --no-build-cache --rerun-tasks -Pkotlin.incremental=false
+      - name: Download Kover binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: kover-binary-*
+          path: .
+          merge-multiple: true
+
+      - name: Generate coverage reports
+        run: ./gradlew koverXmlReport koverHtmlReport koverVerify
 
       - name: Collect CI metrics
         run: bash .github/scripts/collect-ci-metrics.sh
@@ -384,6 +389,34 @@ jobs:
           path: build/libs
           if-no-files-found: ignore
           retention-days: 7
+
+  dokka:
+    name: Dokka
+    needs: [triage]
+    if: needs.triage.outputs.run == 'true' && needs.triage.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK and Gradle
+        uses: ./.github/actions/setup-jdk-gradle
+
+      - name: Generate Dokka
+        run: ./gradlew dokkaGenerate
+
+      - name: Upload Dokka preview
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dokka-preview
+          path: modules/*/build/dokka/html
+          if-no-files-found: warn
+          retention-days: 14
 
   pr-feedback:
     name: PR feedback
@@ -510,8 +543,8 @@ jobs:
 
   vanilla:
     name: Vanilla conformance
-    needs: [gate, changes]
-    if: needs.gate.outputs.run == 'true' && needs.changes.outputs.vanilla == 'true'
+    needs: [triage]
+    if: needs.triage.outputs.run == 'true' && needs.triage.outputs.vanilla == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -622,23 +655,24 @@ jobs:
   status:
     name: Status
     if: always()
-    needs: [gate, changes, lint-kotlin, lint-actions, build, aggregate, vanilla, dependencies]
+    needs: [triage, lint-kotlin, lint-actions, build, aggregate, dokka, vanilla, dependencies]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Evaluate
         env:
           EVENT_NAME: ${{ github.event_name }}
-          GATE_RESULT: ${{ needs.gate.result }}
-          CHANGES_RESULT: ${{ needs.changes.result }}
+          GATE_RESULT: ${{ needs.triage.result }}
+          CHANGES_RESULT: ${{ needs.triage.result }}
           LINT_KOTLIN_RESULT: ${{ needs.lint-kotlin.result }}
           LINT_ACTIONS_RESULT: ${{ needs.lint-actions.result }}
           BUILD_RESULT: ${{ needs.build.result }}
           AGGREGATE_RESULT: ${{ needs.aggregate.result }}
+          DOKKA_RESULT: ${{ needs.dokka.result }}
           VANILLA_RESULT: ${{ needs.vanilla.result }}
           DEPS_RESULT: ${{ needs.dependencies.result }}
-          GATE_RUN: ${{ needs.gate.outputs.run }}
-          CODE_CHANGED: ${{ needs.changes.outputs.code }}
+          GATE_RUN: ${{ needs.triage.outputs.run }}
+          CODE_CHANGED: ${{ needs.triage.outputs.code }}
         run: |
           set -euo pipefail
           gate="$GATE_RESULT"
@@ -647,6 +681,7 @@ jobs:
           lint_actions="$LINT_ACTIONS_RESULT"
           build="$BUILD_RESULT"
           aggregate="$AGGREGATE_RESULT"
+          dokka="$DOKKA_RESULT"
           vanilla="$VANILLA_RESULT"
           deps="$DEPS_RESULT"
           run="$GATE_RUN"
@@ -689,6 +724,11 @@ jobs:
 
           if [[ "$aggregate" != "success" ]]; then
             echo "::error::Aggregate: $aggregate"
+            exit 1
+          fi
+
+          if [[ "$dokka" != "success" && "$dokka" != "skipped" ]]; then
+            echo "::error::Dokka: $dokka"
             exit 1
           fi
 

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -1,14 +1,14 @@
 name: Qodana
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
+  pull_request_target:
+    branches: [master]
+    types: [opened, synchronize, reopened]
 
 permissions: {}
 
 concurrency:
-  group: qodana-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+  group: qodana-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
   cancel-in-progress: true
 
 env:
@@ -17,9 +17,6 @@ env:
 jobs:
   register:
     name: Register Qodana check
-    if: >-
-      github.event.workflow_run.event == 'pull_request'
-      && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -33,6 +30,7 @@ jobs:
       check_artifact_name: ${{ steps.source.outputs.check_artifact_name }}
       check_external_id: ${{ steps.source.outputs.check_external_id }}
       check_run_id: ${{ steps.source.outputs.check_run_id }}
+      head_repository: ${{ steps.source.outputs.head_repository }}
       head_sha: ${{ steps.source.outputs.head_sha }}
       merge_base_sha: ${{ steps.source.outputs.merge_base_sha }}
       pull_number: ${{ steps.source.outputs.pull_number }}
@@ -44,7 +42,7 @@ jobs:
           ref: ${{ github.sha }}
           persist-credentials: false
 
-      - name: Resolve the completed CI source
+      - name: Resolve the pull-request source
         id: source
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -55,12 +53,12 @@ jobs:
           retries: 3
           retry-exempt-status-codes: 400,401,403,404,422
           script: |
-            const { resolveSource } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-source.js`);
+            const { resolvePullRequestEventSource } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-source.js`);
             const {
               createQodanaCheck,
               writeQodanaCheckRegistration,
             } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-check-registration.js`);
-            const source = await resolveSource({
+            const source = await resolvePullRequestEventSource({
               github,
               context,
               qodanaRunId: Number(process.env.QODANA_RUN_ID),
@@ -69,6 +67,7 @@ jobs:
             core.setOutput('source_kind', source.sourceKind);
             core.setOutput('artifact_name', source.artifactName);
             core.setOutput('pull_number', String(source.pullRequest));
+            core.setOutput('head_repository', source.headRepository);
             core.setOutput('head_sha', source.headSha);
             core.setOutput('base_ref', source.baseRef);
             core.setOutput('merge_base_sha', source.mergeBaseSha || '');
@@ -119,7 +118,7 @@ jobs:
         if: needs.register.outputs.source_kind == 'code'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: ${{ github.repository }}
+          repository: ${{ needs.register.outputs.head_repository }}
           ref: ${{ needs.register.outputs.head_sha }}
           path: source
           fetch-depth: 0

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -38,7 +38,7 @@ CI
 │   └─ CodeQL            (actions + java-kotlin matrix, own workflow `codeql.yml`, parallel with CI)
 │
 ├─ Tier 2: Aggregate (after Build shards) ─────────────────────────
-│   ├─ Aggregate         (merge kover binaries → koverXmlReport/koverHtmlReport/koverVerify, metrics, baseline cache)
+│   ├─ Aggregate         (consume shard Kover hand-off → koverXmlReport/koverHtmlReport/koverVerify, metrics, baseline cache — no test re-run)
 │   │   └─ PR feedback   (read-only metrics computation and result artefact)
 │   └─ (Vanilla/Dokka already completed in Tier 1)
 │
@@ -61,10 +61,14 @@ PR metrics publication (workflow_run)
    └─ Publishes one non-gating metrics comment with default-branch code
 ```
 
-All heavy jobs (`Lint`, `Build` shards, `Vanilla`, `Dokka`, `CodeQL`) start in parallel after `Triage` (gated only on `triage.outputs.code`/`vanilla`), not serially. The Qodana security pipeline starts after successful pull-request
+All heavy jobs (`Lint`, `Build` shards, `Vanilla`, `Dokka`, `CodeQL`) start in parallel after `Triage` (gated only on `triage.outputs.code`/`vanilla`), not serially. Vanilla and CodeQL were already parallel to the build before this change. The Qodana security pipeline starts after successful pull-request
 CI. A documentation-only pull request receives a trusted QDJVM attestation. The attestation does not check out or
-analyse code. This sequence prevents analysis of code that does not compile — heavy jobs run in parallel, but Qodana only publishes after CI succeeds and `Aggregate` merges the binary coverage reports. The Status job always starts.
+analyse code. This sequence prevents analysis of code that does not compile — heavy jobs run in parallel, but Qodana only publishes after CI succeeds and `Aggregate` consumes the shard coverage hand-off. The Status job always starts.
 It reports one required check that controls merges.
+
+Each Build shard executes its tests under Kover and uploads a `kover-handoff-<shard>` artefact with the binary `.ic`
+reports and the compiled classes. `Aggregate` restores that data and generates the XML/HTML reports and the `koverVerify`
+gate from it. It does not re-run tests: the Aggregate Gradle invocation contains no test tasks.
 
 The workflow listens for `merge_group` events. Merge groups, schedules, and manual dispatches do not use the path
 filter. They always start the full pipeline: Build (sharded → Aggregate with `koverVerify` at 85%), Vanilla, Dokka, and CodeQL (own workflow). The `Qodana trusted` workflow analyses a
@@ -75,7 +79,7 @@ contains pull-request code.
 
 ### Path classification
 
-The `gate` job classifies every current and previous pull-request file name. It
+The `Triage` job classifies every current and previous pull-request file name. It
 uses the documentation-only allowlist below. A pull request qualifies for the
 documentation path only when it has at least one file and every file name
 matches one of these patterns:
@@ -126,14 +130,14 @@ Select Actions → **CI** → **Run workflow**. A manual workflow always starts 
 
 | Input | Default | Behaviour |
 |-------|---------|-----------|
-| `tasks` | empty | Default full set: `build dokkaGenerate koverXmlReport koverHtmlReport`. If only `module` is set: `:<module>:build` plus root verification (`koverVerify`, BOM/release checks, Kover reports, Dokka). |
+| `tasks` | empty | The sharded matrix task set (each shard runs `koverBinaryReport` + `jar`), with `dokkaGenerate` in the parallel Dokka job and coverage verification in Aggregate. If only `module` is set: `:<module>:build` plus root verification (`:koverVerify`, BOM/release checks, Kover reports, Dokka). |
 | `module` | empty | Optional project name (`core`, `minimessage`, `bom`, …). Ignored when `tasks` is non-empty. |
 
 Module names must match `[A-Za-z0-9_-]+`.
 
 ### Heavy CI gate (Release Please)
 
-The `gate` job skips resource-intensive jobs only for a trusted Release Please
+The `Triage` job skips resource-intensive jobs only for a trusted Release Please
 pull request. The `release-provenance.yml` workflow supplies the independent
 check from the default branch. It does not check out the pull request.
 
@@ -228,10 +232,12 @@ reports zero alerts. This lets GitHub treat the tool as configured.
 
 ### Full builds
 
-Pull requests, pushes, merge groups, schedules, and manual dispatches use the complete default task set:
-`build dokkaGenerate koverXmlReport koverHtmlReport`. Path filters control whether the full CI pipeline starts. They do
-not control which modules compile. Thus, each code pull request includes the coverage gate, BOM checks, and dependent
-module compilation.
+Pull requests, pushes, merge groups, schedules, and manual dispatches run the complete pipeline. The Build matrix shards
+the work: `core` (`:core:koverBinaryReport` + `:core:jar`), `text` (`minimessage` + `serializer`), and `runtime`
+(`coroutines` + `paper` + `test` + `test-snapshot` + `bom`). Dokka runs in its own parallel job. Aggregate consumes the
+shard coverage hand-off and enforces the 85% `koverVerify` gate. Path filters control whether the full CI pipeline
+starts. They do not control which modules compile. Thus, each code pull request includes the coverage gate, BOM checks,
+and dependent module compilation.
 
 ### Merge queue
 
@@ -345,7 +351,7 @@ repository automation tests use `node --test`.
 | `vanilla-fixture-cache-key.sh` | Compute MC fixture cache key |
 | `download-base-metrics.sh` | PR feedback: fetch base coverage/jars/metrics from the base commit's CI run |
 | `build-base-jars.sh` | PR feedback: last-resort jar-only Gradle build of the base SHA |
-| `collect-ci-metrics.sh` | Aggregate: test/skipped counts + build duration → `ci-metrics.json` |
+| `collect-ci-metrics.sh` | Aggregate: test/skipped counts + maximum shard build duration → `ci-metrics.json` |
 | `pr-metrics-publisher.js` | Trusted workflow_run publisher: validates the source run and renders the metrics comment |
 | `qodana-source.js` | Trusted workflow_run source and path classification for Qodana |
 | `qodana-check-registration.js` | Creates and records the source-bound pull-request Qodana check |
@@ -408,7 +414,7 @@ Pull requests show many checks. Only the checks in the **Master** ruleset block 
 
 | Check | Merge gate | Notes |
 |-------|:----------:|-------|
-| **Status** | **Required** | Aggregates lint, build, vanilla, and dependencies. Green when skipped for docs-only or release-please changes |
+| **Status** | **Required** | Aggregates lint, build, Aggregate coverage, Dokka, vanilla, and dependencies. Green when skipped for docs-only or release-please changes |
 | **Title** | **Required** | Conventional PR title (from `pr.yml`) |
 | **Commits** | **Required** | Conventional commit subjects (from `pr.yml`) |
 | **Dependencies** | **Required** | Dependency review |
@@ -430,18 +436,23 @@ Pull requests show many checks. Only the checks in the **Master** ruleset block 
 | Dependency / wrapper caches | `setup-gradle` defaults in `.github/actions/setup-jdk-gradle` |
 | Minecraft conformance fixtures | Uses `actions/cache`. The key comes from `targetMinecraftVersion` and `serverBundleSha1` |
 | PR metrics baselines | Uses the `actions/cache` key `ci-baseline-<sha>` on a master push. Downloads an artefact as a fallback. Rebuilds the JAR only as the last option |
+| Kover coverage hand-off | Shards upload `kover-handoff-<shard>`; Aggregate restores them and runs `:koverXmlReport :koverHtmlReport :koverVerify -Pkover.externalBinariesDir=modules`. No test re-run in Aggregate |
 
-### Artefacts (Build job)
+### Artefacts
+
+Each Build shard uploads test results (`gradle-test-results-<shard>`, always, including failed runs), a Kover hand-off
+(`kover-handoff-<shard>`, always), module JARs (`module-jars-<shard>`, always when present), and a duration file
+(`gradle-duration-<shard>`).
 
 | Artefact | When |
 |----------|------|
-| Test results / HTML test reports | Always (including failed runs) |
-| Kover coverage report | Always, including failed runs. Retained for 14 days |
-| Module JARs (`module-jars`) | Always when present. Used for PR head metrics and as the base download fallback |
-| CI metrics (`ci-metrics`) | On successful builds. It contains test counts and duration for the PR comment. |
+| Test results / HTML test reports | Always (including failed runs), per shard |
+| Kover hand-off (`kover-handoff-<shard>`) | Always, per shard. Binary `.ic` reports + compiled classes |
+| Module JARs (`module-jars`) | Re-uploaded from the shards by Aggregate. Used for PR head metrics and as the base download fallback |
+| Coverage report (`coverage-report`) | From Aggregate. Generated from the shard hand-off without re-running tests. Retained for 14 days |
+| CI metrics (`ci-metrics`) | From Aggregate. Test counts, skipped count, and the maximum shard build duration |
 | PR metrics result (`pr-metrics-result-<run-id>-<run-attempt>`) | Successful PR feedback computation. Contains only bounded, typed metric data. Retained for one day |
-| Dokka preview | Successful PRs only. Contains rendered KDoc HTML. Retained for 14 days. Treat as untrusted HTML |
-| Full `build/libs` upload | Only on **job failure**, or on **push to `master`** |
+| Dokka preview | Uploaded from the Dokka job on successful PRs only. Contains rendered KDoc HTML. Retained for 14 days. Treat as untrusted HTML |
 
 ## Re-running CI
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -35,7 +35,9 @@ CI
 │   ├─ Build             (sharded: core | text (`minimessage` + `serializer`) | runtime (`coroutines` + `paper` + `test` + `bom`) — each `koverBinaryReport` + test results)
 │   ├─ Vanilla           (MC-backed selector tests, path-filtered)
 │   └─ Dokka             (dokkaGenerate, parallel with Build)
-│   └─ CodeQL            (actions + java-kotlin matrix, own workflow `codeql.yml`, parallel with CI)
+│
+├─ CodeQL (independent workflow `codeql.yml`, parallel with CI) ──
+│   └─ CodeQL            (actions + java-kotlin matrix; own Gate + Detect changes jobs, not gated on Triage)
 │
 ├─ Tier 2: Aggregate (after Build shards) ─────────────────────────
 │   ├─ Aggregate         (consume shard Kover hand-off → koverXmlReport/koverHtmlReport/koverVerify, metrics, baseline cache — no test re-run)
@@ -61,7 +63,7 @@ PR metrics publication (workflow_run)
    └─ Publishes one non-gating metrics comment with default-branch code
 ```
 
-All heavy jobs (`Lint`, `Build` shards, `Vanilla`, `Dokka`, `CodeQL`) start in parallel after `Triage` (gated only on `triage.outputs.code`/`vanilla`), not serially. Vanilla and CodeQL were already parallel to the build before this change. The Qodana security pipeline starts after successful pull-request
+All heavy CI jobs (`Lint`, `Build` shards, `Vanilla`, `Dokka`) start in parallel after `Triage` (gated only on `triage.outputs.code`/`vanilla`), not serially. Vanilla was already parallel to the build before this change. CodeQL runs from its own `codeql.yml` workflow with its own gate and path filter, parallel to CI rather than gated on `Triage`. The Qodana security pipeline starts after successful pull-request
 CI. A documentation-only pull request receives a trusted QDJVM attestation. The attestation does not check out or
 analyse code. This sequence prevents analysis of code that does not compile — heavy jobs run in parallel, but Qodana only publishes after CI succeeds and `Aggregate` consumes the shard coverage hand-off. The Status job always starts.
 It reports one required check that controls merges.
@@ -450,7 +452,7 @@ Each Build shard uploads test results (`gradle-test-results-<shard>`, always, in
 | Kover hand-off (`kover-handoff-<shard>`) | Always, per shard. Binary `.ic` reports + compiled classes |
 | Module JARs (`module-jars`) | Re-uploaded from the shards by Aggregate. Used for PR head metrics and as the base download fallback |
 | Coverage report (`coverage-report`) | From Aggregate. Generated from the shard hand-off without re-running tests. Retained for 14 days |
-| CI metrics (`ci-metrics`) | From Aggregate. Test counts, skipped count, and the maximum shard build duration |
+| CI metrics (`ci-metrics`) | From Aggregate. Test counts, skipped count, and build duration (longest shard + Aggregate coverage stage) |
 | PR metrics result (`pr-metrics-result-<run-id>-<run-attempt>`) | Successful PR feedback computation. Contains only bounded, typed metric data. Retained for one day |
 | Dokka preview | Uploaded from the Dokka job on successful PRs only. Contains rendered KDoc HTML. Retained for 14 days. Treat as untrusted HTML |
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -13,7 +13,7 @@ For local development commands, see [CONTRIBUTING.md](../.github/CONTRIBUTING.md
 | **CI** | `ci.yml` | PR, push, `merge_group`, weekly schedule, `workflow_dispatch` | Gate, path filter, parallel lint (Kotlin + Actions), sharded build (`core | text | runtime` → Aggregate), Vanilla. Always reports the required status check |
 | **CodeQL** | `codeql.yml` | PR, push, `merge_group`, weekly schedule | CodeQL analysis (`actions` + `java-kotlin` matrix), parallel with CI |
 | **PR metrics publication** | `pr-metrics-publish.yml` | `workflow_run` after CI | Validates the CI result and publishes one metrics comment with default-branch code |
-| **Qodana** | `qodana.yml` | `workflow_run` after successful PR CI | Runs Qodana with read-only permissions and creates one bounded SARIF artefact |
+| **Qodana** | `qodana.yml` | `pull_request_target` (in parallel with PR CI) | Runs Qodana with read-only permissions and creates one bounded SARIF artefact |
 | **Qodana publication** | `qodana-publish.yml` | `workflow_run` after Qodana | Validates the current PR and publishes SARIF with default-branch code |
 | **Qodana trusted** | `qodana-trusted.yml` | `workflow_run` after successful push, schedule, or dispatch CI | Runs and publishes Qodana for trusted refs |
 | **PR** | `pr.yml` | `pull_request_target` | Title + commit validation, area labels |
@@ -53,9 +53,9 @@ CI
 └─ Status (required merge-gate check) ─────────────────────────────
     └─ Aggregates Tier 1 + Vanilla + Dependencies
 
-Qodana security pipeline (workflow_run)
+Qodana security pipeline (pull_request_target, parallel with PR CI)
 ├─ Qodana            (read-only PR-head analysis or trusted attestation artefact)
-├─ Qodana publication (default-branch validation and SARIF upload)
+├─ Qodana publication (default-branch validation and SARIF upload, workflow_run after Qodana)
 └─ Qodana trusted    (trusted push, schedule, and dispatch analysis)
 
 PR metrics publication (workflow_run)
@@ -63,10 +63,11 @@ PR metrics publication (workflow_run)
    └─ Publishes one non-gating metrics comment with default-branch code
 ```
 
-All heavy CI jobs (`Lint`, `Build` shards, `Vanilla`, `Dokka`) start in parallel after `Triage` (gated only on `triage.outputs.code`/`vanilla`), not serially. Vanilla was already parallel to the build before this change. CodeQL runs from its own `codeql.yml` workflow with its own gate and path filter, parallel to CI rather than gated on `Triage`. The Qodana security pipeline starts after successful pull-request
-CI. A documentation-only pull request receives a trusted QDJVM attestation. The attestation does not check out or
-analyse code. This sequence prevents analysis of code that does not compile — heavy jobs run in parallel, but Qodana only publishes after CI succeeds and `Aggregate` consumes the shard coverage hand-off. The Status job always starts.
-It reports one required check that controls merges.
+All heavy CI jobs (`Lint`, `Build` shards, `Vanilla`, `Dokka`) start in parallel after `Triage` (gated only on `triage.outputs.code`/`vanilla`), not serially. Vanilla was already parallel to the build before this change. CodeQL runs from its own `codeql.yml` workflow with its own gate and path filter, parallel to CI rather than gated on `Triage`. The Qodana security pipeline triggers on `pull_request_target` and runs in parallel with CI
+from the default branch. A documentation-only pull request receives a trusted QDJVM attestation. The attestation does
+not check out or analyse code. The scan may analyse code before CI finishes; results publish when the scan completes,
+and the merge stays gated on the `Status` check. `Aggregate` consumes the shard coverage hand-off without re-running
+tests. The Status job always starts. It reports one required check that controls merges.
 
 Each Build shard executes its tests under Kover and uploads a `kover-handoff-<shard>` artefact with the binary `.ic`
 reports and the compiled classes. `Aggregate` restores that data and generates the XML/HTML reports and the `koverVerify`
@@ -206,13 +207,13 @@ as a bounded artefact.
 
 A separate registration job creates the `Qodana / pull request` check on the
 validated pull-request head. The check starts with `in_progress`. The read-only
-scan job cannot update it. The registration artefact binds the check to the CI
-run, Qodana run, run attempts, and source commits.
+scan job cannot update it. The registration artefact binds the check to the
+Qodana run, run attempt, and source commits.
 
-The `Qodana publication` workflow checks out the default branch. It validates
-the CI run, current pull request, changed paths, run attempt, head SHA, base
-SHA, artefact name, artefact archive, and SARIF structure. It then normalises
-the SARIF with default-branch code. The upload uses a verified non-Git artefact
+The `Qodana publication` workflow checks out the default branch. It resolves
+the current pull request by head SHA and validates it, the changed paths, the
+Qodana run attempt, head SHA, base SHA, artefact name, artefact archive, and
+SARIF structure. It then normalises the SARIF with default-branch code. The upload uses a verified non-Git artefact
 directory, the validated pull-request head SHA, the stable
 `.github/workflows/ci.yml:qodana` analysis key, and the `Kotventure/qodana`
 category.
@@ -305,7 +306,7 @@ For an occasional diagnostic scan, give `build-scan: true` to `gradle-job`. The 
 | Default workflow permissions | Set the repository default to `contents: read` |
 | Release provenance workflow | Uses `contents: read` and `pull-requests: read`. Does not check out pull-request code |
 | CI gate | Uses `actions: read`, `contents: read`, and `pull-requests: read` |
-| Qodana scan | The registration job adds `checks: write` and creates the source-bound check. The analysis job uses only `actions: read`, `contents: read`, and `pull-requests: read`. It has no write permission, no `QODANA_TOKEN`, and no Qodana GitHub side effects |
+| Qodana scan | Triggers on `pull_request_target` from the default branch and runs in parallel with CI. The registration job adds `checks: write` and creates the source-bound check. The analysis job uses only `actions: read`, `contents: read`, and `pull-requests: read`. It has no write permission, no `QODANA_TOKEN`, and no Qodana GitHub side effects |
 | Qodana publication | Uses `actions: read`, `checks: write`, `contents: read`, `pull-requests: read`, and `security-events: write`. It runs default-branch code, validates the artefacts, uploads SARIF, and completes the source-bound check |
 | Qodana trusted | The registration and report jobs use `checks: write`. The analysis job uses `actions: read`, `contents: read`, and `security-events: write` only for push, schedule, and manual-dispatch refs |
 | Release workflow | Uses an installation token from `release-please-kotventure`. Its `GITHUB_TOKEN` has no permissions |
@@ -355,7 +356,7 @@ repository automation tests use `node --test`.
 | `build-base-jars.sh` | PR feedback: last-resort jar-only Gradle build of the base SHA |
 | `collect-ci-metrics.sh` | Aggregate: test/skipped counts + longest shard and Aggregate coverage durations → `ci-metrics.json` |
 | `pr-metrics-publisher.js` | Trusted workflow_run publisher: validates the source run and renders the metrics comment |
-| `qodana-source.js` | Trusted workflow_run source and path classification for Qodana |
+| `qodana-source.js` | Trusted `pull_request_target` source resolution and path classification for Qodana |
 | `qodana-check-registration.js` | Creates and records the source-bound pull-request Qodana check |
 | `qodana-publisher.js` | Trusted Qodana publication source validation |
 | `qodana-publisher-archive.js` | Bounded single-file SARIF archive extraction |

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -32,7 +32,7 @@ CI
 ├─ Tier 1: Core (parallel, fast feedback — all gated on Triage) ──
 │   ├─ Lint (Kotlin)     (spotlessCheck + ktlintCheck)
 │   ├─ Lint (Actions)    (declaration check + pr-metrics-comment tests)
-│   ├─ Build             (sharded: core | text (`minimessage` + `serializer`) | runtime (`coroutines` + `paper` + `test` + `bom`) — each `koverBinaryReport` + test results)
+│   ├─ Build             (sharded: core | text (`minimessage` + `serializer`) | runtime (`coroutines` + `paper` + `test` + `test-snapshot` + `bom`) — each `koverBinaryReport` + test results)
 │   ├─ Vanilla           (MC-backed selector tests, path-filtered)
 │   └─ Dokka             (dokkaGenerate, parallel with Build)
 │
@@ -353,7 +353,7 @@ repository automation tests use `node --test`.
 | `vanilla-fixture-cache-key.sh` | Compute MC fixture cache key |
 | `download-base-metrics.sh` | PR feedback: fetch base coverage/jars/metrics from the base commit's CI run |
 | `build-base-jars.sh` | PR feedback: last-resort jar-only Gradle build of the base SHA |
-| `collect-ci-metrics.sh` | Aggregate: test/skipped counts + maximum shard build duration → `ci-metrics.json` |
+| `collect-ci-metrics.sh` | Aggregate: test/skipped counts + longest shard and Aggregate coverage durations → `ci-metrics.json` |
 | `pr-metrics-publisher.js` | Trusted workflow_run publisher: validates the source run and renders the metrics comment |
 | `qodana-source.js` | Trusted workflow_run source and path classification for Qodana |
 | `qodana-check-registration.js` | Creates and records the source-bound pull-request Qodana check |

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -26,20 +26,21 @@ For local development commands, see [CONTRIBUTING.md](../.github/CONTRIBUTING.md
 ```
 CI
 │
-├─ Tier 0: Triage ─────────────────────────────────────────────────
-│   ├─ Gate              (verify provenance before a release-only skip; `ci-gate.js`)
-│   └─ Detect changes    (path filter → code, vanilla)
+├─ Triage ─────────────────────────────────────────────────────────
+│   └─ Triage            (gate + path filter → code, vanilla, docs_only — single runner)
 │
-├─ Tier 1: Core (parallel, fast feedback) ─────────────────────────
+├─ Tier 1: Core (parallel, fast feedback — all gated on Triage) ──
 │   ├─ Lint (Kotlin)     (spotlessCheck + ktlintCheck)
 │   ├─ Lint (Actions)    (declaration check + pr-metrics-comment tests)
-│   ├─ Build             (sharded: core | text (`minimessage` + `serializer`) | runtime (`coroutines` + `paper` + `test` + `bom`) → Aggregate)
-│   │   └─ Aggregate     (kover, dokka, metrics, baseline cache — after all shards)
-│   │       └─ PR feedback   (read-only metrics computation and result artefact)
-│   └─ Vanilla           (MC-backed selector tests, path-filtered, parallel with Tier 1)
+│   ├─ Build             (sharded: core | text (`minimessage` + `serializer`) | runtime (`coroutines` + `paper` + `test` + `bom`) — each `koverBinaryReport` + test results)
+│   ├─ Vanilla           (MC-backed selector tests, path-filtered)
+│   └─ Dokka             (dokkaGenerate, parallel with Build)
+│   └─ CodeQL            (actions + java-kotlin matrix, own workflow `codeql.yml`, parallel with CI)
 │
-├─ CodeQL (parallel with CI) ──────────────────────────────────────
-│   └─ CodeQL            (actions + java-kotlin matrix, own workflow `codeql.yml`)
+├─ Tier 2: Aggregate (after Build shards) ─────────────────────────
+│   ├─ Aggregate         (merge kover binaries → koverXmlReport/koverHtmlReport/koverVerify, metrics, baseline cache)
+│   │   └─ PR feedback   (read-only metrics computation and result artefact)
+│   └─ (Vanilla/Dokka already completed in Tier 1)
 │
 ├─ Policy (independent of tiers) ──────────────────────────────────
 │   ├─ Dependencies      (dependency-review-action, PRs only)
@@ -60,13 +61,13 @@ PR metrics publication (workflow_run)
    └─ Publishes one non-gating metrics comment with default-branch code
 ```
 
-Vanilla and CodeQL start in parallel with Tier 1 (gated only on `changes` + `gate`), not after Tier 1. The Qodana security pipeline starts after successful pull-request
+All heavy jobs (`Lint`, `Build` shards, `Vanilla`, `Dokka`, `CodeQL`) start in parallel after `Triage` (gated only on `triage.outputs.code`/`vanilla`), not serially. The Qodana security pipeline starts after successful pull-request
 CI. A documentation-only pull request receives a trusted QDJVM attestation. The attestation does not check out or
-analyse code. This sequence prevents analysis of code that does not compile — Tier 2 still runs in parallel, but Qodana only publishes after CI succeeds. The Status job always starts.
+analyse code. This sequence prevents analysis of code that does not compile — heavy jobs run in parallel, but Qodana only publishes after CI succeeds and `Aggregate` merges the binary coverage reports. The Status job always starts.
 It reports one required check that controls merges.
 
 The workflow listens for `merge_group` events. Merge groups, schedules, and manual dispatches do not use the path
-filter. They always start the full pipeline: Build (sharded), Vanilla, and CodeQL (own workflow). The `Qodana trusted` workflow analyses a
+filter. They always start the full pipeline: Build (sharded → Aggregate with `koverVerify` at 85%), Vanilla, Dokka, and CodeQL (own workflow). The `Qodana trusted` workflow analyses a
 push, schedule, or manual-dispatch ref after CI completes. It does not run for a merge-group ref because a merge group
 contains pull-request code.
 

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -5,6 +5,10 @@
 // aggregated HTML/XML output lands in `build/reports/kover/`; `./gradlew koverHtmlReport`
 // generates it locally.
 //
+// With the `-Pkover.externalBinariesDir=<dir>` property (CI Aggregate job), the report is
+// generated from binary `.ic` coverage reports produced by the build shards instead of from
+// `kover` project dependencies. This consumes existing coverage without re-running tests.
+//
 // Coverage threshold policy
 // -------------------------
 // Baseline: 85% line coverage. The project is pre-alpha, but every behavioural change ships
@@ -14,10 +18,17 @@
 // any threshold change in the PR description so reviewers are not surprised by a CI failure.
 def coverageLineThreshold = 85
 
-dependencies {
-    subprojects
-            .findAll { subproject -> subproject.name != 'bom' }
-            .each { subproject -> kover subproject }
+def externalBinariesDir = providers.gradleProperty('kover.externalBinariesDir').orNull
+if (externalBinariesDir != null) {
+    dependencies {
+        add('kover', fileTree(externalBinariesDir) { include '**/*.artifact' })
+    }
+} else {
+    dependencies {
+        subprojects
+                .findAll { subproject -> subproject.name != 'bom' }
+                .each { subproject -> kover subproject }
+    }
 }
 
 kover {

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -5,10 +5,6 @@
 // aggregated HTML/XML output lands in `build/reports/kover/`; `./gradlew koverHtmlReport`
 // generates it locally.
 //
-// With the `-Pkover.externalBinariesDir=<dir>` property (CI Aggregate job), the report is
-// generated from binary `.ic` coverage reports produced by the build shards instead of from
-// `kover` project dependencies. This consumes existing coverage without re-running tests.
-//
 // Coverage threshold policy
 // -------------------------
 // Baseline: 85% line coverage. The project is pre-alpha, but every behavioural change ships


### PR DESCRIPTION
## Summary

Reduce the CI critical path to the required `Status` merge gate. The build is sharded, Dokka runs in parallel, and the coverage stage consumes the shards' Kover binary reports instead of re-running tests. The final coverage report and the 85% `koverVerify` threshold are unchanged; the DAG and measurements below are from real runs.

## CI DAG

```
Before (master @ PR #511)
Gate → Detect changes → parallel [Lint Kotlin, Lint Actions, Build core, Build text, Build runtime, Vanilla]
  → Aggregate (re-ran ALL tests + vanilla conformance + Dokka, cold)
  → Status

After (this PR)
Triage (Gate + path filter, one runner)
  → parallel [Lint Kotlin, Lint Actions, Build core, Build text, Build runtime, Vanilla, Dokka]
  → Aggregate (consumes shard Kover hand-off; zero test tasks)
  → Status
```

`CodeQL`, `Dependencies`, `Commits`, and PR-metrics publication keep their existing independent workflows. Qodana now triggers on `pull_request_target` and runs in parallel with PR CI (the trusted publication and trusted-ref paths are unchanged). `Status` stays the single required check.

## Optimisations

- **Combined Triage** — the former serial `Gate` → `Detect changes` pair is one `triage` job: gate decision, path filter, and output resolution in a single runner.
- **Path filter scope** — `dorny/paths-filter` runs only for `pull_request` and `push`. `merge_group`, `schedule`, and `workflow_dispatch` keep the fail-closed full pipeline (`code=true`, `vanilla=true`, `documentation_only=false`) without depending on path filtering.
- **Build sharding** — `core | text | runtime` shards run `koverBinaryReport` (which executes the tests) plus the module `jar` tasks; `test-snapshot` joined the runtime shard so its coverage stays in the report.
- **Parallel Dokka** — `dokkaGenerate` runs in its own job; the Dokka preview artefact is uploaded from that job only (one owner). Aggregate no longer generates or uploads Dokka.
- **Kover coverage hand-off** — shards upload `kover-handoff-<shard>` (Kover `.ic` binary reports + compiled classes + `jvm.artifact` manifests). Aggregate restores them into `modules/*/build/kover` and runs `:koverXmlReport :koverHtmlReport :koverVerify -Pkover.externalBinariesDir=modules`. The reports and the 85% gate are generated from the shard data with **zero test execution in Aggregate**.
- **Failed-build Aggregate skip** — Aggregate runs only when `needs.build.result == 'success'`. A failed build skips Aggregate but still fails `Status` (which gates on the build result directly).
- **Caching** — removed the forced-cold Aggregate flags (`--no-build-cache --rerun-tasks -Pkotlin.incremental=false`). Normal Gradle cache and configuration-cache behaviour is used everywhere.
- **Checkout depth** — shallow checkout where jobs do not need Git history; `fetch-depth: 0` remains where it is used (Lint Kotlin/spotless ratchet, Commits job).
- **CI metrics** — `ci-metrics.json` regains a valid `durationSeconds`: the longest shard build plus the Aggregate coverage build (the sequential build time on the critical path), with the test count re-derived from the downloaded per-shard JUnit XMLs.
- **Parallel Qodana** — the pull-request scan moves from `workflow_run` after successful CI to `pull_request_target` (`opened`/`synchronize`/`reopened`), so the scan starts immediately, in parallel with CI, instead of waiting for CI to finish. The register job resolves the PR source from the event and re-validates it via the API; the analysis checkouts use the validated head repository, which also fixes fork-PR scans. Artifact names bind to the Qodana run and source SHAs (no CI-run segment). The result publishes when the scan completes regardless of the CI outcome; merges stay gated on `Status`.

## Correctness safeguards

- Coverage threshold retained: `koverVerify` enforces the same 85% line rule on the merged report.
- Release Please trust retained: `ci-gate.js` gate decision and the release-only skip are unchanged.
- Merge queue retained: `merge_group` triggers the full pipeline.
- Qodana trust boundaries retained: default-branch code for the scan and publication, read-only scan permissions, no secrets/`QODANA_TOKEN`, and the trusted `workflow_run` publication with `security-events: write` are unchanged.
- Dependency review retained.
- CodeQL Kotlin analysis retained (`java-kotlin`, `build-mode: manual`) — `codeql.yml` is untouched.
- Single required `Status` check retained, fail-closed on Triage/build failure.

## Measurements

From live runs (wall-clock to `Status` completion):

| Stage | master @ PR #511 (run 31419624171) | This PR (run 31429421717) |
|---|---|---|
| Gate/Triage | 18:33:31 → 18:33:38 (7s) | 20:31:13 → 20:31:20 (7s) |
| Lint (Kotlin) | 18:33:47 → 18:34:24 (37s) | 20:31:22 → 20:31:57 (35s) |
| Build shards | 32–43s | 64–97s |
| Vanilla | 36s | 37s |
| Dokka | inside Aggregate | 20:31:22 → 20:33:00 (98s, parallel) |
| Aggregate | 18:34:33 → 18:38:11 (3m38s, 84 tasks, re-ran all tests + Dokka) | 20:33:08 → 20:34:08 (60s, 7 tasks, **0 test tasks**) |
| **Status** | **18:38:16 (4m45s total)** | **20:34:13 (3m00s total)** |

Required-CI wall-clock: **~4m45s → ~3m00s** (about 1m45s faster). The Aggregate Gradle invocation executes zero test tasks; coverage equals the master baseline (552 classes, 94% line coverage, gate at 85%). Runner-minutes increase slightly (extra parallel jobs); the optimisation target is wall-clock latency.

The `pull_request_target` trigger executes the workflow file from the default branch, so the parallel Qodana scan activates on the first PR event after this PR merges; until then the legacy `workflow_run` path keeps running unchanged (verified green on the final commit).

Closes #511 follow-up.


