### PR TITLE
fix(ci): drop edited from heavy pull-request workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [master]
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, synchronize, reopened]
   push:
     branches: [master]
   merge_group:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,7 @@ name: CodeQL
 on:
   pull_request:
     branches: [master]
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, synchronize, reopened]
   push:
     branches: [master]
   merge_group:

--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -5,7 +5,7 @@ on:
   # Keep contents and pull-requests permissions read-only.
   pull_request_target:
     branches: [master]
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -127,6 +127,22 @@ The full CI path includes these code paths:
 | Weekly schedule | ✓ | ✓ | Trusted Qodana | ✓ |
 | `workflow_dispatch` | ✓ | ✓ | Trusted Qodana | ✓ |
 
+### Pull-request activity types
+
+The pull-request workflows listen for a subset of the `pull_request` activity types. `ci.yml`,
+`codeql.yml`, `qodana.yml`, and `release-provenance.yml` listen for `opened`, `synchronize`, and
+`reopened`. `pr.yml` additionally listens for `edited` and `ready_for_review` so that a title fix
+re-validates the required `Title` check without a new push.
+
+GitHub delivers `synchronize` when the head branch moves. It can also deliver an `edited` event at the
+same time when a branch is force-pushed or a bot updates the pull request (a title, body, or base
+change). The heavy workflows deliberately exclude `edited`: the second delivery carries the same head
+SHA and no code change, so re-running the pipeline would duplicate work, and the per-pull-request
+`concurrency` groups cancel one of the two run sets where they exist. Keeping `edited` only in `pr.yml`
+preserves title re-validation without duplicate heavy runs. A pull-request retarget fires `edited` and
+therefore does not re-run the heavy pipeline; the next push to the head branch or a `merge_group` entry
+re-runs it against the new base.
+
 ### Manual CI (`workflow_dispatch`)
 
 Select Actions → **CI** → **Run workflow**. A manual workflow always starts and does not use the path filter.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -131,17 +131,12 @@ The full CI path includes these code paths:
 
 The pull-request workflows listen for a subset of the `pull_request` activity types. `ci.yml`,
 `codeql.yml`, `qodana.yml`, and `release-provenance.yml` listen for `opened`, `synchronize`, and
-`reopened`. `pr.yml` additionally listens for `edited` and `ready_for_review` so that a title fix
-re-validates the required `Title` check without a new push.
+`reopened`. `pr.yml` listens for `opened`, `edited`, `synchronize`, `reopened`, and
+`ready_for_review`.
 
-GitHub delivers `synchronize` when the head branch moves. It can also deliver an `edited` event at the
-same time when a branch is force-pushed or a bot updates the pull request (a title, body, or base
-change). The heavy workflows deliberately exclude `edited`: the second delivery carries the same head
-SHA and no code change, so re-running the pipeline would duplicate work, and the per-pull-request
-`concurrency` groups cancel one of the two run sets where they exist. Keeping `edited` only in `pr.yml`
-preserves title re-validation without duplicate heavy runs. A pull-request retarget fires `edited` and
-therefore does not re-run the heavy pipeline; the next push to the head branch or a `merge_group` entry
-re-runs it against the new base.
+GitHub delivers `synchronize` when the head branch moves, including force-pushes. It delivers `edited`
+when pull-request metadata changes: the title, body, or base branch. `pr.yml` listens for `edited` so a
+title fix re-validates the required `Title` check without a new push.
 
 ### Manual CI (`workflow_dispatch`)
 


### PR DESCRIPTION
## Problem

Pull requests get **two run sets for one push** — one cancelled, one success — filling the UI with cancelled runs (PR 521 is a clear example).

GitHub delivers a second `pull_request` event alongside `synchronize` for force-pushed or bot-updated branches. Verified from the run pages for a single push (head `4b010e07`): CI run 31446383267 shows trigger `synchronize` (cancelled) and run 31446383417 shows trigger `edited` (success). Qodana — which listens for `opened, synchronize, reopened` only — received exactly **one** run, proving the second delivery is an `edited`. The per-pull-request `concurrency` groups in `ci.yml`, `codeql.yml`, and `pr.yml` then cancel one of the two sets.

Triggered by force-pushes (Release Please advancing the release branch, `gh stack` re-pushing after a rebase) and bot-driven PR updates — never by a code change. Both deliveries carry the same head SHA.

## Change

- `ci.yml`, `codeql.yml`, `release-provenance.yml`: activity types → `[opened, synchronize, reopened]` (drop `edited`).
- `pr.yml`: **keeps** `edited` and `ready_for_review` — the required `Title` check reads `github.event.pull_request.title` and must re-validate a title fix without a push. Its jobs are small.
- `docs/CI.md`: new *Pull-request activity types* section documenting the behaviour.

## Impact analysis

- Title/body edits no longer re-run the heavy pipeline (no code change — correct).
- A pull-request retarget fires `edited`, so heavy CI does not re-run for a new base; the next head push or `merge_group` entry re-runs it. Stacked PR bases are fixed by branch naming.
- Merge queue (`merge_group`), Qodana (already excluded `edited`), dependency review, and the required Status/Title/Commits checks are unaffected.
- `actionlint` passes on all changed workflows.
