### PR TITLE
refactor(ci): share path classification

### DIFF
--- a/.github/scripts/ci-gate.js
+++ b/.github/scripts/ci-gate.js
@@ -1,26 +1,9 @@
 'use strict';
 
-const RELEASE_ONLY_FILES = new Set([
-  'CHANGELOG.md',
-  '.release-please-manifest.json',
-  'gradle/libs.versions.toml',
-]);
-
-const DOCUMENTATION_PATH_PATTERNS = [
-  /^README\.md$/,
-  /^LICENSE\.md$/,
-  /^AGENTS\.md$/,
-  /^docs\/.+$/,
-  /^\.github\/(?:CONTRIBUTING|SUPPORT)\.md$/,
-  /^\.github\/pull_request_template\.md$/,
-  /^\.github\/(?:PULL_REQUEST_TEMPLATE|ISSUE_TEMPLATE)\/[^/]+$/,
-  /^modules\/[^/]+\/README\.md$/,
-  /^assets\/.+\.(?:svg|png|jpe?g|gif|webp)$/i,
-];
-
-function isDocumentationPath(name) {
-  return DOCUMENTATION_PATH_PATTERNS.some((pattern) => pattern.test(name));
-}
+const {
+  RELEASE_ONLY_FILES,
+  isDocumentationPath,
+} = require('./shared/path-classification.js');
 
 function setAlways(core, documentationOnly = false) {
   core.setOutput('run', 'true');
@@ -185,7 +168,6 @@ async function decideGate({ github, context, core }) {
 }
 
 module.exports = {
-  DOCUMENTATION_PATH_PATTERNS,
   RELEASE_ONLY_FILES,
   decideGate,
   isDocumentationPath,

--- a/.github/scripts/qodana-contract.js
+++ b/.github/scripts/qodana-contract.js
@@ -1,6 +1,14 @@
 'use strict';
 
 const { createValidators } = require('./shared/validation.js');
+const {
+  DOCUMENTATION_PATH_PATTERNS,
+  RELEASE_ONLY_FILES,
+  changedPathNames,
+  classifyChangedFiles,
+  isDocumentationPath,
+  isSafeRepositoryPath,
+} = require('./shared/path-classification.js');
 
 const CI_WORKFLOW_NAME = 'CI';
 const CI_WORKFLOW_PATH = '.github/workflows/ci.yml';
@@ -12,79 +20,12 @@ const MAX_ARTIFACT_BYTES = 16 * 1024 * 1024;
 const MAX_SARIF_BYTES = 16 * 1024 * 1024;
 const MAX_SARIF_RESULTS = 50_000;
 
-const RELEASE_ONLY_FILES = new Set([
-  'CHANGELOG.md',
-  '.release-please-manifest.json',
-  'gradle/libs.versions.toml',
-]);
-
-const DOCUMENTATION_PATH_PATTERNS = [
-  /^README\.md$/,
-  /^LICENSE\.md$/,
-  /^AGENTS\.md$/,
-  /^docs\/.+$/,
-  /^\.github\/(?:CONTRIBUTING|SUPPORT)\.md$/,
-  /^\.github\/pull_request_template\.md$/,
-  /^\.github\/(?:PULL_REQUEST_TEMPLATE|ISSUE_TEMPLATE)\/[^/]+$/,
-  /^modules\/[^/]+\/README\.md$/,
-  /^assets\/.+\.(?:svg|png|jpe?g|gif|webp)$/i,
-];
-
 const {
   requireInteger: requirePositiveInteger,
   requireSha,
 } = createValidators((message) => {
   throw new Error(message);
 });
-
-function isSafeRepositoryPath(name) {
-  return typeof name === 'string'
-    && name.length > 0
-    && !name.includes('\\')
-    && !name.startsWith('/')
-    && !name.split('/').includes('..')
-    && !name.includes('\u0000');
-}
-
-function isDocumentationPath(name) {
-  return isSafeRepositoryPath(name)
-    && DOCUMENTATION_PATH_PATTERNS.some((pattern) => pattern.test(name));
-}
-
-function changedPathNames(files) {
-  if (!Array.isArray(files) || files.length === 0) {
-    return null;
-  }
-
-  const paths = [];
-  for (const file of files) {
-    if (!file || typeof file.filename !== 'string' || file.filename.length === 0) {
-      return null;
-    }
-    paths.push(file.filename);
-    if (file.previous_filename != null) {
-      if (typeof file.previous_filename !== 'string' || file.previous_filename.length === 0) {
-        return null;
-      }
-      paths.push(file.previous_filename);
-    }
-  }
-  return paths;
-}
-
-function classifyChangedFiles(files) {
-  const paths = changedPathNames(files);
-  if (!paths) {
-    return 'code';
-  }
-  if (paths.every(isDocumentationPath)) {
-    return 'documentation';
-  }
-  if (paths.every((name) => isSafeRepositoryPath(name) && RELEASE_ONLY_FILES.has(name))) {
-    return 'release-candidate';
-  }
-  return 'code';
-}
 
 function buildArtifactName({
   sourceKind,

--- a/.github/scripts/shared/path-classification.js
+++ b/.github/scripts/shared/path-classification.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const RELEASE_ONLY_FILES = new Set([
+  'CHANGELOG.md',
+  '.release-please-manifest.json',
+  'gradle/libs.versions.toml',
+]);
+
+const DOCUMENTATION_PATH_PATTERNS = [
+  /^README\.md$/,
+  /^LICENSE\.md$/,
+  /^AGENTS\.md$/,
+  /^docs\/.+$/,
+  /^\.github\/(?:CONTRIBUTING|SUPPORT)\.md$/,
+  /^\.github\/pull_request_template\.md$/,
+  /^\.github\/(?:PULL_REQUEST_TEMPLATE|ISSUE_TEMPLATE)\/[^/]+$/,
+  /^modules\/[^/]+\/README\.md$/,
+  /^assets\/.+\.(?:svg|png|jpe?g|gif|webp)$/i,
+];
+
+function isSafeRepositoryPath(name) {
+  return typeof name === 'string'
+    && name.length > 0
+    && !name.includes('\\')
+    && !name.startsWith('/')
+    && !name.split('/').includes('..')
+    && !name.includes('\u0000');
+}
+
+function isDocumentationPath(name) {
+  return isSafeRepositoryPath(name)
+    && DOCUMENTATION_PATH_PATTERNS.some((pattern) => pattern.test(name));
+}
+
+function changedPathNames(files) {
+  if (!Array.isArray(files) || files.length === 0) {
+    return null;
+  }
+
+  const paths = [];
+  for (const file of files) {
+    if (!file || typeof file.filename !== 'string' || file.filename.length === 0) {
+      return null;
+    }
+    paths.push(file.filename);
+    if (file.previous_filename != null) {
+      if (typeof file.previous_filename !== 'string' || file.previous_filename.length === 0) {
+        return null;
+      }
+      paths.push(file.previous_filename);
+    }
+  }
+  return paths;
+}
+
+function classifyChangedFiles(files) {
+  const paths = changedPathNames(files);
+  if (!paths) {
+    return 'code';
+  }
+  if (paths.every(isDocumentationPath)) {
+    return 'documentation';
+  }
+  if (paths.every((name) => isSafeRepositoryPath(name) && RELEASE_ONLY_FILES.has(name))) {
+    return 'release-candidate';
+  }
+  return 'code';
+}
+
+module.exports = {
+  DOCUMENTATION_PATH_PATTERNS,
+  RELEASE_ONLY_FILES,
+  changedPathNames,
+  classifyChangedFiles,
+  isDocumentationPath,
+  isSafeRepositoryPath,
+};


### PR DESCRIPTION
## Summary

Move the path-classification helpers out of `qodana-contract.js` into a shared `.github/scripts/shared/path-classification.js`, and switch the CI gate to the shared implementation.

The new shared module owns:

- `RELEASE_ONLY_FILES`, `DOCUMENTATION_PATH_PATTERNS`
- `isSafeRepositoryPath`, `isDocumentationPath`
- `changedPathNames`, `classifyChangedFiles`

`qodana-contract.js` re-exports these names unchanged, so `qodana-source.js`, the publishers, and the test suites keep working. `ci-gate.js` now imports `isDocumentationPath` and `RELEASE_ONLY_FILES` from the shared module and deletes its local copies.

Stacked on #522.

## Behaviour

- **Fail-closed tightening in the CI gate.** `ci-gate.js`'s local `isDocumentationPath` lacked the `isSafeRepositoryPath` guard, so an unsafe name like `docs/../.github/workflows/ci.yml` matched `/^docs\/.+/` and was classified documentation-only. The shared classifier rejects such names, routing them to full CI — matching what the Qodana classifier already does.
- Qodana pipeline behaviour is unchanged (the shared functions are verbatim moves; `qodana-contract.js` keeps every export).

## Validation

- 117/117 node tests pass.
- `git diff --check` clean; every touched file passes `node --check`.
- Classification smoke test passes (documentation, release-candidate, code, unsafe-path routing).

Net: **−89 lines** in `ci-gate.js` + `qodana-contract.js`, replaced by the 79-line shared module.
