### PR TITLE
refactor(ci): share Release Please provenance lookup

### DIFF
--- a/.github/scripts/ci-gate.js
+++ b/.github/scripts/ci-gate.js
@@ -4,6 +4,7 @@ const {
   RELEASE_ONLY_FILES,
   isDocumentationPath,
 } = require('./shared/path-classification.js');
+const { findReleaseProvenanceRun } = require('./shared/release-provenance.js');
 
 function setAlways(core, documentationOnly = false) {
   core.setOutput('run', 'true');
@@ -94,33 +95,18 @@ async function decideGate({ github, context, core }) {
     return;
   }
 
-  const findProvenanceRun = async () => {
-    const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      workflow_id: 'release-provenance.yml',
-      event: 'pull_request_target',
-      per_page: 100,
-    });
-
-    return runs
-      .filter((run) => {
-        const associatedPullRequests = run.pull_requests || [];
-        return run.event === 'pull_request_target'
-          && run.head_sha === pullRequest.head.sha
-          && run.head_branch === pullRequest.head.ref
-          && (associatedPullRequests.length === 0
-            || associatedPullRequests.some(
-              (candidate) => candidate.number === pullRequest.number,
-            ));
-      })
-      .sort((left, right) => new Date(right.created_at) - new Date(left.created_at))[0];
-  };
-
   let provenanceRun;
   try {
     for (let attempt = 0; attempt < 6; attempt += 1) {
-      provenanceRun = await findProvenanceRun();
+      provenanceRun = await findReleaseProvenanceRun({
+        github,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        repository,
+        headSha: pullRequest.head.sha,
+        headRef: pullRequest.head.ref,
+        pullNumber: pullRequest.number,
+      });
       if (provenanceRun?.status === 'completed' || attempt === 5) {
         break;
       }

--- a/.github/scripts/qodana-source.js
+++ b/.github/scripts/qodana-source.js
@@ -8,6 +8,7 @@ const {
 } = require('./qodana-contract.js');
 const { createValidators } = require('./shared/validation.js');
 const { validateEventRun } = require('./shared/run-context.js');
+const { hasTrustedReleaseProvenance } = require('./shared/release-provenance.js');
 
 class QodanaSourceRejectedError extends Error {
   constructor(message, { stale = false } = {}) {
@@ -66,93 +67,6 @@ function hasTrustedReleaseMetadata({ repository, pullRequest }) {
     && pullRequest.head?.ref === 'release-please--branches--master'
     && pullRequest.user?.login === 'release-please-kotventure[bot]'
     && pullRequest.user?.type === 'Bot';
-}
-
-async function readTrustedReleaseProvenance({ github, owner, repo, repository, pullRequest }) {
-  let workflow;
-  try {
-    const response = await github.rest.actions.getWorkflow({
-      owner,
-      repo,
-      workflow_id: 'release-provenance.yml',
-    });
-    workflow = requireObject(response.data, 'release provenance workflow');
-  } catch {
-    return 'missing';
-  }
-  if (workflow.path !== '.github/workflows/release-provenance.yml') {
-    return 'missing';
-  }
-
-  let runs;
-  try {
-    runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
-      owner,
-      repo,
-      workflow_id: 'release-provenance.yml',
-      event: 'pull_request_target',
-      per_page: 100,
-    });
-  } catch {
-    return 'missing';
-  }
-
-  const candidate = runs
-    .filter((run) => {
-      const associatedPullRequests = Array.isArray(run?.pull_requests) ? run.pull_requests : [];
-      return run?.event === 'pull_request_target'
-        && run.repository?.full_name === repository.full_name
-        && run.head_sha === pullRequest.head.sha
-        && run.head_branch === pullRequest.head.ref
-        && (associatedPullRequests.length === 0
-          || associatedPullRequests.some((item) => item.number === pullRequest.number));
-    })
-    .sort((left, right) => new Date(right.created_at) - new Date(left.created_at))[0];
-
-  if (!candidate) {
-    return 'missing';
-  }
-  if (candidate.status !== 'completed') {
-    return 'pending';
-  }
-  if (candidate.conclusion !== 'success') {
-    return 'failed';
-  }
-
-  let jobs;
-  try {
-    jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
-      owner,
-      repo,
-      run_id: candidate.id,
-      per_page: 100,
-    });
-  } catch {
-    return 'missing';
-  }
-  const trustedJob = jobs.find((job) => job?.name === 'Trusted release provenance');
-  if (trustedJob?.status === 'completed' && trustedJob.conclusion === 'success') {
-    return 'success';
-  }
-  return trustedJob?.status === 'completed' ? 'failed' : 'pending';
-}
-
-function wait(milliseconds) {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
-
-async function hasTrustedReleaseProvenance(options) {
-  const attempts = options.waitForReleaseProvenance === false ? 1 : 6;
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    const status = await readTrustedReleaseProvenance(options);
-    if (status === 'success' || status === 'failed') {
-      return status === 'success';
-    }
-    if (attempt + 1 < attempts) {
-      await wait(10_000);
-    }
-  }
-  return false;
 }
 
 async function resolveMergeBase({ github, owner, repo, baseSha, headSha }) {

--- a/.github/scripts/shared/release-provenance.js
+++ b/.github/scripts/shared/release-provenance.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const { createValidators } = require('./validation.js');
+
+const RELEASE_PROVENANCE_WORKFLOW_ID = 'release-provenance.yml';
+const RELEASE_PROVENANCE_WORKFLOW_PATH = '.github/workflows/release-provenance.yml';
+const TRUSTED_PROVENANCE_JOB_NAME = 'Trusted release provenance';
+
+const { requireObject } = createValidators((message) => {
+  throw new Error(message);
+});
+
+async function findReleaseProvenanceRun({
+  github,
+  owner,
+  repo,
+  repository,
+  headSha,
+  headRef,
+  pullNumber,
+}) {
+  const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+    owner,
+    repo,
+    workflow_id: RELEASE_PROVENANCE_WORKFLOW_ID,
+    event: 'pull_request_target',
+    per_page: 100,
+  });
+  const repositoryName = typeof repository === 'string' ? repository : repository?.full_name;
+
+  return runs
+    .filter((run) => {
+      const associatedPullRequests = Array.isArray(run?.pull_requests) ? run.pull_requests : [];
+      return run?.event === 'pull_request_target'
+        && run.repository?.full_name === repositoryName
+        && run.head_sha === headSha
+        && run.head_branch === headRef
+        && (associatedPullRequests.length === 0
+          || associatedPullRequests.some((item) => item.number === pullNumber));
+    })
+    .sort((left, right) => new Date(right.created_at) - new Date(left.created_at))[0];
+}
+
+async function readTrustedReleaseProvenance({ github, owner, repo, repository, pullRequest }) {
+  let workflow;
+  try {
+    const response = await github.rest.actions.getWorkflow({
+      owner,
+      repo,
+      workflow_id: RELEASE_PROVENANCE_WORKFLOW_ID,
+    });
+    workflow = requireObject(response.data, 'release provenance workflow');
+  } catch {
+    return 'missing';
+  }
+  if (workflow.path !== RELEASE_PROVENANCE_WORKFLOW_PATH) {
+    return 'missing';
+  }
+
+  let candidate;
+  try {
+    candidate = await findReleaseProvenanceRun({
+      github,
+      owner,
+      repo,
+      repository,
+      headSha: pullRequest.head.sha,
+      headRef: pullRequest.head.ref,
+      pullNumber: pullRequest.number,
+    });
+  } catch {
+    return 'missing';
+  }
+
+  if (!candidate) {
+    return 'missing';
+  }
+  if (candidate.status !== 'completed') {
+    return 'pending';
+  }
+  if (candidate.conclusion !== 'success') {
+    return 'failed';
+  }
+
+  let jobs;
+  try {
+    jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+      owner,
+      repo,
+      run_id: candidate.id,
+      per_page: 100,
+    });
+  } catch {
+    return 'missing';
+  }
+  const trustedJob = jobs.find((job) => job?.name === TRUSTED_PROVENANCE_JOB_NAME);
+  if (trustedJob?.status === 'completed' && trustedJob.conclusion === 'success') {
+    return 'success';
+  }
+  return trustedJob?.status === 'completed' ? 'failed' : 'pending';
+}
+
+function wait(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function hasTrustedReleaseProvenance(options) {
+  const attempts = options.waitForReleaseProvenance === false ? 1 : 6;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const status = await readTrustedReleaseProvenance(options);
+    if (status === 'success' || status === 'failed') {
+      return status === 'success';
+    }
+    if (attempt + 1 < attempts) {
+      await wait(10_000);
+    }
+  }
+  return false;
+}
+
+module.exports = {
+  findReleaseProvenanceRun,
+  hasTrustedReleaseProvenance,
+  readTrustedReleaseProvenance,
+};


### PR DESCRIPTION
## Summary

Move the Release Please provenance lookup into a shared `.github/scripts/shared/release-provenance.js`, used by both the Qodana source resolver and the CI gate.

The shared module owns:

- `findReleaseProvenanceRun` — lists `release-provenance.yml` runs, filters to the matching `pull_request_target` run (event, head SHA, head branch, pull request, and repository), newest first
- `readTrustedReleaseProvenance` — returns `missing` / `pending` / `failed` / `success` after verifying the workflow path and the `Trusted release provenance` job
- `hasTrustedReleaseProvenance` — 1 attempt when not waiting, else 6 × 10 s

`qodana-source.js` imports `hasTrustedReleaseProvenance` from the shared module (still re-exported). `ci-gate.js` delegates its provenance-run lookup to `findReleaseProvenanceRun` and keeps its own control flow (try/catch → full CI).

Stacked on #524.

## Behaviour

- **Fail-closed tightening in the CI gate.** The shared filter checks `run.repository.full_name` against the base repository; `ci-gate.js`'s local lookup lacked that check. Provenance runs for `pull_request_target` always carry the base repository, so legitimate Release Please PRs still match — this only rejects unexpected runs.
- Qodana pipeline behaviour is unchanged (the shared functions are verbatim moves; `qodana-source.js` keeps every export).

## Validation

- 117/117 node tests pass.
- `git diff --check` clean; every touched file passes `node --check`.
- Provenance smoke test passes (object and string repository forms, `success`/`missing` statuses).

Net: **−111 lines** in `ci-gate.js` + `qodana-source.js`, replaced by the 104-line shared module.
