### PR TITLE
chore(ci): harden zip entry counting and drop dead artifact fallback

### DIFF
--- a/.github/actions/pr-metrics-comment/lib/collect.js
+++ b/.github/actions/pr-metrics-comment/lib/collect.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const fs = require('fs');
+const { parseCoverage } = require('./coverage.js');
+const { collectJars } = require('./jars.js');
+const { parsePatches } = require('./patch.js');
+const { computePatchCoverage } = require('./patch-coverage.js');
+const { computeApiSurface } = require('./api-surface.js');
+const { serializeMetricsResult } = require('./metrics-result.js');
+
+function readCoverage(reportPath) {
+  if (!reportPath || !fs.existsSync(reportPath)) {
+    return null;
+  }
+  return parseCoverage(fs.readFileSync(reportPath, 'utf8'));
+}
+
+function readMetrics(metricsPath) {
+  if (!metricsPath || !fs.existsSync(metricsPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(metricsPath, 'utf8'));
+    return Number.isFinite(parsed.tests) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchPatches({ github, context, core }) {
+  try {
+    const files = await github.paginate(github.rest.pulls.listFiles, {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: context.issue.number,
+      per_page: 100,
+    });
+    return parsePatches(files);
+  } catch (error) {
+    core.info(`Could not list PR files: ${error.message}`);
+    return null;
+  }
+}
+
+async function collect({ env, context, github, core }) {
+  const outputPath = env.OUTPUT_PATH;
+  if (!outputPath) {
+    throw new Error('OUTPUT_PATH is required');
+  }
+
+  const headCoverage = readCoverage(env.HEAD_COVERAGE_PATH);
+  const baseCoverage = readCoverage(env.BASE_COVERAGE_PATH);
+  const headJars = collectJars(env.HEAD_LIBS_DIR);
+  const baseJars = collectJars(env.BASE_LIBS_DIR);
+
+  if (!headCoverage && headJars.size === 0) {
+    core.warning('No head coverage report or JARs found; skipping metrics result');
+    return null;
+  }
+
+  const patches = await fetchPatches({ github, context, core });
+  return serializeMetricsResult({
+    context,
+    runId: env.RUN_ID,
+    runAttempt: env.RUN_ATTEMPT,
+    headCoverage,
+    baseCoverage,
+    headJars,
+    baseJars,
+    headMetrics: readMetrics(env.HEAD_METRICS_PATH),
+    baseMetrics: readMetrics(env.BASE_METRICS_PATH),
+    patchCoverage: patches && headCoverage ? computePatchCoverage(patches, headCoverage.files) : null,
+    apiSurface: patches ? computeApiSurface(patches) : null,
+  });
+}
+
+module.exports = { collect };

--- a/.github/actions/pr-metrics-comment/lib/main.js
+++ b/.github/actions/pr-metrics-comment/lib/main.js
@@ -1,77 +1,14 @@
 'use strict';
 
 const fs = require('fs');
-const { parseCoverage } = require('./coverage.js');
-const { collectJars } = require('./jars.js');
-const { parsePatches } = require('./patch.js');
-const { computePatchCoverage } = require('./patch-coverage.js');
-const { computeApiSurface } = require('./api-surface.js');
-const { serializeMetricsResult } = require('./metrics-result.js');
-
-function readCoverage(reportPath) {
-  if (!reportPath || !fs.existsSync(reportPath)) {
-    return null;
-  }
-  return parseCoverage(fs.readFileSync(reportPath, 'utf8'));
-}
-
-function readMetrics(metricsPath) {
-  if (!metricsPath || !fs.existsSync(metricsPath)) {
-    return null;
-  }
-  try {
-    const parsed = JSON.parse(fs.readFileSync(metricsPath, 'utf8'));
-    return Number.isFinite(parsed.tests) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
-async function fetchPatches({ github, context, core }) {
-  try {
-    const files = await github.paginate(github.rest.pulls.listFiles, {
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      pull_number: context.issue.number,
-      per_page: 100,
-    });
-    return parsePatches(files);
-  } catch (error) {
-    core.info(`Could not list PR files: ${error.message}`);
-    return null;
-  }
-}
+const { collect } = require('./collect.js');
 
 module.exports = async function run({ github, context, core }) {
-  const outputPath = process.env.OUTPUT_PATH;
-  if (!outputPath) {
-    throw new Error('OUTPUT_PATH is required');
-  }
-
-  const headCoverage = readCoverage(process.env.HEAD_COVERAGE_PATH);
-  const baseCoverage = readCoverage(process.env.BASE_COVERAGE_PATH);
-  const headJars = collectJars(process.env.HEAD_LIBS_DIR);
-  const baseJars = collectJars(process.env.BASE_LIBS_DIR);
-
-  if (!headCoverage && headJars.size === 0) {
-    core.warning('No head coverage report or JARs found; skipping metrics result');
+  const result = await collect({ env: process.env, context, github, core });
+  if (result === null) {
     return;
   }
-
-  const patches = await fetchPatches({ github, context, core });
-  const result = serializeMetricsResult({
-    context,
-    runId: process.env.RUN_ID,
-    runAttempt: process.env.RUN_ATTEMPT,
-    headCoverage,
-    baseCoverage,
-    headJars,
-    baseJars,
-    headMetrics: readMetrics(process.env.HEAD_METRICS_PATH),
-    baseMetrics: readMetrics(process.env.BASE_METRICS_PATH),
-    patchCoverage: patches && headCoverage ? computePatchCoverage(patches, headCoverage.files) : null,
-    apiSurface: patches ? computeApiSurface(patches) : null,
-  });
+  const outputPath = process.env.OUTPUT_PATH;
   fs.writeFileSync(outputPath, JSON.stringify(result), 'utf8');
   core.info(`Wrote PR metrics result to ${outputPath}`);
 };

--- a/.github/actions/pr-metrics-comment/lib/zip.js
+++ b/.github/actions/pr-metrics-comment/lib/zip.js
@@ -8,7 +8,11 @@ const CENTRAL_HEADER_SIZE = 46;
 function findEocd(buffer) {
   const start = Math.max(0, buffer.length - EOCD_MIN_SIZE - 0xffff);
   for (let i = buffer.length - EOCD_MIN_SIZE; i >= start; i--) {
-    if (buffer.readUInt32LE(i) === EOCD_SIG) {
+    if (buffer.readUInt32LE(i) !== EOCD_SIG) {
+      continue;
+    }
+    const commentLength = buffer.readUInt16LE(i + 20);
+    if (i + EOCD_MIN_SIZE + commentLength === buffer.length) {
       return i;
     }
   }
@@ -35,11 +39,15 @@ function countClassEntries(buffer) {
     const nameLength = buffer.readUInt16LE(offset + 28);
     const extraLength = buffer.readUInt16LE(offset + 30);
     const commentLength = buffer.readUInt16LE(offset + 32);
+    const recordEnd = offset + CENTRAL_HEADER_SIZE + nameLength + extraLength + commentLength;
+    if (recordEnd > buffer.length) {
+      return null;
+    }
     const name = buffer.toString('utf8', offset + CENTRAL_HEADER_SIZE, offset + CENTRAL_HEADER_SIZE + nameLength);
     if (name.endsWith('.class')) {
       classes += 1;
     }
-    offset += CENTRAL_HEADER_SIZE + nameLength + extraLength + commentLength;
+    offset = recordEnd;
   }
   return classes;
 }

--- a/.github/actions/pr-metrics-comment/test/zip.test.js
+++ b/.github/actions/pr-metrics-comment/test/zip.test.js
@@ -29,3 +29,14 @@ test('returns null when the central directory is corrupt', () => {
   zip.writeUInt32LE(0xdeadbeef, 10);
   assert.equal(countClassEntries(zip), null);
 });
+
+test('returns null when trailing data follows the end record', () => {
+  const zip = buildZip(['a.class']);
+  assert.equal(countClassEntries(Buffer.concat([zip, Buffer.from('trailing')])), null);
+});
+
+test('returns null when a central directory record overflows the buffer', () => {
+  const zip = buildZip(['a.class']);
+  zip.writeUInt16LE(0xffff, 10 + 28);
+  assert.equal(countClassEntries(zip), null);
+});

--- a/.github/scripts/download-base-metrics.sh
+++ b/.github/scripts/download-base-metrics.sh
@@ -92,42 +92,38 @@ restore_file_artifact() {
 }
 
 restore_jars() {
-    local artifact download_dir destination
-    local artifact_names=(
-        module-jars
-        gradle-build-artifacts
-    )
+    local artifact='module-jars'
+    local download_dir destination
 
-    for artifact in "${artifact_names[@]}"; do
-        download_dir="$download_root/$artifact"
-        mkdir -p -- "$download_dir"
+    download_dir="$download_root/$artifact"
+    mkdir -p -- "$download_dir"
 
-        if ! gh run download "$run_id" --name "$artifact" --dir "$download_dir"; then
+    if ! gh run download "$run_id" --name "$artifact" --dir "$download_dir"; then
+        warn 'could not restore module JARs from any supported artifact'
+        return 1
+    fi
+
+    local jars=("$download_dir"/**/kotventure-*.jar)
+
+    if (( ${#jars[@]} == 0 )); then
+        warn 'could not restore module JARs from any supported artifact'
+        return 1
+    fi
+
+    mkdir -p -- "$JARS_DIR"
+
+    for jar in "${jars[@]}"; do
+        destination="$JARS_DIR/${jar##*/}"
+
+        if [[ -e $destination ]]; then
+            warn "not overwriting existing JAR: $destination"
             continue
         fi
 
-        local jars=("$download_dir"/**/kotventure-*.jar)
-
-        (( ${#jars[@]} > 0 )) || continue
-
-        mkdir -p -- "$JARS_DIR"
-
-        for jar in "${jars[@]}"; do
-            destination="$JARS_DIR/${jar##*/}"
-
-            if [[ -e $destination ]]; then
-                warn "not overwriting existing JAR: $destination"
-                continue
-            fi
-
-            cp -- "$jar" "$destination"
-        done
-
-        return 0
+        cp -- "$jar" "$destination"
     done
 
-    warn 'could not restore module JARs from any supported artifact'
-    return 1
+    return 0
 }
 
 if (( need_coverage )); then


### PR DESCRIPTION
## Summary

Three small cleanups in the CI scripts and the PR-metrics action library.

- **`lib/zip.js` hardening** — `findEocd` now requires the end record to end exactly at the buffer (`offset + 22 + commentLength === buffer.length`), and the central-directory walk bounds each record by `46 + nameLength + extraLength + commentLength` before reading the entry name. These are the same checks the strict archive extractor applies, now also enforced by the class-entry counter used by `lib/jars.js`.
- **`download-base-metrics.sh`** — `restore_jars` drops the `gradle-build-artifacts` fallback. No workflow uploads an artifact with that name; Aggregate always uploads `module-jars` on success, so the fallback is dead. The function now tries `module-jars` only, keeping the same failure contract (`warn` + non-zero exit).
- **`lib/main.js` thinning** — env reading and result collection move to a new `lib/collect.js` (`collect({ env, context, github, core })` → result or `null`); `main.js` is now a thin entry that wires `process.env`, calls `collect`, and writes the output file. The action's invocation contract is unchanged.

Stacked on #526.

## Behaviour

- Zero behaviour change. The `OUTPUT_PATH is required` throw, the `No head coverage report or JARs found` skip, and all written result content are identical.
- The zip checks reject only malformed archives (trailing data after the end record, or a central-directory record that overflows the buffer) — fail-closed, matching the strict extractor.

## Validation

- 119/119 node tests pass, including two new `zip.test.js` cases for the hardened checks.
- `bash -n .github/scripts/download-base-metrics.sh` passes.
- `git diff --check` clean.
