### PR TITLE
fix(ci): publish Qodana results for pull_request_target runs

### DIFF
--- a/.github/scripts/qodana-publisher-validation.js
+++ b/.github/scripts/qodana-publisher-validation.js
@@ -54,7 +54,7 @@ function validateQodanaWorkflowSource({ eventRun, run, workflow, repository }) {
   if (eventRun.workflow_id != null) {
     requireEqual(eventRun.workflow_id, run.workflow_id, 'workflow run workflow id');
   }
-  requireEqual(eventRun.event, 'workflow_run', 'workflow run event');
+  requireEqual(eventRun.event, 'pull_request_target', 'workflow run event');
   requireEqual(eventRun.status, 'completed', 'workflow run event status');
   requireEqual(eventRun.conclusion, run.conclusion, 'workflow run event conclusion');
   requireEqual(run.event, 'pull_request_target', 'workflow run event');

--- a/.github/scripts/qodana-security.test.js
+++ b/.github/scripts/qodana-security.test.js
@@ -218,7 +218,7 @@ function makePublicationGithub({
     id: qodanaRun.id,
     run_attempt: qodanaRun.run_attempt,
     workflow_id: qodanaRun.workflow_id,
-    event: 'workflow_run',
+    event: qodanaRun.event,
     status: qodanaRun.status,
     conclusion: qodanaRun.conclusion,
   };


### PR DESCRIPTION
## Problem

Every Qodana **publication** run has failed since #514 merged:

```
Qodana publication rejected: workflow run event does not match the trusted value
```

The publication validates the triggering Qodana run's event in two places:

- `run.event` (the run fetched from the API) — expects `pull_request_target` (updated by #514)
- `eventRun.event` (the same run from the `workflow_run` webhook payload) — still expects `workflow_run` (missed by #514)

Both describe the same run, whose event is now `pull_request_target`. The stale check rejected every publication, so the SARIF never reached code scanning. The ruleset's `code_scanning` rule then blocked every PR merge with "Code scanning is waiting for results from QDJVM" even though Qodana analysis completed successfully.

The test fixture encoded the same stale `workflow_run` value, which is why the suite stayed green while production failed.

## Fix

- `qodana-publisher-validation.js` — expect `pull_request_target` for the webhook-payload event check, matching the API-side check.
- `qodana-security.test.js` — the `workflow_run` payload fixture now derives its event from the run it describes, so the test exercises the real event value.

## Validation

- 114/114 node tests pass.
- `actionlint` clean; `git diff --check` clean.
