### PR TITLE
refactor(ci): trigger trusted Qodana directly instead of after CI

### DIFF
--- a/.github/scripts/qodana-security.test.js
+++ b/.github/scripts/qodana-security.test.js
@@ -25,7 +25,6 @@ const { downloadQodanaArtifact } = require('./qodana-publisher-storage.js');
 const {
   resolvePullRequestEventSource,
   resolvePullRequestSource,
-  resolveTrustedCiRun,
   QodanaSourceRejectedError,
 } = require('./qodana-source.js');
 
@@ -74,28 +73,7 @@ function makePullRequest({
   };
 }
 
-function makeCiRun({
-  event = 'workflow_dispatch',
-  headBranch = REPOSITORY.default_branch,
-  headSha = HEAD_SHA,
-} = {}) {
-  return {
-    id: 100,
-    run_attempt: 2,
-    workflow_id: 55,
-    event,
-    status: 'completed',
-    conclusion: 'success',
-    repository: REPOSITORY,
-    head_repository: REPOSITORY,
-    head_branch: headBranch,
-    head_sha: headSha,
-    pull_requests: [],
-  };
-}
-
 function makeGithub({
-  run,
   pullRequest = makePullRequest(),
   files,
   associatedPullRequests,
@@ -130,12 +108,6 @@ function makeGithub({
         }),
       },
       actions: {
-        getWorkflowRun: async () => ({ data: run ?? makeCiRun() }),
-        getWorkflow: async ({ workflow_id: workflowId }) => ({
-          data: workflowId === 'release-provenance.yml'
-            ? { path: '.github/workflows/release-provenance.yml' }
-            : { id: 55, name: 'CI', path: '.github/workflows/ci.yml' },
-        }),
         listJobsForWorkflowRun: listJobs,
         listWorkflowRuns: listReleaseRuns,
       },
@@ -756,31 +728,6 @@ test('resolves the pull_request_target event source for the register job', async
     headSha: HEAD_SHA,
     baseSha: BASE_SHA,
   }));
-});
-
-test('accepts trusted CI only from the current repository default branch', async () => {
-  const run = makeCiRun();
-  const source = await resolveTrustedCiRun({
-    github: makeGithub({ run }),
-    owner: 'LMLiam',
-    repo: 'Kotventure',
-    runId: run.id,
-  });
-  assert.deepEqual(source, {
-    event: 'workflow_dispatch',
-    headSha: HEAD_SHA,
-  });
-
-  run.head_branch = 'feature/untrusted-dispatch';
-  await assert.rejects(
-    resolveTrustedCiRun({
-      github: makeGithub({ run }),
-      owner: 'LMLiam',
-      repo: 'Kotventure',
-      runId: run.id,
-    }),
-    /default branch/,
-  );
 });
 
 test('uses the documentation attestation path without computing a merge base', async () => {

--- a/.github/scripts/qodana-source.js
+++ b/.github/scripts/qodana-source.js
@@ -1,13 +1,10 @@
 'use strict';
 
 const {
-  CI_WORKFLOW_NAME,
-  CI_WORKFLOW_PATH,
   buildArtifactName,
   classifyChangedFiles,
 } = require('./qodana-contract.js');
 const { createValidators } = require('./shared/validation.js');
-const { validateEventRun } = require('./shared/run-context.js');
 const { hasTrustedReleaseProvenance } = require('./shared/release-provenance.js');
 
 class QodanaSourceRejectedError extends Error {
@@ -28,14 +25,6 @@ const {
   requireObject,
   requireSha,
 } = createValidators(reject);
-
-function repositoryName(repository) {
-  requireObject(repository, 'repository');
-  if (typeof repository.full_name !== 'string' || repository.full_name.length === 0) {
-    reject('repository name is invalid');
-  }
-  return repository.full_name;
-}
 
 async function fetchRepository({ github, owner, repo }) {
   const repositoryResponse = await github.rest.repos.get({ owner, repo });
@@ -227,43 +216,9 @@ async function resolvePullRequestEventSource({ github, context, qodanaRunId, qod
   };
 }
 
-async function resolveTrustedCiRun({ github, owner, repo, runId, eventRun }) {
-  requirePositiveInteger(runId, 'workflow run id');
-  const repositoryResponse = await github.rest.repos.get({ owner, repo });
-  const repository = requireObject(repositoryResponse.data, 'repository');
-  requireEqual(repository.full_name, `${owner}/${repo}`, 'repository identity');
-  const runResponse = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
-  const run = requireObject(runResponse.data, 'workflow run');
-  const workflowResponse = await github.rest.actions.getWorkflow({
-    owner,
-    repo,
-    workflow_id: run.workflow_id,
-  });
-  const workflow = requireObject(workflowResponse.data, 'workflow');
-
-  if (eventRun) validateEventRun(reject, { eventRun, run });
-  if (!['push', 'schedule', 'workflow_dispatch'].includes(run.event)) reject('workflow run event is not trusted');
-  requireEqual(run.status, 'completed', 'workflow run status');
-  requireEqual(run.conclusion, 'success', 'workflow run conclusion');
-  requireEqual(run.repository?.full_name, repositoryName(repository), 'workflow run repository');
-  requireEqual(run.repository?.id, repository.id, 'workflow run repository id');
-  requireEqual(run.head_repository?.full_name, repository.full_name, 'workflow head repository');
-  requireEqual(run.head_repository?.id, repository.id, 'workflow head repository id');
-  requireEqual(run.head_branch, repository.default_branch, 'workflow run default branch');
-  requireEqual(workflow.id, run.workflow_id, 'workflow identity');
-  requireEqual(workflow.name, CI_WORKFLOW_NAME, 'workflow name');
-  requireEqual(workflow.path, CI_WORKFLOW_PATH, 'workflow path');
-
-  return {
-    event: run.event,
-    headSha: requireSha(run.head_sha, 'workflow run head SHA'),
-  };
-}
-
 module.exports = {
   QodanaSourceRejectedError,
   hasTrustedReleaseMetadata,
   resolvePullRequestEventSource,
   resolvePullRequestSource,
-  resolveTrustedCiRun,
 };

--- a/.github/scripts/qodana-workflow-security.test.js
+++ b/.github/scripts/qodana-workflow-security.test.js
@@ -80,30 +80,30 @@ test('only the trusted publication workflow can upload Qodana SARIF', () => {
   assert.doesNotMatch(workflow, /Complete the pull-request Qodana check/);
 });
 
-test('trusted Qodana runs are limited to trusted CI events', () => {
+test('trusted Qodana runs are limited to trusted default-branch refs', () => {
   const workflow = readRepositoryFile('.github/workflows/qodana-trusted.yml');
-  const register = readJob(workflow, 'register', 'analyse');
-  const analyse = readJob(workflow, 'analyse', 'report');
-  const report = readJob(workflow, 'report');
+  const analyse = readJob(workflow, 'analyse');
 
-  assert.match(workflow, /workflow_run:/);
-  assert.match(workflow, /event == 'push'/);
+  assert.match(workflow, /push:/);
+  assert.match(workflow, /branches: \[master\]/);
+  assert.match(workflow, /schedule:/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /workflow_run:/);
   assert.doesNotMatch(workflow, /merge_group/);
-  assert.match(workflow, /security-events:\s*write/);
-  assert.match(register, /checks:\s*write/);
+  assert.doesNotMatch(workflow, /pull_request_target:/);
+  assert.match(analyse, /security-events:\s*write/);
   assert.doesNotMatch(analyse, /checks:\s*write/);
-  assert.match(report, /checks:\s*write/);
-  assert.match(report, /needs\.register\.outputs\.check_run_id != ''/);
-  assert.match(report, /REGISTER_RESULT: \$\{\{ needs\.register\.result \}\}/);
   assert.doesNotMatch(workflow, /QODANA_TOKEN/);
-  assert.match(workflow, /resolveTrustedCiRun/);
-  assert.match(workflow, /ref:\s*\$\{\{ needs\.register\.outputs\.head_sha \}\}/);
+  assert.doesNotMatch(workflow, /resolveTrustedCiRun/);
+  assert.match(workflow, /ref:\s*\$\{\{ github\.sha \}\}/);
   assert.match(workflow, /--project-dir source\s+--config qodana\.yaml/);
   assert.doesNotMatch(workflow, /--config source\/qodana\.yaml/);
-  assert.match(workflow, /ref:\s*refs\/heads\/\$\{\{ github\.event\.repository\.default_branch \}\}/);
-  assert.match(workflow, /sha:\s*\$\{\{ needs\.register\.outputs\.head_sha \}\}/);
+  assert.match(workflow, /ref:\s*\$\{\{ github\.ref \}\}/);
+  assert.match(workflow, /sha:\s*\$\{\{ github\.sha \}\}/);
   assert.match(workflow, /checkout_path:\s*source/);
-  assert.match(report, /Complete the trusted Qodana check/);
+  assert.match(workflow, /cache-read-only: true/);
+  assert.match(workflow, /use-caches: true/);
+  assert.doesNotMatch(workflow, /Report trusted Qodana check/);
 });
 
 test('trusted metrics publication reports its result against the pull-request head', () => {

--- a/.github/workflows/qodana-trusted.yml
+++ b/.github/workflows/qodana-trusted.yml
@@ -1,86 +1,25 @@
 name: Qodana trusted
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
+  push:
+    branches: [master]
+  schedule:
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
 
 permissions: {}
 
 concurrency:
-  group: qodana-trusted-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+  group: qodana-trusted-${{ github.ref }}
   cancel-in-progress: true
 
 env:
   NODE_OPTIONS: --use-system-ca
 
 jobs:
-  register:
-    name: Register trusted Qodana check
-    if: >-
-      (
-        github.event.workflow_run.event == 'push'
-        || github.event.workflow_run.event == 'schedule'
-        || github.event.workflow_run.event == 'workflow_dispatch'
-      )
-      && github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      actions: read
-      checks: write
-      contents: read
-    outputs:
-      check_external_id: ${{ steps.source.outputs.check_external_id }}
-      check_run_id: ${{ steps.source.outputs.check_run_id }}
-      head_sha: ${{ steps.source.outputs.head_sha }}
-    steps:
-      - name: Checkout trusted workflow code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.sha }}
-          persist-credentials: false
-
-      - name: Resolve the completed trusted CI source
-        id: source
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          retries: 3
-          retry-exempt-status-codes: 400,401,403,404,422
-          script: |
-            const { resolveTrustedCiRun } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/qodana-source.js`);
-            const source = await resolveTrustedCiRun({
-              github,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              runId: context.payload.workflow_run.id,
-              eventRun: context.payload.workflow_run,
-            });
-            core.setOutput('head_sha', source.headSha);
-            const {
-              buildCheckExternalId,
-              createWorkflowCheck,
-            } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/workflow-run-check.js`);
-            const externalId = buildCheckExternalId({
-              kind: 'qodana-trusted',
-              runId: context.runId,
-              runAttempt: context.runAttempt,
-              headSha: source.headSha,
-            });
-            const check = await createWorkflowCheck({
-              github,
-              context,
-              name: 'Qodana / trusted ref',
-              headSha: source.headSha,
-              externalId,
-              summary: 'Qodana is analysing the validated trusted source.',
-            });
-            core.setOutput('check_run_id', String(check.id));
-            core.setOutput('check_external_id', check.externalId);
-
   analyse:
     name: Qodana trusted ref
-    needs: register
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -94,11 +33,11 @@ jobs:
           ref: ${{ github.sha }}
           persist-credentials: false
 
-      - name: Checkout the validated trusted source
+      - name: Checkout the trusted source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.repository }}
-          ref: ${{ needs.register.outputs.head_sha }}
+          ref: ${{ github.sha }}
           path: source
           persist-credentials: false
 
@@ -121,7 +60,7 @@ jobs:
           push-fixes: none
           use-caches: true
         env:
-          QODANA_REVISION: ${{ needs.register.outputs.head_sha }}
+          QODANA_REVISION: ${{ github.sha }}
 
       - name: Normalize Qodana SARIF regions
         shell: bash
@@ -134,59 +73,6 @@ jobs:
         with:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
           checkout_path: source
-          ref: refs/heads/${{ github.event.repository.default_branch }}
-          sha: ${{ needs.register.outputs.head_sha }}
+          ref: ${{ github.ref }}
+          sha: ${{ github.sha }}
           category: Kotventure/qodana
-
-  report:
-    name: Report trusted Qodana check
-    needs: [register, analyse]
-    if: always() && needs.register.outputs.check_run_id != ''
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      checks: write
-      contents: read
-    steps:
-      - name: Checkout trusted workflow code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.sha }}
-          persist-credentials: false
-
-      - name: Complete the trusted Qodana check
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          ANALYSE_RESULT: ${{ needs.analyse.result }}
-          CHECK_EXTERNAL_ID: ${{ needs.register.outputs.check_external_id }}
-          CHECK_RUN_ID: ${{ needs.register.outputs.check_run_id }}
-          HEAD_SHA: ${{ needs.register.outputs.head_sha }}
-          REGISTER_RESULT: ${{ needs.register.result }}
-        with:
-          retries: 3
-          retry-exempt-status-codes: 400,401,403,404,422
-          script: |
-            const {
-              completeWorkflowCheck,
-              workflowResultConclusion,
-            } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/workflow-run-check.js`);
-            const result = process.env.REGISTER_RESULT === 'success'
-              ? process.env.ANALYSE_RESULT
-              : process.env.REGISTER_RESULT;
-            const conclusion = workflowResultConclusion(result);
-            const summaries = {
-              success: 'Qodana analysed and published the validated trusted source.',
-              failure: 'Qodana analysis or publication failed.',
-              cancelled: 'The trusted Qodana workflow was cancelled.',
-              skipped: 'The trusted Qodana workflow was skipped.',
-            };
-            await completeWorkflowCheck({
-              github,
-              context,
-              checkId: Number(process.env.CHECK_RUN_ID),
-              name: 'Qodana / trusted ref',
-              headSha: process.env.HEAD_SHA,
-              externalId: process.env.CHECK_EXTERNAL_ID,
-              conclusion,
-              summary: summaries[conclusion],
-            });

--- a/.github/workflows/qodana-trusted.yml
+++ b/.github/workflows/qodana-trusted.yml
@@ -102,6 +102,11 @@ jobs:
           path: source
           persist-credentials: false
 
+      - name: Restore Gradle caches for the linter
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-read-only: true
+
       - name: Scan the trusted source with Qodana
         uses: JetBrains/qodana-action@b588768b6e7e6da579e518bc584f79de0d243692 # v2026.2.0
         with:
@@ -114,7 +119,7 @@ jobs:
           use-annotations: false
           post-pr-comment: false
           push-fixes: none
-          use-caches: false
+          use-caches: true
         env:
           QODANA_REVISION: ${{ needs.register.outputs.head_sha }}
 

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -107,6 +107,12 @@ jobs:
         shell: bash
         run: cp --remove-destination -- qodana.yaml source/qodana.yaml
 
+      - name: Restore Gradle caches for the linter
+        if: needs.register.outputs.source_kind == 'code'
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-read-only: true
+
       - name: Scan pull-request code with Qodana
         if: needs.register.outputs.source_kind == 'code'
         uses: JetBrains/qodana-action@b588768b6e7e6da579e518bc584f79de0d243692 # v2026.2.0
@@ -120,7 +126,7 @@ jobs:
           use-annotations: false
           post-pr-comment: false
           push-fixes: none
-          use-caches: false
+          use-caches: true
         env:
           QODANA_PR_SHA: ${{ needs.register.outputs.merge_base_sha }}
           QODANA_REVISION: ${{ needs.register.outputs.head_sha }}

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -15,7 +15,7 @@ For local development commands, see [CONTRIBUTING.md](../.github/CONTRIBUTING.md
 | **PR metrics publication** | `pr-metrics-publish.yml` | `workflow_run` after CI | Validates the CI result and publishes one metrics comment with default-branch code |
 | **Qodana** | `qodana.yml` | `pull_request_target` (in parallel with PR CI) | Runs Qodana with read-only permissions and creates one bounded SARIF artefact |
 | **Qodana publication** | `qodana-publish.yml` | `workflow_run` after Qodana | Validates the current PR and publishes SARIF with default-branch code |
-| **Qodana trusted** | `qodana-trusted.yml` | `workflow_run` after successful push, schedule, or dispatch CI | Runs and publishes Qodana for trusted refs |
+| **Qodana trusted** | `qodana-trusted.yml` | push `master`, weekly schedule, `workflow_dispatch` | Runs and publishes Qodana for trusted refs, parallel with CI |
 | **PR** | `pr.yml` | `pull_request_target` | Title + commit validation, area labels |
 | **Release provenance** | `release-provenance.yml` | `pull_request_target` | Verifies Release Please identity and release files from the default branch |
 | **Release** | `release.yml` | push `master` | Opens or updates release PRs. Creates tags and releases after merge |
@@ -53,10 +53,10 @@ CI
 └─ Status (required merge-gate check) ─────────────────────────────
     └─ Aggregates Tier 1 + Vanilla + Dependencies
 
-Qodana security pipeline (pull_request_target, parallel with PR CI)
-├─ Qodana            (read-only PR-head analysis or trusted attestation artefact)
+Qodana security pipeline (parallel with CI)
+├─ Qodana            (pull_request_target, read-only PR-head analysis or trusted attestation artefact)
 ├─ Qodana publication (default-branch validation and SARIF upload, workflow_run after Qodana)
-└─ Qodana trusted    (trusted push, schedule, and dispatch analysis)
+└─ Qodana trusted    (push master, schedule, and manual-dispatch analysis, direct triggers)
 
 PR metrics publication (workflow_run)
 └─ Validates the completed CI run, result artefact, and current PR
@@ -75,8 +75,8 @@ gate from it. It does not re-run tests: the Aggregate Gradle invocation contains
 
 The workflow listens for `merge_group` events. Merge groups, schedules, and manual dispatches do not use the path
 filter. They always start the full pipeline: Build (sharded → Aggregate with `koverVerify` at 85%), Vanilla, Dokka, and CodeQL (own workflow). The `Qodana trusted` workflow analyses a
-push, schedule, or manual-dispatch ref after CI completes. It does not run for a merge-group ref because a merge group
-contains pull-request code.
+push, schedule, or manual-dispatch ref with its own direct triggers, in parallel with CI. It does not run for a
+merge-group ref because a merge group contains pull-request code.
 
 ## When workflows run
 
@@ -229,11 +229,14 @@ No pull-request code runs in the publication workflow. A failed Qodana analysis
 or a rejected source simply publishes nothing; the job-derived checks on the
 pull request surface the failure.
 
-The `Qodana trusted` workflow handles push, schedule, and manual-dispatch CI.
-It checks out the trusted source commit and uploads its result directly. Its
-write permission does not apply to pull-request or merge-group analysis. A
-registration job creates the `Qodana / trusted ref` check on the validated
-source commit. A separate report job completes the check after analysis.
+The `Qodana trusted` workflow handles push, schedule, and manual-dispatch
+refs with direct triggers, in parallel with CI. A job-level guard restricts it
+to the repository default branch, so a manual dispatch on another branch is
+skipped. It checks out the trusted source commit and uploads its result
+directly. Its `security-events: write` permission does not apply to
+pull-request or merge-group analysis. The job-derived checks appear on the
+analysed commit; no separate registration or report job creates a manual
+check.
 
 The `Master` ruleset requires one applicable QDJVM result for each pull request:
 documentation-only pull requests use the documentation attestation, code pull
@@ -316,7 +319,7 @@ For an occasional diagnostic scan, give `build-scan: true` to `gradle-job`. The 
 | CI gate | Uses `actions: read`, `contents: read`, and `pull-requests: read` |
 | Qodana scan | Triggers on `pull_request_target` from the default branch and runs in parallel with CI. The source-resolution and analysis jobs use only `actions: read`, `contents: read`, and `pull-requests: read`. They have no write permission, no `QODANA_TOKEN`, and no Qodana GitHub side effects. They restore the Gradle and Qodana caches read-only |
 | Qodana publication | Uses `actions: read`, `contents: read`, `pull-requests: read`, and `security-events: write`. It runs default-branch code, validates the artefacts, and uploads SARIF to code scanning |
-| Qodana trusted | The registration and report jobs use `checks: write`. The analysis job uses `actions: read`, `contents: read`, and `security-events: write` only for push, schedule, and manual-dispatch refs |
+| Qodana trusted | Uses `actions: read`, `contents: read`, and `security-events: write`. Runs only on push, schedule, and manual-dispatch refs for the repository default branch. Has no `checks: write` |
 | Release workflow | Uses an installation token from `release-please-kotventure`. Its `GITHUB_TOKEN` has no permissions |
 | Build job | Uses `checks: write` and `contents: read`. Cannot write to pull requests. Clears `GITHUB_TOKEN` for Gradle |
 | PR feedback job | Uses `actions: read`, `pull-requests: read`, and `contents: read`. Computes a bounded result artefact and cannot write to pull requests. Uses the cache or artefacts before a base JAR-only build. Clears `GITHUB_TOKEN` for Gradle |

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -214,7 +214,9 @@ workflow code and the pull-request head into separate paths. It supplies the
 default-branch `qodana.yaml` file to Qodana. The scan job has only read
 permissions. It does not receive `QODANA_TOKEN`. It disables Qodana annotations,
 pull-request comments, fix pushes, and result upload. It stores one SARIF file
-as a bounded artefact.
+as a bounded artefact. It restores the Gradle and Qodana inspection caches
+read-only; GitHub scopes any cache writes from this pull-request-triggered
+workflow to the pull-request merge ref.
 
 The `Qodana publication` workflow checks out the default branch. It resolves
 the current pull request by head SHA and validates it, the changed paths, the
@@ -312,7 +314,7 @@ For an occasional diagnostic scan, give `build-scan: true` to `gradle-job`. The 
 | Default workflow permissions | Set the repository default to `contents: read` |
 | Release provenance workflow | Uses `contents: read` and `pull-requests: read`. Does not check out pull-request code |
 | CI gate | Uses `actions: read`, `contents: read`, and `pull-requests: read` |
-| Qodana scan | Triggers on `pull_request_target` from the default branch and runs in parallel with CI. The source-resolution and analysis jobs use only `actions: read`, `contents: read`, and `pull-requests: read`. They have no write permission, no `QODANA_TOKEN`, and no Qodana GitHub side effects |
+| Qodana scan | Triggers on `pull_request_target` from the default branch and runs in parallel with CI. The source-resolution and analysis jobs use only `actions: read`, `contents: read`, and `pull-requests: read`. They have no write permission, no `QODANA_TOKEN`, and no Qodana GitHub side effects. They restore the Gradle and Qodana caches read-only |
 | Qodana publication | Uses `actions: read`, `contents: read`, `pull-requests: read`, and `security-events: write`. It runs default-branch code, validates the artefacts, and uploads SARIF to code scanning |
 | Qodana trusted | The registration and report jobs use `checks: write`. The analysis job uses `actions: read`, `contents: read`, and `security-events: write` only for push, schedule, and manual-dispatch refs |
 | Release workflow | Uses an installation token from `release-please-kotventure`. Its `GITHUB_TOKEN` has no permissions |
@@ -445,6 +447,7 @@ Pull requests show many checks. Only the checks in the **Master** ruleset block 
 | Minecraft conformance fixtures | Uses `actions/cache`. The key comes from `targetMinecraftVersion` and `serverBundleSha1` |
 | PR metrics baselines | Uses the `actions/cache` key `ci-baseline-<sha>` on a master push. Downloads an artefact as a fallback. Rebuilds the JAR only as the last option |
 | Kover coverage hand-off | Shards upload `kover-handoff-<shard>`; Aggregate restores them and runs `:koverXmlReport :koverHtmlReport :koverVerify -Pkover.externalBinariesDir=modules`. No test re-run in Aggregate |
+| Qodana caches | The Qodana analyse jobs restore the Gradle caches read-only (`cache-read-only: true`) and restore and save the Qodana inspection cache (`use-caches: true`). Default-branch-scope caches are written only by trusted CI pushes; pull-request-triggered runs restore them |
 
 ### Artefacts
 


### PR DESCRIPTION
## Problem

The `Qodana trusted` workflow was the last leftover from the old `workflow_run` architecture. It only started **after the entire CI pipeline finished** (via `workflow_run` on CI completion) and gated the scan on CI concluding `success` — so trusted Qodana results for master pushes arrived minutes after the code, and the workflow carried a manual check-registration job and a report job to surface a `Qodana / trusted ref` check.

The PR-path Qodana workflow moved to `pull_request_target` (direct trigger, parallel with CI) earlier; this change brings the trusted path in line.

## Change

- **Direct triggers**: `push` to `master`, the weekly schedule, and `workflow_dispatch`. The trusted scan now runs **in parallel with CI** instead of waiting for it.
- **Single analyse job**: the `register` and `report` jobs are gone, along with the manual `Qodana / trusted ref` check and the `checks: write` permission. Job-derived checks appear on the analysed commit automatically.
- **Dead code removed**: `resolveTrustedCiRun` (and its tests, plus now-unused test stubs) deleted from `qodana-source.js`.
- **Docs**: workflow map, DAG, event matrix, trust table, and the trusted-flow description updated in `docs/CI.md`.
- **Caching retained**: the Gradle cache restore (`cache-read-only: true`) and Qodana inspection cache (`use-caches: true`) from #530 stay in place.

## Trust boundary

- A job-level guard (`github.ref == refs/heads/<default branch>`) restricts analysis to the repository default branch, preserving the previous `resolveTrustedCiRun` invariant that only default-branch refs are scanned. A manual dispatch on a feature branch is skipped.
- The workflow keeps `security-events: write` for the SARIF upload and drops `checks: write`. It never triggers on pull requests or merge groups.

## Behaviour note

The old flow scanned a push only if CI succeeded; the new flow scans every push in parallel, so a commit whose CI later fails still receives a Qodana scan. On a broken master the linter's Gradle import may fail, producing a failed `Qodana trusted` job on that commit and no SARIF. This is the intended tradeoff for parallelism.
