### PR TITLE
refactor(ci): parse patches with jsdiff

### DIFF
--- a/.github/actions/pr-metrics-comment/lib/patch.js
+++ b/.github/actions/pr-metrics-comment/lib/patch.js
@@ -1,24 +1,23 @@
 'use strict';
 
-const HUNK_HEADER = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+const { parsePatch } = require('diff');
 
-function parsePatch(patch) {
+function parseHunks(patch) {
   const addedLines = [];
   const removedText = [];
-  let newLine = 0;
-  for (const line of patch.split('\n')) {
-    const hunk = line.match(HUNK_HEADER);
-    if (hunk) {
-      newLine = parseInt(hunk[1], 10);
-      continue;
-    }
-    if (line.startsWith('+')) {
-      addedLines.push({ line: newLine, text: line.slice(1) });
-      newLine += 1;
-    } else if (line.startsWith('-')) {
-      removedText.push(line.slice(1));
-    } else if (!line.startsWith('\\')) {
-      newLine += 1;
+  for (const file of parsePatch(patch)) {
+    for (const hunk of file.hunks) {
+      let newLine = hunk.newStart;
+      for (const line of hunk.lines) {
+        if (line.startsWith('+')) {
+          addedLines.push({ line: newLine, text: line.slice(1) });
+          newLine += 1;
+        } else if (line.startsWith('-')) {
+          removedText.push(line.slice(1));
+        } else if (!line.startsWith('\\')) {
+          newLine += 1;
+        }
+      }
     }
   }
   return { addedLines, removedText };
@@ -28,7 +27,7 @@ function parsePatches(files) {
   const parsed = [];
   for (const file of files) {
     if (!file.patch || file.status === 'removed') continue;
-    parsed.push({ path: file.filename, ...parsePatch(file.patch) });
+    parsed.push({ path: file.filename, ...parseHunks(file.patch) });
   }
   return parsed;
 }

--- a/.github/actions/pr-metrics-comment/test/patch.test.js
+++ b/.github/actions/pr-metrics-comment/test/patch.test.js
@@ -6,7 +6,7 @@ const { parsePatches } = require('../lib/patch.js');
 
 test('tracks added line numbers across context and removals', () => {
   const patch = [
-    '@@ -1,4 +1,5 @@',
+    '@@ -1,3 +1,4 @@',
     ' context',
     '-old line',
     '+new line',
@@ -56,4 +56,38 @@ test('skips removed files and files without a patch', () => {
   ];
   const parsed = parsePatches(files);
   assert.deepEqual(parsed.map((f) => f.path), ['Kept.kt']);
+});
+
+test('jsdiff parses GitHub REST hunk-only patches without file headers', () => {
+  const { parsePatch } = require('diff');
+  const patch = [
+    '@@ -1,3 +1,4 @@',
+    ' context',
+    '-old line',
+    '+new line',
+    '+second new',
+    ' more context',
+  ].join('\n');
+  const [file] = parsePatch(patch);
+  assert.equal(file.oldFileName, undefined);
+  assert.equal(file.newFileName, undefined);
+  assert.deepEqual(file.hunks[0].lines, [
+    ' context',
+    '-old line',
+    '+new line',
+    '+second new',
+    ' more context',
+  ]);
+});
+
+test('rejects a hunk whose declared counts do not match its body', () => {
+  const patch = [
+    '@@ -1,4 +1,5 @@',
+    ' context',
+    '-old line',
+    '+new line',
+    '+second new',
+    ' more context',
+  ].join('\n');
+  assert.throws(() => parsePatches([{ filename: 'Foo.kt', status: 'modified', patch }]));
 });

--- a/.github/package-lock.json
+++ b/.github/package-lock.json
@@ -7,7 +7,19 @@
     "": {
       "name": "kotventure-ci-tooling",
       "version": "1.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "diff": "9.0.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     }
   }
 }

--- a/.github/package.json
+++ b/.github/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "license": "MIT",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "diff": "9.0.0"
+  }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install CI tooling dependencies
+        working-directory: .github
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
       - name: Check one type declaration per file
         run: bash .github/scripts/check-one-declaration-per-file.sh
 
@@ -493,6 +497,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Install CI tooling dependencies
+        working-directory: .github
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Restore base baseline cache
         id: base-cache

--- a/.github/workflows/pr-metrics-publish.yml
+++ b/.github/workflows/pr-metrics-publish.yml
@@ -37,6 +37,10 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
+      - name: Install CI tooling dependencies
+        working-directory: .github
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
       - name: Validate source run
         id: source
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Summary

Replaces the hand-rolled hunk parser in `lib/patch.js` with the maintained
`diff` (jsdiff) package (`diff@9.0.0`, BSD-3-Clause, zero runtime dependencies).

- `parsePatches` keeps its exact exported shape, so `patch-coverage.js` and
  every consumer are untouched.
- Added-line numbers still derive from the hunk `newStart` plus iteration.
- jsdiff 9 validates declared hunk counts: a patch whose counts do not match
  its body now fails closed instead of parsing leniently. Git- and
  GitHub-generated patches always satisfy the counts; the one test fixture
  with inconsistent counts was corrected, and the stricter behaviour is pinned
  by a new test.
- The GitHub REST hunk-only patch format (no file headers) is documented
  jsdiff input; a contract test pins it.

Adds the `npm ci` step to the three jobs that run this code: Lint (Actions),
PR feedback, and PR metrics publication.

## Validation

- `node --test` suite: 119/119 pass
- `actionlint` clean on both touched workflows
- `git diff --check` clean
