### PR TITLE
chore(ci): scaffold npm tooling manifest under .github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,19 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "chore(ci)"
+
+  - package-ecosystem: "npm"
+    directory: "/.github"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "type: chore"
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/package-lock.json
+++ b/.github/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "kotventure-ci-tooling",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kotventure-ci-tooling",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/.github/package.json
+++ b/.github/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "kotventure-ci-tooling",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ bin/
 ### Agent scratch ###
 .agents/plans/
 .superpowers/
+
+### Node tooling ###
+.github/node_modules/

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -376,6 +376,13 @@ repository automation tests use `node --test`.
 | `qodana-publisher-storage.js` | Bounded artifact download and SARIF validation |
 | `workflow-run-check.js` | Creates, validates, and completes source-bound workflow checks |
 
+The `.github/package.json` manifest and its committed `package-lock.json` hold the npm
+dependencies of the CI tooling. Only four jobs install them: Lint (Actions), PR feedback,
+PR metrics publication, and Qodana publication. Each runs `npm ci --ignore-scripts
+--no-audit --no-fund` from `/.github`; the trusted publishers install against the
+default-branch lockfile. All other script jobs (Triage, CodeQL Gate, Qodana register,
+Release provenance) are dependency-free.
+
 ## Action pins and Dependabot
 
 Each third-party action uses a fixed SHA and has a version comment. One `github-actions` entry in
@@ -386,6 +393,7 @@ new composite actions without a configuration change.
 |-----------|----------|---------------|
 | Gradle (`/`) | Minor and patch updates grouped (`gradle-minor-patch`). Major updates ungrouped | 10 |
 | GitHub Actions (root + composites) | Minor and patch updates grouped. Major updates ungrouped | 10 |
+| npm (`/.github`) | Minor and patch updates grouped (`npm-minor-patch`). Major updates ungrouped | 10 |
 
 ## Branch protection (`master`)
 


### PR DESCRIPTION
## Summary

Adds an npm package manifest for the CI tooling under `.github`, with a committed
lockfile and Dependabot coverage.

- `.github/package.json` — private, MIT, CommonJS, zero dependencies today.
- `.github/package-lock.json` — generated (`lockfileVersion` 3), committed.
- `.gitignore` — ignores `.github/node_modules/`.
- `.github/dependabot.yml` — new `npm` ecosystem entry for `/.github`, weekly
  schedule, minor+patch grouped (`npm-minor-patch`), `chore(ci)` commit prefix,
  matching the existing `github-actions` entry.
- `docs/CI.md` — documents the manifest and the four jobs that will install the
  dependencies (Lint (Actions), PR feedback, PR metrics publication, Qodana
  publication); all other script jobs stay dependency-free.

No workflow changes: no job installs anything yet. The `npm ci` steps land with
the first actual dependency.

## Validation

- `npm ci --ignore-scripts --no-audit --no-fund` in `/.github` succeeds.
- Node test suite: 117/117 pass.
- `git diff --check` clean.
