### PR TITLE
refactor(ci): share validation helpers

### DIFF
--- a/.github/scripts/pr-metrics-publisher-validation.js
+++ b/.github/scripts/pr-metrics-publisher-validation.js
@@ -9,6 +9,7 @@ const {
     RESULT_ARTIFACT_PREFIX,
     WORKFLOW_NAME,
 } = require('./pr-metrics-publisher-contract.js');
+const { createValidators } = require('./shared/validation.js');
 
 class PublicationRejectedError extends Error {
     constructor(message) {
@@ -21,42 +22,12 @@ function reject(message) {
     throw new PublicationRejectedError(message);
 }
 
-function requireEqual(actual, expected, label) {
-    if (actual !== expected) {
-        reject(`${label} does not match the trusted value`);
-    }
-
-    return actual;
-}
-
-function requireSafeInteger(
-        value,
-        label,
-        minimum = 1,
-        maximum = Number.MAX_SAFE_INTEGER
-) {
-    if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
-        reject(`${label} is invalid`);
-    }
-
-    return value;
-}
-
-function requireObject(value, label) {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-        reject(`${label} is missing`);
-    }
-
-    return value;
-}
-
-function requireString(value, label) {
-    if (typeof value !== 'string' || value.length === 0) {
-        reject(`${label} is invalid`);
-    }
-
-    return value;
-}
+const {
+    requireEqual,
+    requireInteger: requireSafeInteger,
+    requireObject,
+    requireString,
+} = createValidators(reject);
 
 function expectedArtifactName({ runId, runAttempt }) {
     const id = requireSafeInteger(runId, 'workflow run id');

--- a/.github/scripts/qodana-contract.js
+++ b/.github/scripts/qodana-contract.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { createValidators } = require('./shared/validation.js');
+
 const CI_WORKFLOW_NAME = 'CI';
 const CI_WORKFLOW_PATH = '.github/workflows/ci.yml';
 const QODANA_WORKFLOW_NAME = 'Qodana';
@@ -28,7 +30,12 @@ const DOCUMENTATION_PATH_PATTERNS = [
   /^assets\/.+\.(?:svg|png|jpe?g|gif|webp)$/i,
 ];
 
-const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const {
+  requireInteger: requirePositiveInteger,
+  requireSha,
+} = createValidators((message) => {
+  throw new Error(message);
+});
 
 function isSafeRepositoryPath(name) {
   return typeof name === 'string'
@@ -77,20 +84,6 @@ function classifyChangedFiles(files) {
     return 'release-candidate';
   }
   return 'code';
-}
-
-function requireSha(value, label) {
-  if (typeof value !== 'string' || !SHA_PATTERN.test(value)) {
-    throw new Error(`${label} is invalid`);
-  }
-  return value;
-}
-
-function requirePositiveInteger(value, label) {
-  if (!Number.isSafeInteger(value) || value < 1) {
-    throw new Error(`${label} is invalid`);
-  }
-  return value;
 }
 
 function buildArtifactName({

--- a/.github/scripts/qodana-publisher-validation.js
+++ b/.github/scripts/qodana-publisher-validation.js
@@ -9,6 +9,7 @@ const {
   QODANA_WORKFLOW_PATH,
   parseArtifactName,
 } = require('./qodana-contract.js');
+const { createValidators } = require('./shared/validation.js');
 
 class QodanaPublicationRejectedError extends Error {}
 
@@ -16,32 +17,12 @@ function reject(message) {
   throw new QodanaPublicationRejectedError(message);
 }
 
-function requireObject(value, label) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    reject(`${label} is missing`);
-  }
-  return value;
-}
-
-function requireEqual(actual, expected, label) {
-  if (actual !== expected) {
-    reject(`${label} does not match the trusted value`);
-  }
-}
-
-function requirePositiveInteger(value, label) {
-  if (!Number.isSafeInteger(value) || value < 1) {
-    reject(`${label} is invalid`);
-  }
-  return value;
-}
-
-function requireSha(value, label) {
-  if (typeof value !== 'string' || !/^[0-9a-f]{40}$/.test(value)) {
-    reject(`${label} is invalid`);
-  }
-  return value;
-}
+const {
+  requireEqual,
+  requireInteger: requirePositiveInteger,
+  requireObject,
+  requireSha,
+} = createValidators(reject);
 
 function validateQodanaWorkflowSource({ eventRun, run, workflow, repository }) {
   requireObject(eventRun, 'workflow_run event');

--- a/.github/scripts/qodana-publisher.js
+++ b/.github/scripts/qodana-publisher.js
@@ -7,13 +7,10 @@ const {
   validateQodanaArtifactSource,
   validateQodanaWorkflowSource,
 } = require('./qodana-publisher-validation.js');
-
-function requireObject(value, label) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new QodanaPublicationRejectedError(`${label} is missing`);
-  }
-  return value;
-}
+const { createValidators } = require('./shared/validation.js');
+const { requireObject } = createValidators((message) => {
+  throw new QodanaPublicationRejectedError(message);
+});
 
 async function resolvePublication({ github, context }) {
   const eventRun = requireObject(context.payload?.workflow_run, 'workflow_run event');

--- a/.github/scripts/qodana-source.js
+++ b/.github/scripts/qodana-source.js
@@ -6,6 +6,7 @@ const {
   buildArtifactName,
   classifyChangedFiles,
 } = require('./qodana-contract.js');
+const { createValidators } = require('./shared/validation.js');
 
 class QodanaSourceRejectedError extends Error {
   constructor(message, { stale = false } = {}) {
@@ -19,32 +20,12 @@ function reject(message, stale = false) {
   throw new QodanaSourceRejectedError(message, { stale });
 }
 
-function requireObject(value, label) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    reject(`${label} is missing`);
-  }
-  return value;
-}
-
-function requireEqual(actual, expected, label, stale = false) {
-  if (actual !== expected) {
-    reject(`${label} does not match the trusted value`, stale);
-  }
-}
-
-function requirePositiveInteger(value, label) {
-  if (!Number.isSafeInteger(value) || value < 1) {
-    reject(`${label} is invalid`);
-  }
-  return value;
-}
-
-function requireSha(value, label) {
-  if (typeof value !== 'string' || !/^[0-9a-f]{40}$/.test(value)) {
-    reject(`${label} is invalid`);
-  }
-  return value;
-}
+const {
+  requireEqual,
+  requireInteger: requirePositiveInteger,
+  requireObject,
+  requireSha,
+} = createValidators(reject);
 
 function repositoryName(repository) {
   requireObject(repository, 'repository');

--- a/.github/scripts/shared/validation.js
+++ b/.github/scripts/shared/validation.js
@@ -1,0 +1,56 @@
+'use strict';
+
+function createValidators(reject) {
+  function requireObject(value, label) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      reject(`${label} is missing`);
+    }
+    return value;
+  }
+
+  function requireEqual(actual, expected, label, stale = false) {
+    if (actual !== expected) {
+      reject(`${label} does not match the trusted value`, stale);
+    }
+    return actual;
+  }
+
+  function requireInteger(value, label, minimum = 1, maximum = Number.MAX_SAFE_INTEGER) {
+    if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+      reject(`${label} is invalid`);
+    }
+    return value;
+  }
+
+  function requireString(value, label) {
+    if (typeof value !== 'string' || value.length === 0) {
+      reject(`${label} is invalid`);
+    }
+    return value;
+  }
+
+  function requireText(value, label, maximumLength) {
+    if (typeof value !== 'string' || value.length < 1 || value.length > maximumLength) {
+      reject(`${label} is invalid`);
+    }
+    return value;
+  }
+
+  function requireSha(value, label) {
+    if (typeof value !== 'string' || !/^[0-9a-f]{40}$/.test(value)) {
+      reject(`${label} is invalid`);
+    }
+    return value;
+  }
+
+  return {
+    requireEqual,
+    requireInteger,
+    requireObject,
+    requireSha,
+    requireString,
+    requireText,
+  };
+}
+
+module.exports = { createValidators };

--- a/.github/scripts/workflow-run-check.js
+++ b/.github/scripts/workflow-run-check.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const { createValidators } = require('./shared/validation.js');
+
 const KIND_PATTERN = /^[a-z0-9-]{1,48}$/;
 const EXTERNAL_ID_PREFIX = 'workflow-run-check';
 const CHECK_APP_SLUG = 'github-actions';
@@ -12,39 +13,15 @@ const WORKFLOW_RESULTS = new Set([
   'timed_out',
 ]);
 
-function requireObject(value, label) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error(`${label} is missing`);
-  }
-  return value;
-}
-
-function requirePositiveInteger(value, label) {
-  if (!Number.isSafeInteger(value) || value < 1) {
-    throw new Error(`${label} is invalid`);
-  }
-  return value;
-}
-
-function requireSha(value, label) {
-  if (typeof value !== 'string' || !SHA_PATTERN.test(value)) {
-    throw new Error(`${label} is invalid`);
-  }
-  return value;
-}
-
-function requireText(value, label, maximumLength) {
-  if (typeof value !== 'string' || value.length < 1 || value.length > maximumLength) {
-    throw new Error(`${label} is invalid`);
-  }
-  return value;
-}
-
-function requireEqual(actual, expected, label) {
-  if (actual !== expected) {
-    throw new Error(`${label} does not match the trusted value`);
-  }
-}
+const {
+  requireEqual,
+  requireInteger: requirePositiveInteger,
+  requireObject,
+  requireSha,
+  requireText,
+} = createValidators((message) => {
+  throw new Error(message);
+});
 
 function workflowRunUrl(context) {
   const serverUrl = requireText(context?.serverUrl, 'GitHub server URL', 512);


### PR DESCRIPTION
## Summary

Extract the five copy-pasted `require*` validation helper sets — in `qodana-source.js`, `qodana-publisher-validation.js`, `pr-metrics-publisher-validation.js`, `workflow-run-check.js`, `qodana-contract.js`, and `qodana-publisher.js` — into a single `createValidators(reject)` factory in `.github/scripts/shared/validation.js`.

First PR of a stacked series; base is post-#514 `master`.

## Behaviour

- **Zero behaviour change.** Message templates (`${label} is invalid`, `${label} is missing`, `${label} does not match the trusted value`) are preserved exactly; each pipeline keeps its own error type and `reject` function.
- `requirePositiveInteger` / `requireSafeInteger` call sites use `requireInteger(value, label)`.
- `requireEqual` still forwards `stale` to `reject` (the Qodana source resolver needs it).
- Deliberately left local: the full-message `requirePositiveInteger` in `pr-metrics-publisher.js` (unique full-sentence wording) and the ZIP range helper in `qodana-publisher-archive.js`.

## Validation

- 116/116 node tests pass (full suite, unchanged).
- `git diff --check` clean.
