### PR TITLE
fix(ci): accept stacked pull requests for Qodana

### DIFF
--- a/.github/scripts/qodana-security.test.js
+++ b/.github/scripts/qodana-security.test.js
@@ -45,6 +45,7 @@ const HEAD_REPOSITORY = {
 };
 
 function makePullRequest({
+  baseRef = REPOSITORY.default_branch,
   files = [{ filename: 'src/Main.kt' }],
   state = 'open',
   baseSha = BASE_SHA,
@@ -58,7 +59,7 @@ function makePullRequest({
     changed_files: files.length,
     base: {
       repo: REPOSITORY,
-      ref: 'master',
+      ref: baseRef,
       sha: baseSha,
     },
     head: {
@@ -668,6 +669,39 @@ test('resolves same-repository and fork pull-request heads', async () => {
     headSha: HEAD_SHA,
   });
   assert.equal(source.headRepository, forkRepository.full_name);
+  assert.equal(source.headSha, HEAD_SHA);
+});
+
+test('accepts stacked pull requests whose base is another feature branch', async () => {
+  const stackedBase = 'chore/ci-shared-validation';
+  const pullRequest = makePullRequest({ baseRef: stackedBase });
+  const source = await resolvePullRequestSource({
+    github: makeGithub({ pullRequest }),
+    owner: 'LMLiam',
+    repo: 'Kotventure',
+    headSha: HEAD_SHA,
+  });
+  assert.equal(source.sourceKind, 'code');
+  assert.equal(source.baseRef, stackedBase);
+  assert.equal(source.baseSha, BASE_SHA);
+  assert.equal(source.pullRequest, 42);
+});
+
+test('registers a stacked pull request from the pull_request_target event', async () => {
+  const stackedBase = 'chore/ci-shared-validation';
+  const pullRequest = makePullRequest({ baseRef: stackedBase });
+  const source = await resolvePullRequestEventSource({
+    github: makeGithub({ pullRequest }),
+    context: {
+      repo: { owner: 'LMLiam', repo: 'Kotventure' },
+      payload: { pull_request: pullRequest },
+    },
+    qodanaRunId: QODANA_RUN_ID,
+    qodanaRunAttempt: QODANA_RUN_ATTEMPT,
+  });
+  assert.equal(source.sourceKind, 'code');
+  assert.equal(source.baseRef, stackedBase);
+  assert.equal(source.pullRequest, 42);
   assert.equal(source.headSha, HEAD_SHA);
 });
 

--- a/.github/scripts/qodana-source.js
+++ b/.github/scripts/qodana-source.js
@@ -202,7 +202,6 @@ function validatePullRequestState({
   requireEqual(pullRequest.state, 'open', 'pull request state', true);
   requireEqual(pullRequest.base?.repo?.full_name, repository.full_name, 'pull request base repository', true);
   requireEqual(pullRequest.base?.repo?.id, repository.id, 'pull request base repository id', true);
-  requireEqual(pullRequest.base?.ref, repository.default_branch, 'pull request base branch', true);
   requireSha(pullRequest.base?.sha, 'pull request base SHA');
   requireSha(pullRequest.head?.sha, 'pull request head SHA');
   if (expectedHeadSha != null) {
@@ -277,7 +276,6 @@ async function findPullRequestForHeadSha({ github, owner, repo, repository, head
     ? associatedPullRequests.filter((pullRequest) => pullRequest?.state === 'open'
       && pullRequest.base?.repo?.full_name === repository.full_name
       && pullRequest.base?.repo?.id === repository.id
-      && pullRequest.base?.ref === repository.default_branch
       && pullRequest.head?.sha === headSha)
     : [];
   if (matchingPullRequests.length !== 1) {
@@ -323,7 +321,6 @@ async function resolvePullRequestEventSource({ github, context, qodanaRunId, qod
   const repository = await fetchRepository({ github, owner, repo });
   requireEqual(pullRequestEvent.base?.repo?.full_name, repository.full_name, 'pull request base repository');
   requireEqual(pullRequestEvent.base?.repo?.id, repository.id, 'pull request base repository id');
-  requireEqual(pullRequestEvent.base?.ref, repository.default_branch, 'pull request base branch');
   const pullNumber = requirePositiveInteger(pullRequestEvent.number, 'pull request number');
   const response = await github.rest.pulls.get({ owner, repo, pull_number: pullNumber });
   const pullRequest = requireObject(response.data, 'pull request');


### PR DESCRIPTION
## Problem

The Qodana `pull_request_target` pipeline rejects any PR whose base branch is not the repository default branch:

```
QodanaSourceRejectedError: pull request base branch does not match the trusted value
```

Stacked PRs (via `gh stack`) legitimately target another PR branch as their base — e.g. PR #516 is based on `chore/ci-shared-validation`. The register job rejected the source, so the Qodana scan never ran and the Qodana check failed.

## Fix

Remove the base-branch-equals-default-branch requirement from the three PR-source validation sites in `qodana-source.js`:

1. `validatePullRequestState` — the `pull request base branch` equality check
2. `findPullRequestForHeadSha` — the base-branch filter
3. `resolvePullRequestEventSource` — the event-payload base-branch check

## Security boundaries retained

- **Base repository identity** (`full_name` + `id`) is still required — a PR must target the trusted repository.
- **Base SHA binding** — `expectedBaseSha` staleness handling and descriptor base-SHA equality are unchanged.
- **Head SHA binding** — open-state + head-SHA staleness checks unchanged.
- **Release Please** — `hasTrustedReleaseMetadata` still requires `base.ref === default_branch` (line 82), so only genuine master-targeting Release Please PRs take the trusted release path.
- **Trusted CI runs** — `resolveTrustedCiRun` still requires the default branch for push/schedule/dispatch (line 374).

The base *branch name* was never a security boundary on its own — the repo identity and SHA bindings are. Requiring it broke legitimate stacked PRs.

## Tests

- `makePullRequest` fixture gains a `baseRef` option.
- New tests: `resolvePullRequestSource` and `resolvePullRequestEventSource` both accept a PR based on another feature branch.
- 118/118 node tests pass (was 116).