### PR TITLE
perf(ci): cache Gradle deps and Qodana analysis for the linter

### DIFF
--- a/.github/workflows/qodana-trusted.yml
+++ b/.github/workflows/qodana-trusted.yml
@@ -102,6 +102,11 @@ jobs:
           path: source
           persist-credentials: false
 
+      - name: Restore Gradle caches for the linter
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-read-only: true
+
       - name: Scan the trusted source with Qodana
         uses: JetBrains/qodana-action@b588768b6e7e6da579e518bc584f79de0d243692 # v2026.2.0
         with:
@@ -114,7 +119,7 @@ jobs:
           use-annotations: false
           post-pr-comment: false
           push-fixes: none
-          use-caches: false
+          use-caches: true
         env:
           QODANA_REVISION: ${{ needs.register.outputs.head_sha }}
 

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -107,6 +107,12 @@ jobs:
         shell: bash
         run: cp --remove-destination -- qodana.yaml source/qodana.yaml
 
+      - name: Restore Gradle caches for the linter
+        if: needs.register.outputs.source_kind == 'code'
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-read-only: true
+
       - name: Scan pull-request code with Qodana
         if: needs.register.outputs.source_kind == 'code'
         uses: JetBrains/qodana-action@b588768b6e7e6da579e518bc584f79de0d243692 # v2026.2.0
@@ -120,7 +126,7 @@ jobs:
           use-annotations: false
           post-pr-comment: false
           push-fixes: none
-          use-caches: false
+          use-caches: true
         env:
           QODANA_PR_SHA: ${{ needs.register.outputs.merge_base_sha }}
           QODANA_REVISION: ${{ needs.register.outputs.head_sha }}

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -214,7 +214,9 @@ workflow code and the pull-request head into separate paths. It supplies the
 default-branch `qodana.yaml` file to Qodana. The scan job has only read
 permissions. It does not receive `QODANA_TOKEN`. It disables Qodana annotations,
 pull-request comments, fix pushes, and result upload. It stores one SARIF file
-as a bounded artefact.
+as a bounded artefact. It restores the Gradle and Qodana inspection caches
+read-only; GitHub scopes any cache writes from this pull-request-triggered
+workflow to the pull-request merge ref.
 
 The `Qodana publication` workflow checks out the default branch. It resolves
 the current pull request by head SHA and validates it, the changed paths, the
@@ -312,7 +314,7 @@ For an occasional diagnostic scan, give `build-scan: true` to `gradle-job`. The 
 | Default workflow permissions | Set the repository default to `contents: read` |
 | Release provenance workflow | Uses `contents: read` and `pull-requests: read`. Does not check out pull-request code |
 | CI gate | Uses `actions: read`, `contents: read`, and `pull-requests: read` |
-| Qodana scan | Triggers on `pull_request_target` from the default branch and runs in parallel with CI. The source-resolution and analysis jobs use only `actions: read`, `contents: read`, and `pull-requests: read`. They have no write permission, no `QODANA_TOKEN`, and no Qodana GitHub side effects |
+| Qodana scan | Triggers on `pull_request_target` from the default branch and runs in parallel with CI. The source-resolution and analysis jobs use only `actions: read`, `contents: read`, and `pull-requests: read`. They have no write permission, no `QODANA_TOKEN`, and no Qodana GitHub side effects. They restore the Gradle and Qodana caches read-only |
 | Qodana publication | Uses `actions: read`, `contents: read`, `pull-requests: read`, and `security-events: write`. It runs default-branch code, validates the artefacts, and uploads SARIF to code scanning |
 | Qodana trusted | The registration and report jobs use `checks: write`. The analysis job uses `actions: read`, `contents: read`, and `security-events: write` only for push, schedule, and manual-dispatch refs |
 | Release workflow | Uses an installation token from `release-please-kotventure`. Its `GITHUB_TOKEN` has no permissions |
@@ -445,6 +447,7 @@ Pull requests show many checks. Only the checks in the **Master** ruleset block 
 | Minecraft conformance fixtures | Uses `actions/cache`. The key comes from `targetMinecraftVersion` and `serverBundleSha1` |
 | PR metrics baselines | Uses the `actions/cache` key `ci-baseline-<sha>` on a master push. Downloads an artefact as a fallback. Rebuilds the JAR only as the last option |
 | Kover coverage hand-off | Shards upload `kover-handoff-<shard>`; Aggregate restores them and runs `:koverXmlReport :koverHtmlReport :koverVerify -Pkover.externalBinariesDir=modules`. No test re-run in Aggregate |
+| Qodana caches | The Qodana analyse jobs restore the Gradle caches read-only (`cache-read-only: true`) and restore and save the Qodana inspection cache (`use-caches: true`). Default-branch-scope caches are written only by trusted CI pushes; pull-request-triggered runs restore them |
 
 ### Artefacts
 


### PR DESCRIPTION
## Problem

The Qodana scan step takes **3.5–4 minutes** on every PR. The breakdown from the raw job log (run 31447534509):

- **~27s** — JetBrains IDE distribution download (`qodana-jvm-community`)
- **~75s** — cold Gradle dependency resolution inside the linter (572 downloads: 377 from Maven Central, 187 from plugins.gradle.org, 7 from PaperMC)
- **~76s** — the actual inspection

All caching was disabled (`use-caches: false`, no Gradle cache restore), so every PR paid the full cold-start cost.

## Change

Two levers, both confined to the Qodana analyse jobs:

1. **Gradle cache restore** — `gradle/actions/setup-gradle` with `cache-read-only: true` before the scan. The linter runs natively (`withinDocker: false` in `qodana.yaml`), so it consumes the host `~/.gradle` directly. Kills the ~75s dependency-resolution phase.
2. **Qodana analysis cache** — `use-caches: true` on the `qodana-action` call enables its built-in cache for the IDE distribution and analysis state.

## Trust boundary unchanged

- The analyse jobs keep `actions: read`, `contents: read`, `pull-requests: read` — no write permission, no `QODANA_TOKEN`.
- `cache-read-only: true` means the Gradle cache is only ever restored, never written.
- GitHub scopes any cache writes from `pull_request_target` runs to the pull-request merge ref; default-branch-scope caches are written only by trusted CI pushes.
- Applied identically to `qodana.yml` (PR path) and `qodana-trusted.yml` (push/schedule/manual path).

## Measurement plan

- First run on this PR = cold cache (measures the restore path).
- A follow-up commit will measure the warm path.

Docs updated: `docs/CI.md` (scan description, trust table, cache table).
