### PR TITLE
chore(ci): tidy guards and harden download option validation

### DIFF
--- a/.github/actions/pr-metrics-comment/lib/api-surface.js
+++ b/.github/actions/pr-metrics-comment/lib/api-surface.js
@@ -21,11 +21,7 @@ function cancelPairs(added, removed) {
   const kept = [];
   for (const sig of added) {
     const idx = remaining.indexOf(sig);
-    if (idx >= 0) {
-      remaining.splice(idx, 1);
-    } else {
-      kept.push(sig);
-    }
+    if (idx >= 0) remaining.splice(idx, 1); else kept.push(sig);
   }
   return { added: kept, removed: remaining };
 }
@@ -34,9 +30,7 @@ function computeApiSurface(patches) {
   const addedAll = [];
   const removedAll = [];
   for (const patch of patches) {
-    if (!MAIN_SOURCE.test(patch.path)) {
-      continue;
-    }
+    if (!MAIN_SOURCE.test(patch.path)) continue;
     addedAll.push(...declarationsIn(patch.addedLines.map((l) => l.text)));
     removedAll.push(...declarationsIn(patch.removedText));
   }

--- a/.github/actions/pr-metrics-comment/lib/collect.js
+++ b/.github/actions/pr-metrics-comment/lib/collect.js
@@ -40,9 +40,7 @@ async function fetchPatches({ github, context, core }) {
 
 async function collect({ env, context, github, core }) {
   const outputPath = env.OUTPUT_PATH;
-  if (!outputPath) {
-    throw new Error('OUTPUT_PATH is required');
-  }
+  if (!outputPath) throw new Error('OUTPUT_PATH is required');
 
   const headCoverage = readCoverage(env.HEAD_COVERAGE_PATH);
   const baseCoverage = readCoverage(env.BASE_COVERAGE_PATH);

--- a/.github/actions/pr-metrics-comment/lib/collect.js
+++ b/.github/actions/pr-metrics-comment/lib/collect.js
@@ -9,16 +9,12 @@ const { computeApiSurface } = require('./api-surface.js');
 const { serializeMetricsResult } = require('./metrics-result.js');
 
 function readCoverage(reportPath) {
-  if (!reportPath || !fs.existsSync(reportPath)) {
-    return null;
-  }
+  if (!reportPath || !fs.existsSync(reportPath)) return null;
   return parseCoverage(fs.readFileSync(reportPath, 'utf8'));
 }
 
 function readMetrics(metricsPath) {
-  if (!metricsPath || !fs.existsSync(metricsPath)) {
-    return null;
-  }
+  if (!metricsPath || !fs.existsSync(metricsPath)) return null;
   try {
     const parsed = JSON.parse(fs.readFileSync(metricsPath, 'utf8'));
     return Number.isFinite(parsed.tests) ? parsed : null;

--- a/.github/actions/pr-metrics-comment/lib/comment.js
+++ b/.github/actions/pr-metrics-comment/lib/comment.js
@@ -3,9 +3,7 @@
 const MARKER = '<!-- pr-metrics -->';
 
 async function upsertComment({ github, context, body, pullNumber = context.issue.number }) {
-  if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
-    throw new Error('pullNumber must be a positive integer');
-  }
+  if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) throw new Error('pullNumber must be a positive integer');
   const fullBody = `${MARKER}\n${body}`.trimEnd() + '\n';
   const comments = await github.paginate(github.rest.issues.listComments, {
     owner: context.repo.owner,

--- a/.github/actions/pr-metrics-comment/lib/coverage.js
+++ b/.github/actions/pr-metrics-comment/lib/coverage.js
@@ -30,9 +30,7 @@ function sourcefileLines(packageName, packageBody, files) {
     while ((lineMatch = lineRegex.exec(sourcefileMatch[2])) !== null) {
       lines.set(parseInt(lineMatch[1], 10), parseInt(lineMatch[3], 10) > 0);
     }
-    if (lines.size > 0) {
-      files.set(`${packageName}/${sourcefileMatch[1]}`, lines);
-    }
+    if (lines.size > 0) files.set(`${packageName}/${sourcefileMatch[1]}`, lines);
   }
 }
 
@@ -44,13 +42,9 @@ function parseCoverage(xml) {
   while ((packageMatch = packageRegex.exec(xml)) !== null) {
     sourcefileLines(packageMatch[1], packageMatch[2], files);
     const counters = packageLineCounter(packageMatch[2]);
-    if (!counters) {
-      continue;
-    }
+    if (!counters) continue;
     const moduleName = moduleFromPackage(packageMatch[1]);
-    if (!modules.has(moduleName)) {
-      modules.set(moduleName, { missed: 0, covered: 0 });
-    }
+    if (!modules.has(moduleName)) modules.set(moduleName, { missed: 0, covered: 0 });
     const entry = modules.get(moduleName);
     entry.missed += counters.missed;
     entry.covered += counters.covered;

--- a/.github/actions/pr-metrics-comment/lib/coverage.js
+++ b/.github/actions/pr-metrics-comment/lib/coverage.js
@@ -5,13 +5,9 @@ const { sanitizeModule } = require('./names.js');
 function moduleFromPackage(pkg) {
   const parts = pkg.split('/');
   const kotIdx = parts.indexOf('kotventure');
-  if (kotIdx < 0) {
-    return sanitizeModule(parts[0] || 'unknown');
-  }
+  if (kotIdx < 0) return sanitizeModule(parts[0] || 'unknown');
   const after = parts.slice(kotIdx + 1);
-  if (after[0] === 'test' && after[1] === 'snapshot') {
-    return 'test-snapshot';
-  }
+  if (after[0] === 'test' && after[1] === 'snapshot') return 'test-snapshot';
   return sanitizeModule(after[0] || 'unknown');
 }
 
@@ -20,9 +16,7 @@ function packageLineCounter(packageBody) {
     .replace(/<class[\s\S]*?<\/class>/g, '')
     .replace(/<sourcefile[\s\S]*?<\/sourcefile>/g, '');
   const match = stripped.match(/<counter type="LINE" missed="(\d+)" covered="(\d+)"\/>/);
-  if (!match) {
-    return null;
-  }
+  if (!match) return null;
   return { missed: parseInt(match[1], 10), covered: parseInt(match[2], 10) };
 }
 

--- a/.github/actions/pr-metrics-comment/lib/jars.js
+++ b/.github/actions/pr-metrics-comment/lib/jars.js
@@ -6,9 +6,7 @@ const { sanitizeModule } = require('./names.js');
 const { countClassEntries } = require('./zip.js');
 
 function parseModuleJar(filename) {
-  if (!filename.endsWith('.jar') || filename.includes('-sources') || filename.includes('-javadoc')) {
-    return null;
-  }
+  if (!filename.endsWith('.jar') || filename.includes('-sources') || filename.includes('-javadoc')) return null;
   const match = filename.match(/^kotventure-(.+)-(\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.]+)?)\.jar$/);
   if (!match) return null;
   return { module: sanitizeModule(match[1]), version: match[2] };
@@ -32,13 +30,9 @@ function collectJars(rootDir) {
         walk(full);
         continue;
       }
-      if (!entry.isFile()) {
-        continue;
-      }
+      if (!entry.isFile()) continue;
       const parsed = parseModuleJar(entry.name);
-      if (!parsed) {
-        continue;
-      }
+      if (!parsed) continue;
       const prev = bestVersion.get(parsed.module);
       if (!prev || versionKey(parsed.version) > versionKey(prev.version)) {
         const size = fs.statSync(full).size;

--- a/.github/actions/pr-metrics-comment/lib/jars.js
+++ b/.github/actions/pr-metrics-comment/lib/jars.js
@@ -10,9 +10,7 @@ function parseModuleJar(filename) {
     return null;
   }
   const match = filename.match(/^kotventure-(.+)-(\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.]+)?)\.jar$/);
-  if (!match) {
-    return null;
-  }
+  if (!match) return null;
   return { module: sanitizeModule(match[1]), version: match[2] };
 }
 
@@ -26,9 +24,7 @@ function versionKey(version) {
 function collectJars(rootDir) {
   const sizes = new Map();
   const bestVersion = new Map();
-  if (!fs.existsSync(rootDir)) {
-    return sizes;
-  }
+  if (!fs.existsSync(rootDir)) return sizes;
   function walk(dir) {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
       const full = path.join(dir, entry.name);

--- a/.github/actions/pr-metrics-comment/lib/main.js
+++ b/.github/actions/pr-metrics-comment/lib/main.js
@@ -5,9 +5,7 @@ const { collect } = require('./collect.js');
 
 module.exports = async function run({ github, context, core }) {
   const result = await collect({ env: process.env, context, github, core });
-  if (result === null) {
-    return;
-  }
+  if (result === null) return;
   const outputPath = process.env.OUTPUT_PATH;
   fs.writeFileSync(outputPath, JSON.stringify(result), 'utf8');
   core.info(`Wrote PR metrics result to ${outputPath}`);

--- a/.github/actions/pr-metrics-comment/lib/mermaid.js
+++ b/.github/actions/pr-metrics-comment/lib/mermaid.js
@@ -9,9 +9,7 @@ function mermaidFence(config, bodyLines) {
 }
 
 function deltaVerticalBars({ title, labels, deltas, yLabel, color }) {
-  if (!labels.length) {
-    return null;
-  }
+  if (!labels.length) return null;
   const values = deltas.map((d) => round1(d));
   const min = Math.min(0, ...values);
   const max = Math.max(0, ...values);

--- a/.github/actions/pr-metrics-comment/lib/metrics-result-contract.js
+++ b/.github/actions/pr-metrics-comment/lib/metrics-result-contract.js
@@ -37,9 +37,7 @@ const ZERO_WIDTH_CODE_POINTS = new Set([
 ]);
 
 function exactKeys(value, expected, label) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
-  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${label} must be an object`);
   const actual = Object.keys(value).sort();
   const keys = [...expected].sort();
   if (actual.length !== keys.length || actual.some((key, index) => key !== keys[index])) {
@@ -55,9 +53,7 @@ function boundedInteger(value, label, minimum = 0, maximum = MAX_COUNT) {
 }
 
 function boundedString(value, pattern, label) {
-  if (typeof value !== 'string' || !pattern.test(value)) {
-    throw new Error(`${label} has an invalid value`);
-  }
+  if (typeof value !== 'string' || !pattern.test(value)) throw new Error(`${label} has an invalid value`);
   return value;
 }
 

--- a/.github/actions/pr-metrics-comment/lib/metrics-result-deserialization.js
+++ b/.github/actions/pr-metrics-comment/lib/metrics-result-deserialization.js
@@ -3,9 +3,7 @@
 const { validateMetricsResult } = require('./metrics-result-validation.js');
 
 function deserializeCoverage(coverage) {
-  if (!coverage) {
-    return null;
-  }
+  if (!coverage) return null;
   return {
     modules: new Map(coverage.modules.map(({ name, missed, covered }) => [name, { missed, covered }])),
     totalMissed: coverage.totalMissed,

--- a/.github/actions/pr-metrics-comment/lib/metrics-result-serialization.js
+++ b/.github/actions/pr-metrics-comment/lib/metrics-result-serialization.js
@@ -16,9 +16,7 @@ function readRunNumber(value, label) {
 }
 
 function serializeCoverage(coverage) {
-  if (!coverage) {
-    return null;
-  }
+  if (!coverage) return null;
   return {
     modules: [...coverage.modules.entries()].map(([name, counters]) => ({
       name,

--- a/.github/actions/pr-metrics-comment/lib/metrics-result-serialization.js
+++ b/.github/actions/pr-metrics-comment/lib/metrics-result-serialization.js
@@ -9,9 +9,7 @@ const { validateMetricsResult } = require('./metrics-result-validation.js');
 
 function readRunNumber(value, label) {
   const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed) || parsed < 1) {
-    throw new Error(`${label} must be a positive integer`);
-  }
+  if (!Number.isSafeInteger(parsed) || parsed < 1) throw new Error(`${label} must be a positive integer`);
   return parsed;
 }
 

--- a/.github/actions/pr-metrics-comment/lib/metrics-result-validation.js
+++ b/.github/actions/pr-metrics-comment/lib/metrics-result-validation.js
@@ -18,19 +18,13 @@ const {
 function validateCoverage(value, label) {
   if (value == null) return null;
   exactKeys(value, ['modules', 'totalMissed', 'totalCovered'], label);
-  if (!Array.isArray(value.modules)) {
-    throw new Error(`${label}.modules must be an array`);
-  }
-  if (value.modules.length > MAX_MODULES) {
-    throw new Error(`${label}.modules has too many entries`);
-  }
+  if (!Array.isArray(value.modules)) throw new Error(`${label}.modules must be an array`);
+  if (value.modules.length > MAX_MODULES) throw new Error(`${label}.modules has too many entries`);
   const names = new Set();
   for (const [index, module] of value.modules.entries()) {
     exactKeys(module, ['name', 'missed', 'covered'], `${label}.modules[${index}]`);
     boundedString(module.name, MODULE_PATTERN, `${label}.modules[${index}].name`);
-    if (names.has(module.name)) {
-      throw new Error(`${label}.modules contains a duplicate name`);
-    }
+    if (names.has(module.name)) throw new Error(`${label}.modules contains a duplicate name`);
     names.add(module.name);
     boundedInteger(module.missed, `${label}.modules[${index}].missed`);
     boundedInteger(module.covered, `${label}.modules[${index}].covered`);
@@ -41,24 +35,16 @@ function validateCoverage(value, label) {
 }
 
 function validateJars(value, label) {
-  if (!Array.isArray(value)) {
-    throw new Error(`${label} must be an array`);
-  }
-  if (value.length > MAX_MODULES) {
-    throw new Error(`${label} has too many entries`);
-  }
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  if (value.length > MAX_MODULES) throw new Error(`${label} has too many entries`);
   const names = new Set();
   for (const [index, jar] of value.entries()) {
     exactKeys(jar, ['module', 'size', 'classes'], `${label}[${index}]`);
     boundedString(jar.module, MODULE_PATTERN, `${label}[${index}].module`);
-    if (names.has(jar.module)) {
-      throw new Error(`${label} contains a duplicate module`);
-    }
+    if (names.has(jar.module)) throw new Error(`${label} contains a duplicate module`);
     names.add(jar.module);
     boundedInteger(jar.size, `${label}[${index}].size`);
-    if (jar.classes !== null) {
-      boundedInteger(jar.classes, `${label}[${index}].classes`);
-    }
+    if (jar.classes !== null) boundedInteger(jar.classes, `${label}[${index}].classes`);
   }
   return value;
 }
@@ -68,9 +54,7 @@ function validateBuildMetrics(value, label) {
   exactKeys(value, ['tests', 'skipped', 'durationSeconds'], label);
   boundedInteger(value.tests, `${label}.tests`);
   boundedInteger(value.skipped, `${label}.skipped`);
-  if (value.durationSeconds !== null) {
-    boundedInteger(value.durationSeconds, `${label}.durationSeconds`);
-  }
+  if (value.durationSeconds !== null) boundedInteger(value.durationSeconds, `${label}.durationSeconds`);
   return value;
 }
 
@@ -86,12 +70,8 @@ function validateApiSurface(value) {
   if (value == null) return null;
   exactKeys(value, ['added', 'removed'], 'metrics.apiSurface');
   for (const [name, declarations] of [['added', value.added], ['removed', value.removed]]) {
-    if (!Array.isArray(declarations)) {
-      throw new Error(`metrics.apiSurface.${name} must be an array`);
-    }
-    if (declarations.length > MAX_DECLARATIONS) {
-      throw new Error(`metrics.apiSurface.${name} has too many entries`);
-    }
+    if (!Array.isArray(declarations)) throw new Error(`metrics.apiSurface.${name} must be an array`);
+    if (declarations.length > MAX_DECLARATIONS) throw new Error(`metrics.apiSurface.${name} has too many entries`);
     for (const [index, declaration] of declarations.entries()) {
       boundedDeclaration(declaration, `metrics.apiSurface.${name}[${index}]`);
     }
@@ -115,12 +95,8 @@ function validateProvenance(value) {
     'headSha',
   ], 'provenance');
   boundedString(value.repository, REPOSITORY_PATTERN, 'provenance.repository');
-  if (value.workflow !== WORKFLOW_NAME) {
-    throw new Error(`provenance.workflow must be ${WORKFLOW_NAME}`);
-  }
-  if (value.event !== 'pull_request') {
-    throw new Error('provenance.event must be pull_request');
-  }
+  if (value.workflow !== WORKFLOW_NAME) throw new Error(`provenance.workflow must be ${WORKFLOW_NAME}`);
+  if (value.event !== 'pull_request') throw new Error('provenance.event must be pull_request');
   boundedInteger(value.runId, 'provenance.runId', 1, Number.MAX_SAFE_INTEGER);
   boundedInteger(value.runAttempt, 'provenance.runAttempt', 1, 1000);
   boundedInteger(value.pullRequest, 'provenance.pullRequest', 1, Number.MAX_SAFE_INTEGER);

--- a/.github/actions/pr-metrics-comment/lib/metrics-result-validation.js
+++ b/.github/actions/pr-metrics-comment/lib/metrics-result-validation.js
@@ -16,9 +16,7 @@ const {
 } = require('./metrics-result-contract.js');
 
 function validateCoverage(value, label) {
-  if (value == null) {
-    return null;
-  }
+  if (value == null) return null;
   exactKeys(value, ['modules', 'totalMissed', 'totalCovered'], label);
   if (!Array.isArray(value.modules)) {
     throw new Error(`${label}.modules must be an array`);
@@ -66,9 +64,7 @@ function validateJars(value, label) {
 }
 
 function validateBuildMetrics(value, label) {
-  if (value == null) {
-    return null;
-  }
+  if (value == null) return null;
   exactKeys(value, ['tests', 'skipped', 'durationSeconds'], label);
   boundedInteger(value.tests, `${label}.tests`);
   boundedInteger(value.skipped, `${label}.skipped`);
@@ -79,9 +75,7 @@ function validateBuildMetrics(value, label) {
 }
 
 function validatePatchCoverage(value) {
-  if (value == null) {
-    return null;
-  }
+  if (value == null) return null;
   exactKeys(value, ['covered', 'missed'], 'metrics.patchCoverage');
   boundedInteger(value.covered, 'metrics.patchCoverage.covered');
   boundedInteger(value.missed, 'metrics.patchCoverage.missed');
@@ -89,9 +83,7 @@ function validatePatchCoverage(value) {
 }
 
 function validateApiSurface(value) {
-  if (value == null) {
-    return null;
-  }
+  if (value == null) return null;
   exactKeys(value, ['added', 'removed'], 'metrics.apiSurface');
   for (const [name, declarations] of [['added', value.added], ['removed', value.removed]]) {
     if (!Array.isArray(declarations)) {

--- a/.github/actions/pr-metrics-comment/lib/patch-coverage.js
+++ b/.github/actions/pr-metrics-comment/lib/patch-coverage.js
@@ -7,11 +7,7 @@ function toRanges(lineNumbers) {
   const ranges = [];
   for (const n of sorted) {
     const last = ranges[ranges.length - 1];
-    if (last && n === last[1] + 1) {
-      last[1] = n;
-    } else {
-      ranges.push([n, n]);
-    }
+    if (last && n === last[1] + 1) last[1] = n; else ranges.push([n, n]);
   }
   return ranges;
 }
@@ -22,19 +18,13 @@ function computePatchCoverage(patches, coverageFiles) {
   const uncovered = [];
   for (const patch of patches) {
     const match = patch.path.match(MAIN_SOURCE);
-    if (!match) {
-      continue;
-    }
+    if (!match) continue;
     const lines = coverageFiles.get(match[1]);
-    if (!lines) {
-      continue;
-    }
+    if (!lines) continue;
     const missedLines = [];
     for (const added of patch.addedLines) {
       const lineCovered = lines.get(added.line);
-      if (lineCovered === undefined) {
-        continue;
-      }
+      if (lineCovered === undefined) continue;
       if (lineCovered) {
         covered += 1;
       } else {
@@ -42,9 +32,7 @@ function computePatchCoverage(patches, coverageFiles) {
         missedLines.push(added.line);
       }
     }
-    if (missedLines.length > 0) {
-      uncovered.push({ path: patch.path, ranges: toRanges(missedLines) });
-    }
+    if (missedLines.length > 0) uncovered.push({ path: patch.path, ranges: toRanges(missedLines) });
   }
   return { covered, missed, uncovered };
 }

--- a/.github/actions/pr-metrics-comment/lib/patch.js
+++ b/.github/actions/pr-metrics-comment/lib/patch.js
@@ -27,9 +27,7 @@ function parsePatch(patch) {
 function parsePatches(files) {
   const parsed = [];
   for (const file of files) {
-    if (!file.patch || file.status === 'removed') {
-      continue;
-    }
+    if (!file.patch || file.status === 'removed') continue;
     parsed.push({ path: file.filename, ...parsePatch(file.patch) });
   }
   return parsed;

--- a/.github/actions/pr-metrics-comment/lib/report.js
+++ b/.github/actions/pr-metrics-comment/lib/report.js
@@ -8,18 +8,10 @@ const { statsSection } = require('./sections/stats-section.js');
 
 function footer({ headSha, links }) {
   const parts = [];
-  if (headSha) {
-    parts.push(`Updated for \`${headSha}\``);
-  }
-  if (links?.run) {
-    parts.push(`[Run](${links.run})`);
-  }
-  if (links?.dokka) {
-    parts.push(`[Dokka preview](${links.dokka})`);
-  }
-  if (links?.tests) {
-    parts.push(`[Test results](${links.tests})`);
-  }
+  if (headSha) parts.push(`Updated for \`${headSha}\``);
+  if (links?.run) parts.push(`[Run](${links.run})`);
+  if (links?.dokka) parts.push(`[Dokka preview](${links.dokka})`);
+  if (links?.tests) parts.push(`[Test results](${links.tests})`);
   return parts.length > 0 ? ['---', '', parts.join(' · '), ''] : [];
 }
 
@@ -39,18 +31,10 @@ function buildReport({
   links = {},
 }) {
   const parts = [];
-  if (headCoverage) {
-    parts.push(coverageSection({ headCoverage, baseCoverage, gateThreshold }));
-  }
-  if (patchCoverage) {
-    parts.push(patchSection(patchCoverage));
-  }
-  if (headJars.size > 0) {
-    parts.push(jarSection({ headJars, baseJars, growthThreshold }));
-  }
-  if (apiSurface) {
-    parts.push(apiSection(apiSurface));
-  }
+  if (headCoverage) parts.push(coverageSection({ headCoverage, baseCoverage, gateThreshold }));
+  if (patchCoverage) parts.push(patchSection(patchCoverage));
+  if (headJars.size > 0) parts.push(jarSection({ headJars, baseJars, growthThreshold }));
+  if (apiSurface) parts.push(apiSection(apiSurface));
   parts.push(statsSection({ headMetrics, baseMetrics }));
 
   const warnings = parts.flatMap((p) => p.warnings);

--- a/.github/actions/pr-metrics-comment/lib/sections/api-section.js
+++ b/.github/actions/pr-metrics-comment/lib/sections/api-section.js
@@ -3,9 +3,7 @@
 function apiSection(apiSurface) {
   const added = apiSurface.added.length;
   const removed = apiSurface.removed.length;
-  if (added === 0 && removed === 0) {
-    return { lines: [], verdictPart: null, warnings: [], changed: false };
-  }
+  if (added === 0 && removed === 0) return { lines: [], verdictPart: null, warnings: [], changed: false };
   const lines = [
     `### Public API — +${added} / −${removed} declarations`,
     '',

--- a/.github/actions/pr-metrics-comment/lib/sections/coverage-section.js
+++ b/.github/actions/pr-metrics-comment/lib/sections/coverage-section.js
@@ -28,9 +28,7 @@ function moduleRows(headCoverage, baseCoverage, deltaLabels, deltaVals, membersh
         deltaVals.push(delta);
       }
     } else if (headPct != null) {
-      if (hasBase) {
-        membership.changed = true;
-      }
+      if (hasBase) membership.changed = true;
       table += hasBase
         ? `| ${name} | ${formatPct(headPct)} | — | new |\n`
         : `| ${name} | ${formatPct(headPct)} |\n`;
@@ -67,11 +65,9 @@ function coverageSection({ headCoverage, baseCoverage, gateThreshold }) {
   }
 
   const lines = ['### Coverage', ''];
-  if (!hasBase) {
-    lines.push('_Base coverage unavailable — chart omitted; table has absolute head coverage._', '');
-  } else if (deltaLabels.length === 0) {
-    lines.push('_No per-module coverage delta (≥ 0.05pp) — chart omitted._', '');
-  } else {
+  if (!hasBase) lines.push('_Base coverage unavailable — chart omitted; table has absolute head coverage._', '');
+  else if (deltaLabels.length === 0) lines.push('_No per-module coverage delta (≥ 0.05pp) — chart omitted._', '');
+  else {
     const sorted = sortedDeltas(deltaLabels, deltaVals);
     lines.push(deltaVerticalBars({
       title: 'Coverage delta (pp, PR − base)',

--- a/.github/actions/pr-metrics-comment/lib/sections/jar-section.js
+++ b/.github/actions/pr-metrics-comment/lib/sections/jar-section.js
@@ -9,9 +9,7 @@ function kb(bytes) {
 }
 
 function classCell(head, base) {
-  if (head?.classes == null) {
-    return '—';
-  }
+  if (head?.classes == null) return '—';
   if (base?.classes != null && base.classes !== head.classes) {
     return `${head.classes} (${formatCount(head.classes - base.classes)})`;
   }

--- a/.github/actions/pr-metrics-comment/lib/sections/jar-section.js
+++ b/.github/actions/pr-metrics-comment/lib/sections/jar-section.js
@@ -54,11 +54,9 @@ function jarSection({ headJars, baseJars, growthThreshold }) {
   }
 
   const lines = ['### Artifact sizes', ''];
-  if (!hasAnyBase) {
-    lines.push('_Base JARs unavailable — chart omitted; table has absolute head sizes._', '');
-  } else if (deltaLabels.length === 0) {
-    lines.push('_No per-module size delta (≥ 0.05%) — chart omitted._', '');
-  } else {
+  if (!hasAnyBase) lines.push('_Base JARs unavailable — chart omitted; table has absolute head sizes._', '');
+  else if (deltaLabels.length === 0) lines.push('_No per-module size delta (≥ 0.05%) — chart omitted._', '');
+  else {
     const sorted = sortedDeltas(deltaLabels, deltaVals);
     lines.push(deltaVerticalBars({
       title: 'JAR size delta (%, PR − base)',

--- a/.github/actions/pr-metrics-comment/lib/sections/stats-section.js
+++ b/.github/actions/pr-metrics-comment/lib/sections/stats-section.js
@@ -3,17 +3,13 @@
 const { formatCount, detailsTable } = require('./format.js');
 
 function formatDuration(seconds) {
-  if (seconds == null) {
-    return '—';
-  }
+  if (seconds == null) return '—';
   const minutes = Math.floor(seconds / 60);
   return minutes > 0 ? `${minutes}m${String(seconds % 60).padStart(2, '0')}s` : `${seconds}s`;
 }
 
 function statsSection({ headMetrics, baseMetrics }) {
-  if (!headMetrics) {
-    return { lines: [], verdictPart: null, warnings: [], changed: false };
-  }
+  if (!headMetrics) return { lines: [], verdictPart: null, warnings: [], changed: false };
   const testsDelta = baseMetrics ? headMetrics.tests - baseMetrics.tests : null;
   let table = '| | PR | Base |\n|--|----|------|\n';
   table += `| Tests | ${headMetrics.tests} | ${baseMetrics ? baseMetrics.tests : '—'} |\n`;

--- a/.github/actions/pr-metrics-comment/lib/zip.js
+++ b/.github/actions/pr-metrics-comment/lib/zip.js
@@ -12,21 +12,15 @@ function findEocd(buffer) {
       continue;
     }
     const commentLength = buffer.readUInt16LE(i + 20);
-    if (i + EOCD_MIN_SIZE + commentLength === buffer.length) {
-      return i;
-    }
+    if (i + EOCD_MIN_SIZE + commentLength === buffer.length) return i;
   }
   return -1;
 }
 
 function countClassEntries(buffer) {
-  if (buffer.length < EOCD_MIN_SIZE) {
-    return null;
-  }
+  if (buffer.length < EOCD_MIN_SIZE) return null;
   const eocd = findEocd(buffer);
-  if (eocd < 0) {
-    return null;
-  }
+  if (eocd < 0) return null;
   const totalEntries = buffer.readUInt16LE(eocd + 10);
   const cdOffset = buffer.readUInt32LE(eocd + 16);
   let classes = 0;
@@ -40,9 +34,7 @@ function countClassEntries(buffer) {
     const extraLength = buffer.readUInt16LE(offset + 30);
     const commentLength = buffer.readUInt16LE(offset + 32);
     const recordEnd = offset + CENTRAL_HEADER_SIZE + nameLength + extraLength + commentLength;
-    if (recordEnd > buffer.length) {
-      return null;
-    }
+    if (recordEnd > buffer.length) return null;
     const name = buffer.toString('utf8', offset + CENTRAL_HEADER_SIZE, offset + CENTRAL_HEADER_SIZE + nameLength);
     if (name.endsWith('.class')) {
       classes += 1;

--- a/.github/actions/pr-metrics-comment/lib/zip.js
+++ b/.github/actions/pr-metrics-comment/lib/zip.js
@@ -8,9 +8,7 @@ const CENTRAL_HEADER_SIZE = 46;
 function findEocd(buffer) {
   const start = Math.max(0, buffer.length - EOCD_MIN_SIZE - 0xffff);
   for (let i = buffer.length - EOCD_MIN_SIZE; i >= start; i--) {
-    if (buffer.readUInt32LE(i) !== EOCD_SIG) {
-      continue;
-    }
+    if (buffer.readUInt32LE(i) !== EOCD_SIG) continue;
     const commentLength = buffer.readUInt16LE(i + 20);
     if (i + EOCD_MIN_SIZE + commentLength === buffer.length) return i;
   }
@@ -36,9 +34,7 @@ function countClassEntries(buffer) {
     const recordEnd = offset + CENTRAL_HEADER_SIZE + nameLength + extraLength + commentLength;
     if (recordEnd > buffer.length) return null;
     const name = buffer.toString('utf8', offset + CENTRAL_HEADER_SIZE, offset + CENTRAL_HEADER_SIZE + nameLength);
-    if (name.endsWith('.class')) {
-      classes += 1;
-    }
+    if (name.endsWith('.class')) classes += 1;
     offset = recordEnd;
   }
   return classes;

--- a/.github/scripts/ci-gate.js
+++ b/.github/scripts/ci-gate.js
@@ -107,9 +107,7 @@ async function decideGate({ github, context, core }) {
         headRef: pullRequest.head.ref,
         pullNumber: pullRequest.number,
       });
-      if (provenanceRun?.status === 'completed' || attempt === 5) {
-        break;
-      }
+      if (provenanceRun?.status === 'completed' || attempt === 5) break;
       await new Promise((resolve) => setTimeout(resolve, 10_000));
     }
   } catch (error) {

--- a/.github/scripts/download-base-metrics.sh
+++ b/.github/scripts/download-base-metrics.sh
@@ -99,14 +99,14 @@ restore_jars() {
     mkdir -p -- "$download_dir"
 
     if ! gh run download "$run_id" --name "$artifact" --dir "$download_dir"; then
-        warn 'could not restore module JARs from any supported artifact'
+        warn "could not restore module JARs from artifact '$artifact'"
         return 1
     fi
 
     local jars=("$download_dir"/**/kotventure-*.jar)
 
     if (( ${#jars[@]} == 0 )); then
-        warn 'could not restore module JARs from any supported artifact'
+        warn "could not restore module JARs from artifact '$artifact'"
         return 1
     fi
 

--- a/.github/scripts/pr-metrics-publisher-storage.js
+++ b/.github/scripts/pr-metrics-publisher-storage.js
@@ -36,19 +36,13 @@ function readMetricsArtifact(directory) {
     const filePath = path.join(directory, RESULT_FILE_NAME);
     const stats = fs.lstatSync(filePath);
 
-    if (!stats.isFile() || stats.isSymbolicLink()) {
-        throw new Error(`${RESULT_FILE_NAME} must be a regular file`);
-    }
+    if (!stats.isFile() || stats.isSymbolicLink()) throw new Error(`${RESULT_FILE_NAME} must be a regular file`);
 
-    if (stats.size > MAX_RESULT_BYTES) {
-        throw new Error(`metrics result exceeds ${MAX_RESULT_BYTES} bytes`);
-    }
+    if (stats.size > MAX_RESULT_BYTES) throw new Error(`metrics result exceeds ${MAX_RESULT_BYTES} bytes`);
 
     const bytes = fs.readFileSync(filePath);
 
-    if (bytes.length > MAX_RESULT_BYTES) {
-        throw new Error(`metrics result exceeds ${MAX_RESULT_BYTES} bytes`);
-    }
+    if (bytes.length > MAX_RESULT_BYTES) throw new Error(`metrics result exceeds ${MAX_RESULT_BYTES} bytes`);
 
     let result;
 

--- a/.github/scripts/pr-metrics-publisher-test-fixtures.js
+++ b/.github/scripts/pr-metrics-publisher-test-fixtures.js
@@ -231,13 +231,9 @@ function makeGithub({
             },
         },
         paginate: async (method) => {
-            if (method === listAssociatedPullRequests) {
-                return associatedPullRequests;
-            }
+            if (method === listAssociatedPullRequests) return associatedPullRequests;
 
-            if (method === listWorkflowRunArtifacts) {
-                return artifacts;
-            }
+            if (method === listWorkflowRunArtifacts) return artifacts;
 
             throw new Error('unexpected pagination method');
         },
@@ -314,9 +310,7 @@ function makeArtifactFetch(archiveResponse) {
                 };
             }
 
-            if (location === ARTIFACT_STORAGE_URL) {
-                return archiveResponse;
-            }
+            if (location === ARTIFACT_STORAGE_URL) return archiveResponse;
 
             throw new Error(`unexpected artifact request: ${location}`);
         },

--- a/.github/scripts/pr-metrics-publisher-validation.js
+++ b/.github/scripts/pr-metrics-publisher-validation.js
@@ -282,16 +282,12 @@ function validateWorkflowSource({
 }
 
 function selectMetricsArtifact({ artifacts, source }) {
-    if (!Array.isArray(artifacts)) {
-        reject('workflow artifacts are missing');
-    }
+    if (!Array.isArray(artifacts)) reject('workflow artifacts are missing');
 
     const name = expectedArtifactName(source);
     const matches = artifacts.filter((artifact) => artifact?.name === name);
 
-    if (matches.length !== 1) {
-        reject(`expected exactly one metrics artifact, found ${matches.length}`);
-    }
+    if (matches.length !== 1) reject(`expected exactly one metrics artifact, found ${matches.length}`);
 
     const [artifact] = matches;
 

--- a/.github/scripts/pr-metrics-publisher.js
+++ b/.github/scripts/pr-metrics-publisher.js
@@ -184,9 +184,7 @@ async function validateSource({
 }
 
 function readCoverageGateThreshold(filePath) {
-    if (!fs.existsSync(filePath)) {
-        return null;
-    }
+    if (!fs.existsSync(filePath)) return null;
 
     const contents = fs.readFileSync(filePath, 'utf8');
     const match = contents.match(/coverageLineThreshold\s*=\s*(\d+)/);
@@ -230,9 +228,7 @@ async function publishMetrics({
         core,
     });
 
-    if (!source) {
-        return false;
-    }
+    if (!source) return false;
 
     const result = validateResultProvenance(
             readMetricsArtifact(artifactDirectory),

--- a/.github/scripts/pr-metrics-publisher.js
+++ b/.github/scripts/pr-metrics-publisher.js
@@ -29,9 +29,7 @@ function rejectPublication(message) {
 }
 
 function requirePositiveInteger(value, message) {
-    if (!Number.isSafeInteger(value) || value < 1) {
-        rejectPublication(message);
-    }
+    if (!Number.isSafeInteger(value) || value < 1) rejectPublication(message);
 
     return value;
 }
@@ -42,13 +40,9 @@ async function resolvePullRequestNumber({
     repo,
     run,
 }) {
-    if (!Array.isArray(run.pull_requests)) {
-        rejectPublication('workflow run pull requests are invalid');
-    }
+    if (!Array.isArray(run.pull_requests)) rejectPublication('workflow run pull requests are invalid');
 
-    if (run.pull_requests.length > 1) {
-        rejectPublication('workflow run must identify exactly one pull request');
-    }
+    if (run.pull_requests.length > 1) rejectPublication('workflow run must identify exactly one pull request');
 
     if (run.pull_requests.length === 1) {
         return requirePositiveInteger(
@@ -67,9 +61,7 @@ async function resolvePullRequestNumber({
             },
     );
 
-    if (associatedPullRequests.length !== 1) {
-        rejectPublication('workflow run must identify exactly one pull request');
-    }
+    if (associatedPullRequests.length !== 1) rejectPublication('workflow run must identify exactly one pull request');
 
     return requirePositiveInteger(
             associatedPullRequests[0].number,
@@ -145,9 +137,7 @@ async function resolvePublishableSource({ github, context, core }) {
             context,
         });
     } catch (error) {
-        if (!(error instanceof PublicationRejectedError)) {
-            throw error;
-        }
+        if (!(error instanceof PublicationRejectedError)) throw error;
 
         core.warning(`Metrics publication skipped: ${error.message}`);
         return null;
@@ -208,9 +198,7 @@ function buildArtifactLinks({
     for (const artifact of source.artifacts) {
         const key = REPORT_ARTIFACT_LINKS.get(artifact.name);
 
-        if (key && Number.isSafeInteger(artifact.id)) {
-            links[key] = `${runUrl}/artifacts/${artifact.id}`;
-        }
+        if (key && Number.isSafeInteger(artifact.id)) links[key] = `${runUrl}/artifacts/${artifact.id}`;
     }
 
     return links;

--- a/.github/scripts/pr-metrics-publisher.test.js
+++ b/.github/scripts/pr-metrics-publisher.test.js
@@ -55,9 +55,7 @@ function makeReadableBody(chunks) {
             getReader() {
                 return {
                     read: async () => {
-                        if (index >= chunks.length) {
-                            return { done: true };
-                        }
+                        if (index >= chunks.length) return { done: true };
 
                         return {
                             done: false,
@@ -664,9 +662,7 @@ describe('publisher orchestration', () => {
             listComments,
         };
         github.paginate = async (method, parameters) => {
-            if (method === listComments) {
-                return [];
-            }
+            if (method === listComments) return [];
 
             return paginate(method, parameters);
         };

--- a/.github/scripts/qodana-attestation.js
+++ b/.github/scripts/qodana-attestation.js
@@ -57,9 +57,7 @@ function createAttestation({ sourceKind, headSha }) {
 }
 
 function writeAttestation({ sourceKind, headSha, outputPath }) {
-  if (typeof outputPath !== 'string' || outputPath.length === 0) {
-    throw new Error('attestation output path is required');
-  }
+  if (typeof outputPath !== 'string' || outputPath.length === 0) throw new Error('attestation output path is required');
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   fs.writeFileSync(outputPath, JSON.stringify(createAttestation({ sourceKind, headSha })));
 }

--- a/.github/scripts/qodana-contract.js
+++ b/.github/scripts/qodana-contract.js
@@ -34,9 +34,7 @@ function buildArtifactName({
   headSha,
   baseSha,
 }) {
-  if (!['code', 'documentation', 'release'].includes(sourceKind)) {
-    throw new Error('Qodana source kind is invalid');
-  }
+  if (!['code', 'documentation', 'release'].includes(sourceKind)) throw new Error('Qodana source kind is invalid');
   return `${QODANA_ARTIFACT_PREFIX}${sourceKind}-${requirePositiveInteger(qodanaRunId, 'Qodana workflow run id')}-${requirePositiveInteger(qodanaRunAttempt, 'Qodana workflow run attempt')}-${requireSha(headSha, 'head SHA')}-${requireSha(baseSha, 'base SHA')}`;
 }
 

--- a/.github/scripts/qodana-contract.js
+++ b/.github/scripts/qodana-contract.js
@@ -41,15 +41,11 @@ function buildArtifactName({
 }
 
 function parseArtifactName(name) {
-  if (typeof name !== 'string') {
-    return null;
-  }
+  if (typeof name !== 'string') return null;
   const match = name.match(
     new RegExp(`^${QODANA_ARTIFACT_PREFIX}(code|documentation|release)-(\\d+)-(\\d+)-([0-9a-f]{40})-([0-9a-f]{40})$`),
   );
-  if (!match) {
-    return null;
-  }
+  if (!match) return null;
   const qodanaRunId = Number(match[2]);
   const qodanaRunAttempt = Number(match[3]);
   if (!Number.isSafeInteger(qodanaRunId) || qodanaRunId < 1

--- a/.github/scripts/qodana-publisher-validation.js
+++ b/.github/scripts/qodana-publisher-validation.js
@@ -33,9 +33,7 @@ function validateQodanaWorkflowSource({ eventRun, run, workflow, repository }) {
 
   requireEqual(eventRun.id, run.id, 'workflow run id');
   requireEqual(eventRun.run_attempt, run.run_attempt, 'workflow run attempt');
-  if (eventRun.workflow_id != null) {
-    requireEqual(eventRun.workflow_id, run.workflow_id, 'workflow run workflow id');
-  }
+  if (eventRun.workflow_id != null) requireEqual(eventRun.workflow_id, run.workflow_id, 'workflow run workflow id');
   requireEqual(eventRun.event, 'pull_request_target', 'workflow run event');
   requireEqual(eventRun.status, 'completed', 'workflow run event status');
   requireEqual(eventRun.conclusion, run.conclusion, 'workflow run event conclusion');
@@ -65,9 +63,7 @@ function validateQodanaWorkflowSource({ eventRun, run, workflow, repository }) {
 }
 
 function matchingRunArtifacts({ artifacts, qodanaRun, prefix, parse }) {
-  if (!Array.isArray(artifacts)) {
-    reject('workflow artifacts are missing');
-  }
+  if (!Array.isArray(artifacts)) reject('workflow artifacts are missing');
   return artifacts
     .filter((artifact) => typeof artifact?.name === 'string'
       && artifact.name.startsWith(prefix))
@@ -86,9 +82,7 @@ function selectRunArtifact({
   label,
 }) {
   const candidates = matchingRunArtifacts({ artifacts, qodanaRun, prefix, parse });
-  if (candidates.length !== 1) {
-    reject(`expected exactly one ${label}, found ${candidates.length}`);
-  }
+  if (candidates.length !== 1) reject(`expected exactly one ${label}, found ${candidates.length}`);
   const [{ artifact, descriptor }] = candidates;
   validateArtifactBinding(reject, {
     artifact,
@@ -139,9 +133,7 @@ function validateArtifactLocation(location) {
     && (typeof uriBaseId !== 'string' || !/^[A-Za-z0-9_.-]{1,128}$/.test(uriBaseId))) {
     reject('SARIF artifact location base id is invalid');
   }
-  if (uri == null) {
-    return;
-  }
+  if (uri == null) return;
   if (typeof uri !== 'string' || uri.length > 4096 || uri.includes('\u0000')) {
     reject('SARIF artifact location is invalid');
   }
@@ -159,25 +151,17 @@ function validateNestedArtifactLocations(root) {
   while (pending.length > 0) {
     const { value, depth } = pending.pop();
     visited += 1;
-    if (visited > 250_000 || depth > 100) {
-      reject('SARIF structure is too complex');
-    }
-    if (!value || typeof value !== 'object') {
-      continue;
-    }
+    if (visited > 250_000 || depth > 100) reject('SARIF structure is too complex');
+    if (!value || typeof value !== 'object') continue;
     if (Array.isArray(value)) {
       for (const item of value) {
         pending.push({ value: item, depth: depth + 1 });
       }
       continue;
     }
-    if (Object.hasOwn(value, 'uri') || Object.hasOwn(value, 'uriBaseId')) {
-      validateArtifactLocation(value);
-    }
+    if (Object.hasOwn(value, 'uri') || Object.hasOwn(value, 'uriBaseId')) validateArtifactLocation(value);
     for (const [key, child] of Object.entries(value)) {
-      if (key === 'artifactLocation') {
-        validateArtifactLocation(child);
-      }
+      if (key === 'artifactLocation') validateArtifactLocation(child);
       pending.push({ value: child, depth: depth + 1 });
     }
   }
@@ -185,9 +169,7 @@ function validateNestedArtifactLocations(root) {
 
 function validateQodanaSarif(value) {
   const bytes = Buffer.isBuffer(value) ? value : Buffer.from(String(value), 'utf8');
-  if (bytes.length < 1 || bytes.length > MAX_SARIF_BYTES) {
-    reject('SARIF size is invalid');
-  }
+  if (bytes.length < 1 || bytes.length > MAX_SARIF_BYTES) reject('SARIF size is invalid');
   let document;
   try {
     document = JSON.parse(bytes.toString('utf8'));
@@ -196,31 +178,21 @@ function validateQodanaSarif(value) {
   }
   requireObject(document, 'SARIF document');
   requireEqual(document.version, '2.1.0', 'SARIF version');
-  if (!Array.isArray(document.runs) || document.runs.length !== 1) {
-    reject('SARIF must contain exactly one run');
-  }
+  if (!Array.isArray(document.runs) || document.runs.length !== 1) reject('SARIF must contain exactly one run');
   const [run] = document.runs;
   requireObject(run, 'SARIF run');
   const tool = requireObject(run.tool, 'SARIF tool');
   const driver = requireObject(tool.driver, 'SARIF driver');
-  if (driver.name !== 'QDJVM') {
-    reject('SARIF driver name is invalid');
-  }
-  if (!Array.isArray(run.results) || run.results.length > MAX_SARIF_RESULTS) {
-    reject('SARIF results are invalid');
-  }
+  if (driver.name !== 'QDJVM') reject('SARIF driver name is invalid');
+  if (!Array.isArray(run.results) || run.results.length > MAX_SARIF_RESULTS) reject('SARIF results are invalid');
   for (const result of run.results) {
     requireObject(result, 'SARIF result');
   }
   if (run.artifacts != null) {
-    if (!Array.isArray(run.artifacts)) {
-      reject('SARIF artifacts are invalid');
-    }
+    if (!Array.isArray(run.artifacts)) reject('SARIF artifacts are invalid');
     for (const artifact of run.artifacts) {
       const location = requireObject(artifact, 'SARIF artifact').location;
-      if (location != null) {
-        validateArtifactLocation(location);
-      }
+      if (location != null) validateArtifactLocation(location);
     }
   }
   if (run.originalUriBaseIds != null) {

--- a/.github/scripts/qodana-publisher.js
+++ b/.github/scripts/qodana-publisher.js
@@ -122,21 +122,11 @@ async function writePublicationOutputs({ github, context, core }) {
   try {
     const publication = await resolvePublication({ github, context });
     core.setOutput('publish', String(publication.publish));
-    if (publication.artifactId != null) {
-      core.setOutput('artifact_id', String(publication.artifactId));
-    }
-    if (publication.headSha != null) {
-      core.setOutput('head_sha', publication.headSha);
-    }
-    if (publication.pullNumber != null) {
-      core.setOutput('pull_number', String(publication.pullNumber));
-    }
-    if (publication.sourceKind != null) {
-      core.setOutput('source_kind', publication.sourceKind);
-    }
-    if (publication.rejection) {
-      core.setFailed(`Qodana publication rejected: ${publication.rejection.message}`);
-    }
+    if (publication.artifactId != null) core.setOutput('artifact_id', String(publication.artifactId));
+    if (publication.headSha != null) core.setOutput('head_sha', publication.headSha);
+    if (publication.pullNumber != null) core.setOutput('pull_number', String(publication.pullNumber));
+    if (publication.sourceKind != null) core.setOutput('source_kind', publication.sourceKind);
+    if (publication.rejection) core.setFailed(`Qodana publication rejected: ${publication.rejection.message}`);
     return publication;
   } catch (error) {
     if (error instanceof QodanaSourceRejectedError && error.stale) {

--- a/.github/scripts/qodana-security.test.js
+++ b/.github/scripts/qodana-security.test.js
@@ -145,18 +145,10 @@ function makeGithub({
       },
     },
     paginate: async (method) => {
-      if (method === listFiles) {
-        return changedFiles;
-      }
-      if (method === listAssociatedPullRequests) {
-        return listAssociatedPullRequests();
-      }
-      if (method === listJobs) {
-        return listJobs();
-      }
-      if (method === listReleaseRuns) {
-        return listReleaseRuns();
-      }
+      if (method === listFiles) return changedFiles;
+      if (method === listAssociatedPullRequests) return listAssociatedPullRequests();
+      if (method === listJobs) return listJobs();
+      if (method === listReleaseRuns) return listReleaseRuns();
       throw new Error('unexpected pagination method');
     },
   };
@@ -314,21 +306,11 @@ function makePublicationGithub({
         },
       },
       paginate: async (method) => {
-        if (method === listArtifacts) {
-          return listArtifacts();
-        }
-        if (method === listFiles) {
-          return files;
-        }
-        if (method === listJobs) {
-          return listJobs();
-        }
-        if (method === listReleaseRuns) {
-          return listReleaseRuns();
-        }
-        if (method === listAssociatedPullRequests) {
-          return listAssociatedPullRequests();
-        }
+        if (method === listArtifacts) return listArtifacts();
+        if (method === listFiles) return files;
+        if (method === listJobs) return listJobs();
+        if (method === listReleaseRuns) return listReleaseRuns();
+        if (method === listAssociatedPullRequests) return listAssociatedPullRequests();
         throw new Error('unexpected publication pagination method');
       },
     },

--- a/.github/scripts/qodana-source.js
+++ b/.github/scripts/qodana-source.js
@@ -271,7 +271,6 @@ async function resolveTrustedCiRun({ github, owner, repo, runId, eventRun }) {
 module.exports = {
   QodanaSourceRejectedError,
   hasTrustedReleaseMetadata,
-  hasTrustedReleaseProvenance,
   resolvePullRequestEventSource,
   resolvePullRequestSource,
   resolveTrustedCiRun,

--- a/.github/scripts/qodana-source.js
+++ b/.github/scripts/qodana-source.js
@@ -90,12 +90,8 @@ function validatePullRequestState({
   requireEqual(pullRequest.base?.repo?.id, repository.id, 'pull request base repository id', true);
   requireSha(pullRequest.base?.sha, 'pull request base SHA');
   requireSha(pullRequest.head?.sha, 'pull request head SHA');
-  if (expectedHeadSha != null) {
-    requireEqual(pullRequest.head?.sha, expectedHeadSha, 'pull request head SHA', true);
-  }
-  if (expectedBaseSha != null) {
-    requireEqual(pullRequest.base.sha, expectedBaseSha, 'pull request base SHA', true);
-  }
+  if (expectedHeadSha != null) requireEqual(pullRequest.head?.sha, expectedHeadSha, 'pull request head SHA', true);
+  if (expectedBaseSha != null) requireEqual(pullRequest.base.sha, expectedBaseSha, 'pull request base SHA', true);
 }
 
 async function completePullRequestSource({
@@ -245,12 +241,8 @@ async function resolveTrustedCiRun({ github, owner, repo, runId, eventRun }) {
   });
   const workflow = requireObject(workflowResponse.data, 'workflow');
 
-  if (eventRun) {
-    validateEventRun(reject, { eventRun, run });
-  }
-  if (!['push', 'schedule', 'workflow_dispatch'].includes(run.event)) {
-    reject('workflow run event is not trusted');
-  }
+  if (eventRun) validateEventRun(reject, { eventRun, run });
+  if (!['push', 'schedule', 'workflow_dispatch'].includes(run.event)) reject('workflow run event is not trusted');
   requireEqual(run.status, 'completed', 'workflow run status');
   requireEqual(run.conclusion, 'success', 'workflow run conclusion');
   requireEqual(run.repository?.full_name, repositoryName(repository), 'workflow run repository');

--- a/.github/scripts/shared/artifact-archive.js
+++ b/.github/scripts/shared/artifact-archive.js
@@ -236,9 +236,7 @@ function extractSingleEntryArchive(archive, {
 
   function decompressEntry(compressedData, entry) {
     try {
-      if (entry.compressionMethod === STORED_COMPRESSION) {
-        return Buffer.from(compressedData);
-      }
+      if (entry.compressionMethod === STORED_COMPRESSION) return Buffer.from(compressedData);
 
       return zlib.inflateRawSync(compressedData, {
         maxOutputLength: maxBytes,

--- a/.github/scripts/shared/artifact-archive.js
+++ b/.github/scripts/shared/artifact-archive.js
@@ -66,15 +66,11 @@ function extractSingleEntryArchive(archive, {
       offset >= firstOffset;
       offset -= 1
     ) {
-      if (archive.readUInt32LE(offset) !== END_OF_CENTRAL_DIRECTORY_SIGNATURE) {
-        continue;
-      }
+      if (archive.readUInt32LE(offset) !== END_OF_CENTRAL_DIRECTORY_SIGNATURE) continue;
 
       const commentLength = archive.readUInt16LE(offset + 20);
 
-      if (offset + END_OF_CENTRAL_DIRECTORY_LENGTH + commentLength === archive.length) {
-        return offset;
-      }
+      if (offset + END_OF_CENTRAL_DIRECTORY_LENGTH + commentLength === archive.length) return offset;
     }
 
     rejectArchive('has no valid end record');
@@ -99,15 +95,11 @@ function extractSingleEntryArchive(archive, {
       rejectArchive('uses unsupported ZIP64 or multi-disk metadata');
     }
 
-    if (entriesOnDisk !== 1 || totalEntries !== 1) {
-      rejectArchive('must contain exactly one file');
-    }
+    if (entriesOnDisk !== 1 || totalEntries !== 1) rejectArchive('must contain exactly one file');
 
     assertRange(archive, centralDirectoryOffset, centralDirectorySize, 'central directory');
 
-    if (centralDirectoryOffset + centralDirectorySize !== endOffset) {
-      rejectArchive('has a misplaced central directory');
-    }
+    if (centralDirectoryOffset + centralDirectorySize !== endOffset) rejectArchive('has a misplaced central directory');
 
     if (centralDirectorySize < CENTRAL_DIRECTORY_HEADER_LENGTH
       || archive.readUInt32LE(centralDirectoryOffset) !== CENTRAL_DIRECTORY_SIGNATURE) {
@@ -122,18 +114,14 @@ function extractSingleEntryArchive(archive, {
       + extraLength
       + commentLength;
 
-    if (recordLength !== centralDirectorySize) {
-      rejectArchive('has an invalid central directory record');
-    }
+    if (recordLength !== centralDirectorySize) rejectArchive('has an invalid central directory record');
 
     const fileNameOffset = centralDirectoryOffset + CENTRAL_DIRECTORY_HEADER_LENGTH;
     assertRange(archive, fileNameOffset, fileNameLength, 'file name');
 
     const fileName = archive.subarray(fileNameOffset, fileNameOffset + fileNameLength);
 
-    if (!fileName.equals(expectedName)) {
-      rejectArchive(`must contain only ${expectedName.toString('utf8')}`);
-    }
+    if (!fileName.equals(expectedName)) rejectArchive(`must contain only ${expectedName.toString('utf8')}`);
 
     const flags = archive.readUInt16LE(centralDirectoryOffset + 8);
     const compressionMethod = archive.readUInt16LE(centralDirectoryOffset + 10);
@@ -163,9 +151,7 @@ function extractSingleEntryArchive(archive, {
       rejectArchive('contains an entry outside the size limit');
     }
 
-    if (localHeaderOffset >= centralDirectoryOffset) {
-      rejectArchive('has an invalid local file header offset');
-    }
+    if (localHeaderOffset >= centralDirectoryOffset) rejectArchive('has an invalid local file header offset');
 
     return {
       centralDirectoryOffset,
@@ -216,9 +202,7 @@ function extractSingleEntryArchive(archive, {
       localFileNameOffset + localFileNameLength,
     );
 
-    if (!localFileName.equals(entry.fileName)) {
-      rejectArchive('has inconsistent file names');
-    }
+    if (!localFileName.equals(entry.fileName)) rejectArchive('has inconsistent file names');
 
     const compressedDataOffset = localFileNameOffset + localFileNameLength + localExtraLength;
 

--- a/.github/scripts/shared/artifact-binding.js
+++ b/.github/scripts/shared/artifact-binding.js
@@ -10,9 +10,7 @@ function validateArtifactBinding(reject, { artifact, expected, maxBytes, label }
   } = createValidators(reject);
 
   requireInteger(artifact.id, `${label} id`);
-  if (artifact.expired !== false) {
-    reject(`${label} is expired`);
-  }
+  if (artifact.expired !== false) reject(`${label} is expired`);
   requireInteger(artifact.size_in_bytes, `${label} size`, 1, maxBytes);
 
   const workflowRun = requireObject(artifact.workflow_run, `${label} workflow run`);

--- a/.github/scripts/shared/artifact-download.js
+++ b/.github/scripts/shared/artifact-download.js
@@ -50,9 +50,7 @@ async function readStreamingBytes(body, maximumBytes, label) {
 }
 
 async function readResponseBytes(response, maximumBytes, label) {
-  if (!response || response.ok === false) {
-    throw new Error(`${label} download failed`);
-  }
+  if (!response || response.ok === false) throw new Error(`${label} download failed`);
 
   const contentLength = Number(getHeader(response.headers, 'content-length'));
 
@@ -64,15 +62,11 @@ async function readResponseBytes(response, maximumBytes, label) {
     return readStreamingBytes(response.body, maximumBytes, label);
   }
 
-  if (typeof response.arrayBuffer !== 'function') {
-    throw new Error(`${label} download has no readable body`);
-  }
+  if (typeof response.arrayBuffer !== 'function') throw new Error(`${label} download has no readable body`);
 
   const result = Buffer.from(await response.arrayBuffer());
 
-  if (result.length > maximumBytes) {
-    throw new Error(`${label} download exceeds ${maximumBytes} bytes`);
-  }
+  if (result.length > maximumBytes) throw new Error(`${label} download exceeds ${maximumBytes} bytes`);
 
   return result;
 }
@@ -94,33 +88,23 @@ function validateDownloadOptions({
     throw new Error(`${label} download requires a repository`);
   }
 
-  if (!Number.isSafeInteger(artifactId) || artifactId < 1) {
-    throw new Error(`${label} id is invalid`);
-  }
+  if (!Number.isSafeInteger(artifactId) || artifactId < 1) throw new Error(`${label} id is invalid`);
 
   if (typeof outputDirectory !== 'string' || outputDirectory.length === 0) {
     throw new Error(`${label} output directory is required`);
   }
 
-  if (typeof fileName !== 'string' || fileName.length === 0) {
-    throw new Error(`${label} download file name is invalid`);
-  }
+  if (typeof fileName !== 'string' || fileName.length === 0) throw new Error(`${label} download file name is invalid`);
 
   if (!Number.isSafeInteger(maxArchiveBytes) || maxArchiveBytes < 1) {
     throw new Error(`${label} download archive size limit is invalid`);
   }
 
-  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
-    throw new Error(`${label} download size limit is invalid`);
-  }
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) throw new Error(`${label} download size limit is invalid`);
 
-  if (typeof token !== 'string' || token.length === 0) {
-    throw new Error(`${label} download requires a GitHub token`);
-  }
+  if (typeof token !== 'string' || token.length === 0) throw new Error(`${label} download requires a GitHub token`);
 
-  if (typeof fetchImpl !== 'function') {
-    throw new Error(`${label} download requires fetch`);
-  }
+  if (typeof fetchImpl !== 'function') throw new Error(`${label} download requires fetch`);
 }
 
 async function downloadSingleFileArtifact({
@@ -164,9 +148,7 @@ async function downloadSingleFileArtifact({
     },
   );
 
-  if (response.status !== 302) {
-    throw new Error(`${label} download returned HTTP ${response.status}`);
-  }
+  if (response.status !== 302) throw new Error(`${label} download returned HTTP ${response.status}`);
 
   const location = getHeader(response.headers, 'location');
   let artifactUrl;
@@ -177,9 +159,7 @@ async function downloadSingleFileArtifact({
     throw new Error(`${label} download redirect is invalid`);
   }
 
-  if (artifactUrl.protocol !== 'https:') {
-    throw new Error(`${label} download redirect is invalid`);
-  }
+  if (artifactUrl.protocol !== 'https:') throw new Error(`${label} download redirect is invalid`);
 
   const archiveResponse = await fetchImpl(artifactUrl.href, {
     redirect: 'follow',
@@ -194,9 +174,7 @@ async function downloadSingleFileArtifact({
     maxBytes,
   });
 
-  if (validateResult) {
-    validateResult(result);
-  }
+  if (validateResult) validateResult(result);
 
   fs.mkdirSync(outputDirectory, { recursive: true });
 

--- a/.github/scripts/shared/artifact-download.js
+++ b/.github/scripts/shared/artifact-download.js
@@ -10,9 +10,7 @@ const ARTIFACT_STORAGE_TIMEOUT_MS = 60_000;
 function getHeader(headers, name) {
   if (!headers) return null;
 
-  if (typeof headers.get === 'function') {
-    return headers.get(name);
-  }
+  if (typeof headers.get === 'function') return headers.get(name);
 
   return headers[name] ?? headers[name.toLowerCase()] ?? null;
 }
@@ -33,9 +31,7 @@ async function readStreamingBytes(body, maximumBytes, label) {
   while (true) {
     const { done, value } = await reader.read();
 
-    if (done) {
-      return Buffer.concat(chunks, totalBytes);
-    }
+    if (done) return Buffer.concat(chunks, totalBytes);
 
     if (!(value instanceof Uint8Array)) {
       await cancelReader(reader);
@@ -86,6 +82,9 @@ function validateDownloadOptions({
   repo,
   artifactId,
   outputDirectory,
+  fileName,
+  maxArchiveBytes,
+  maxBytes,
   token,
   fetchImpl,
   label,
@@ -101,6 +100,18 @@ function validateDownloadOptions({
 
   if (typeof outputDirectory !== 'string' || outputDirectory.length === 0) {
     throw new Error(`${label} output directory is required`);
+  }
+
+  if (typeof fileName !== 'string' || fileName.length === 0) {
+    throw new Error(`${label} download file name is invalid`);
+  }
+
+  if (!Number.isSafeInteger(maxArchiveBytes) || maxArchiveBytes < 1) {
+    throw new Error(`${label} download archive size limit is invalid`);
+  }
+
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new Error(`${label} download size limit is invalid`);
   }
 
   if (typeof token !== 'string' || token.length === 0) {
@@ -131,6 +142,9 @@ async function downloadSingleFileArtifact({
     repo,
     artifactId,
     outputDirectory,
+    fileName,
+    maxArchiveBytes,
+    maxBytes,
     token,
     fetchImpl,
     label,

--- a/.github/scripts/shared/path-classification.js
+++ b/.github/scripts/shared/path-classification.js
@@ -51,9 +51,7 @@ function classifyChangedFiles(files) {
   const paths = changedPathNames(files);
   if (!paths) return 'code';
   if (paths.every(isDocumentationPath)) return 'documentation';
-  if (paths.every((name) => isSafeRepositoryPath(name) && RELEASE_ONLY_FILES.has(name))) {
-    return 'release-candidate';
-  }
+  if (paths.every((name) => isSafeRepositoryPath(name) && RELEASE_ONLY_FILES.has(name))) return 'release-candidate';
   return 'code';
 }
 

--- a/.github/scripts/shared/path-classification.js
+++ b/.github/scripts/shared/path-classification.js
@@ -33,20 +33,14 @@ function isDocumentationPath(name) {
 }
 
 function changedPathNames(files) {
-  if (!Array.isArray(files) || files.length === 0) {
-    return null;
-  }
+  if (!Array.isArray(files) || files.length === 0) return null;
 
   const paths = [];
   for (const file of files) {
-    if (!file || typeof file.filename !== 'string' || file.filename.length === 0) {
-      return null;
-    }
+    if (!file || typeof file.filename !== 'string' || file.filename.length === 0) return null;
     paths.push(file.filename);
     if (file.previous_filename != null) {
-      if (typeof file.previous_filename !== 'string' || file.previous_filename.length === 0) {
-        return null;
-      }
+      if (typeof file.previous_filename !== 'string' || file.previous_filename.length === 0) return null;
       paths.push(file.previous_filename);
     }
   }
@@ -55,12 +49,8 @@ function changedPathNames(files) {
 
 function classifyChangedFiles(files) {
   const paths = changedPathNames(files);
-  if (!paths) {
-    return 'code';
-  }
-  if (paths.every(isDocumentationPath)) {
-    return 'documentation';
-  }
+  if (!paths) return 'code';
+  if (paths.every(isDocumentationPath)) return 'documentation';
   if (paths.every((name) => isSafeRepositoryPath(name) && RELEASE_ONLY_FILES.has(name))) {
     return 'release-candidate';
   }

--- a/.github/scripts/shared/release-provenance.js
+++ b/.github/scripts/shared/release-provenance.js
@@ -99,9 +99,7 @@ async function hasTrustedReleaseProvenance(options) {
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     const status = await readTrustedReleaseProvenance(options);
     if (status === 'success' || status === 'failed') return status === 'success';
-    if (attempt + 1 < attempts) {
-      await wait(10_000);
-    }
+    if (attempt + 1 < attempts) await wait(10_000);
   }
   return false;
 }

--- a/.github/scripts/shared/release-provenance.js
+++ b/.github/scripts/shared/release-provenance.js
@@ -53,9 +53,7 @@ async function readTrustedReleaseProvenance({ github, owner, repo, repository, p
   } catch {
     return 'missing';
   }
-  if (workflow.path !== RELEASE_PROVENANCE_WORKFLOW_PATH) {
-    return 'missing';
-  }
+  if (workflow.path !== RELEASE_PROVENANCE_WORKFLOW_PATH) return 'missing';
 
   let candidate;
   try {
@@ -72,15 +70,9 @@ async function readTrustedReleaseProvenance({ github, owner, repo, repository, p
     return 'missing';
   }
 
-  if (!candidate) {
-    return 'missing';
-  }
-  if (candidate.status !== 'completed') {
-    return 'pending';
-  }
-  if (candidate.conclusion !== 'success') {
-    return 'failed';
-  }
+  if (!candidate) return 'missing';
+  if (candidate.status !== 'completed') return 'pending';
+  if (candidate.conclusion !== 'success') return 'failed';
 
   let jobs;
   try {
@@ -94,9 +86,7 @@ async function readTrustedReleaseProvenance({ github, owner, repo, repository, p
     return 'missing';
   }
   const trustedJob = jobs.find((job) => job?.name === TRUSTED_PROVENANCE_JOB_NAME);
-  if (trustedJob?.status === 'completed' && trustedJob.conclusion === 'success') {
-    return 'success';
-  }
+  if (trustedJob?.status === 'completed' && trustedJob.conclusion === 'success') return 'success';
   return trustedJob?.status === 'completed' ? 'failed' : 'pending';
 }
 
@@ -108,9 +98,7 @@ async function hasTrustedReleaseProvenance(options) {
   const attempts = options.waitForReleaseProvenance === false ? 1 : 6;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     const status = await readTrustedReleaseProvenance(options);
-    if (status === 'success' || status === 'failed') {
-      return status === 'success';
-    }
+    if (status === 'success' || status === 'failed') return status === 'success';
     if (attempt + 1 < attempts) {
       await wait(10_000);
     }

--- a/.github/scripts/shared/run-context.js
+++ b/.github/scripts/shared/run-context.js
@@ -8,9 +8,7 @@ function validateEventRun(reject, { eventRun, run }) {
   requireEqual(eventRun.id, run.id, 'workflow run id');
   requireEqual(eventRun.run_attempt, run.run_attempt, 'workflow run attempt');
   requireEqual(eventRun.head_sha, run.head_sha, 'workflow run head SHA');
-  if (eventRun.workflow_id != null) {
-    requireEqual(eventRun.workflow_id, run.workflow_id, 'workflow run workflow id');
-  }
+  if (eventRun.workflow_id != null) requireEqual(eventRun.workflow_id, run.workflow_id, 'workflow run workflow id');
 }
 
 async function fetchWorkflowRunContext(reject, { github, owner, repo, eventRun }) {

--- a/.github/scripts/shared/validation.js
+++ b/.github/scripts/shared/validation.js
@@ -2,44 +2,32 @@
 
 function createValidators(reject) {
   function requireObject(value, label) {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      reject(`${label} is missing`);
-    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) reject(`${label} is missing`);
     return value;
   }
 
   function requireEqual(actual, expected, label, stale = false) {
-    if (actual !== expected) {
-      reject(`${label} does not match the trusted value`, stale);
-    }
+    if (actual !== expected) reject(`${label} does not match the trusted value`, stale);
     return actual;
   }
 
   function requireInteger(value, label, minimum = 1, maximum = Number.MAX_SAFE_INTEGER) {
-    if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
-      reject(`${label} is invalid`);
-    }
+    if (!Number.isSafeInteger(value) || value < minimum || value > maximum) reject(`${label} is invalid`);
     return value;
   }
 
   function requireString(value, label) {
-    if (typeof value !== 'string' || value.length === 0) {
-      reject(`${label} is invalid`);
-    }
+    if (typeof value !== 'string' || value.length === 0) reject(`${label} is invalid`);
     return value;
   }
 
   function requireText(value, label, maximumLength) {
-    if (typeof value !== 'string' || value.length < 1 || value.length > maximumLength) {
-      reject(`${label} is invalid`);
-    }
+    if (typeof value !== 'string' || value.length < 1 || value.length > maximumLength) reject(`${label} is invalid`);
     return value;
   }
 
   function requireSha(value, label) {
-    if (typeof value !== 'string' || !/^[0-9a-f]{40}$/.test(value)) {
-      reject(`${label} is invalid`);
-    }
+    if (typeof value !== 'string' || !/^[0-9a-f]{40}$/.test(value)) reject(`${label} is invalid`);
     return value;
   }
 

--- a/.github/scripts/workflow-run-check.js
+++ b/.github/scripts/workflow-run-check.js
@@ -32,9 +32,7 @@ function workflowRunUrl(context) {
 }
 
 function buildCheckExternalId({ kind, runId, runAttempt, headSha }) {
-  if (typeof kind !== 'string' || !KIND_PATTERN.test(kind)) {
-    throw new Error('check kind is invalid');
-  }
+  if (typeof kind !== 'string' || !KIND_PATTERN.test(kind)) throw new Error('check kind is invalid');
   return `${EXTERNAL_ID_PREFIX}:${kind}:${requirePositiveInteger(Number(runId), 'workflow run id')}:${requirePositiveInteger(Number(runAttempt), 'workflow run attempt')}:${requireSha(headSha, 'check head SHA')}`;
 }
 
@@ -90,9 +88,7 @@ async function createWorkflowCheck({
 }
 
 function workflowResultConclusion(result) {
-  if (typeof result !== 'string' || !WORKFLOW_RESULTS.has(result)) {
-    throw new Error('workflow result is invalid');
-  }
+  if (typeof result !== 'string' || !WORKFLOW_RESULTS.has(result)) throw new Error('workflow result is invalid');
   return result;
 }
 


### PR DESCRIPTION
## Summary

Final PR of the CI-script consolidation stack. A tidy pass over the shared modules, the publishers, and the PR-metrics action library.

- **One-liner guard sweep.** Small single-statement `if` / `if/else` / `else if` blocks become one-liners across `.github/scripts/` and `.github/actions/pr-metrics-comment/` (167 conversions across two commits). Covers value and bare `return`s, `throw`, `continue`/`break`, simple expression bodies, and short if/else pairs. Rule: single-statement body, no comments, resulting line ≤ 120 chars. Guards that exceed that (or sit in chains with a multi-statement branch, where mixed bracing would hurt) stay multi-line.
- **`qodana-source.js`** drops the dead `hasTrustedReleaseProvenance` re-export — nothing imports it from there; consumers use the shared module directly.
- **`artifact-download.js`** validates `fileName`, `maxArchiveBytes`, and `maxBytes` up front in `validateDownloadOptions`, so a missing or `NaN` size limit can never silently disable the streaming download cap (NaN comparisons are false and would have bypassed the bound).
- **`download-base-metrics.sh`** warning now names the single `module-jars` artifact instead of "any supported artifact".

Stacked on #527.

## Behaviour

- Zero behaviour change — the sweeps are formatting only; every conversion was verified against its original (no else absorbed, no multi-statement body collapsed).
- The downloader now fails fast with `${label} download … is invalid` if a caller passes a bad size limit or file name — fail-closed hardening.

## Validation

- 119/119 node tests pass in every run (sweeps touched test helpers too — still green).
- `node --check` on all changed JS files, `bash -n` on the shell script.
- `git diff --check` clean; no converted line exceeds 120 chars.
