### PR TITLE
refactor(ci): enumerate jar classes with yauzl

### DIFF
--- a/.github/actions/pr-metrics-comment/lib/collect.js
+++ b/.github/actions/pr-metrics-comment/lib/collect.js
@@ -44,8 +44,10 @@ async function collect({ env, context, github, core }) {
 
   const headCoverage = readCoverage(env.HEAD_COVERAGE_PATH);
   const baseCoverage = readCoverage(env.BASE_COVERAGE_PATH);
-  const headJars = collectJars(env.HEAD_LIBS_DIR);
-  const baseJars = collectJars(env.BASE_LIBS_DIR);
+  const [headJars, baseJars] = await Promise.all([
+    collectJars(env.HEAD_LIBS_DIR),
+    collectJars(env.BASE_LIBS_DIR),
+  ]);
 
   if (!headCoverage && headJars.size === 0) {
     core.warning('No head coverage report or JARs found; skipping metrics result');

--- a/.github/actions/pr-metrics-comment/lib/jars.js
+++ b/.github/actions/pr-metrics-comment/lib/jars.js
@@ -19,15 +19,15 @@ function versionKey(version) {
   }).join('.');
 }
 
-function collectJars(rootDir) {
+async function collectJars(rootDir) {
   const sizes = new Map();
   const bestVersion = new Map();
   if (!fs.existsSync(rootDir)) return sizes;
-  function walk(dir) {
+  async function walk(dir) {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        walk(full);
+        await walk(full);
         continue;
       }
       if (!entry.isFile()) continue;
@@ -36,13 +36,13 @@ function collectJars(rootDir) {
       const prev = bestVersion.get(parsed.module);
       if (!prev || versionKey(parsed.version) > versionKey(prev.version)) {
         const size = fs.statSync(full).size;
-        const classes = countClassEntries(fs.readFileSync(full));
+        const classes = await countClassEntries(fs.readFileSync(full));
         bestVersion.set(parsed.module, { version: parsed.version });
         sizes.set(parsed.module, { size, classes });
       }
     }
   }
-  walk(rootDir);
+  await walk(rootDir);
   return sizes;
 }
 

--- a/.github/actions/pr-metrics-comment/lib/zip.js
+++ b/.github/actions/pr-metrics-comment/lib/zip.js
@@ -1,43 +1,18 @@
 'use strict';
 
-const EOCD_SIG = 0x06054b50;
-const CENTRAL_SIG = 0x02014b50;
-const EOCD_MIN_SIZE = 22;
-const CENTRAL_HEADER_SIZE = 46;
+const yauzl = require('yauzl');
 
-function findEocd(buffer) {
-  const start = Math.max(0, buffer.length - EOCD_MIN_SIZE - 0xffff);
-  for (let i = buffer.length - EOCD_MIN_SIZE; i >= start; i--) {
-    if (buffer.readUInt32LE(i) !== EOCD_SIG) continue;
-    const commentLength = buffer.readUInt16LE(i + 20);
-    if (i + EOCD_MIN_SIZE + commentLength === buffer.length) return i;
-  }
-  return -1;
-}
-
-function countClassEntries(buffer) {
-  if (buffer.length < EOCD_MIN_SIZE) return null;
-  const eocd = findEocd(buffer);
-  if (eocd < 0) return null;
-  const totalEntries = buffer.readUInt16LE(eocd + 10);
-  const cdOffset = buffer.readUInt32LE(eocd + 16);
-  let classes = 0;
-  let offset = cdOffset;
-  for (let entry = 0; entry < totalEntries; entry++) {
-    if (offset + CENTRAL_HEADER_SIZE > buffer.length
-        || buffer.readUInt32LE(offset) !== CENTRAL_SIG) {
-      return null;
+async function countClassEntries(buffer) {
+  try {
+    const zipfile = await yauzl.fromBufferPromise(buffer);
+    let classes = 0;
+    for await (const entry of zipfile.eachEntry()) {
+      if (entry.fileName.endsWith('.class')) classes += 1;
     }
-    const nameLength = buffer.readUInt16LE(offset + 28);
-    const extraLength = buffer.readUInt16LE(offset + 30);
-    const commentLength = buffer.readUInt16LE(offset + 32);
-    const recordEnd = offset + CENTRAL_HEADER_SIZE + nameLength + extraLength + commentLength;
-    if (recordEnd > buffer.length) return null;
-    const name = buffer.toString('utf8', offset + CENTRAL_HEADER_SIZE, offset + CENTRAL_HEADER_SIZE + nameLength);
-    if (name.endsWith('.class')) classes += 1;
-    offset = recordEnd;
+    return classes;
+  } catch {
+    return null;
   }
-  return classes;
 }
 
 module.exports = { countClassEntries };

--- a/.github/actions/pr-metrics-comment/test/jars.test.js
+++ b/.github/actions/pr-metrics-comment/test/jars.test.js
@@ -18,45 +18,45 @@ function makeTree(files) {
   return root;
 }
 
-test('collects module jar sizes from a nested tree', () => {
+test('collects module jar sizes from a nested tree', async () => {
   const root = makeTree({
     'module-jars/kotventure-core-1.2.3.jar': 100,
     'other/kotventure-minimessage-1.2.3.jar': 200,
   });
-  const jars = collectJars(root);
+  const jars = await collectJars(root);
   assert.equal(jars.get('core').size, 100);
   assert.equal(jars.get('minimessage').size, 200);
 });
 
-test('prefers the highest version, comparing segments numerically', () => {
+test('prefers the highest version, comparing segments numerically', async () => {
   const root = makeTree({
     'kotventure-core-1.2.3.jar': 100,
     'kotventure-core-1.10.0.jar': 300,
     'kotventure-core-0.9.9.jar': 50,
   });
-  assert.equal(collectJars(root).get('core').size, 300);
+  assert.equal((await collectJars(root)).get('core').size, 300);
 });
 
-test('counts classes for real archives and reports null otherwise', () => {
+test('counts classes for real archives and reports null otherwise', async () => {
   const root = makeTree({
     'kotventure-core-1.2.3.jar': buildZip(['a/B.class', 'a/C.class', 'META-INF/MANIFEST.MF']),
     'kotventure-minimessage-1.2.3.jar': 100,
   });
-  const jars = collectJars(root);
+  const jars = await collectJars(root);
   assert.equal(jars.get('core').classes, 2);
   assert.equal(jars.get('minimessage').classes, null);
 });
 
-test('ignores sources, javadoc, and non-kotventure jars', () => {
+test('ignores sources, javadoc, and non-kotventure jars', async () => {
   const root = makeTree({
     'kotventure-core-1.2.3-sources.jar': 10,
     'kotventure-core-1.2.3-javadoc.jar': 10,
     'unrelated-1.2.3.jar': 10,
     'kotventure-core-1.2.3.txt': 10,
   });
-  assert.equal(collectJars(root).size, 0);
+  assert.equal((await collectJars(root)).size, 0);
 });
 
-test('returns an empty map for a missing directory', () => {
-  assert.equal(collectJars(path.join(os.tmpdir(), 'does-not-exist')).size, 0);
+test('returns an empty map for a missing directory', async () => {
+  assert.equal((await collectJars(path.join(os.tmpdir(), 'does-not-exist'))).size, 0);
 });

--- a/.github/actions/pr-metrics-comment/test/zip.test.js
+++ b/.github/actions/pr-metrics-comment/test/zip.test.js
@@ -5,38 +5,38 @@ const assert = require('node:assert/strict');
 const { countClassEntries } = require('../lib/zip.js');
 const { buildZip } = require('./helpers/zip-fixture.js');
 
-test('counts .class entries in the central directory', () => {
+test('counts .class entries in the central directory', async () => {
   const zip = buildZip([
     'io/github/lmliam/kotventure/core/Texts.class',
     'io/github/lmliam/kotventure/core/Texts$Companion.class',
     'META-INF/MANIFEST.MF',
     'io/github/lmliam/kotventure/core/',
   ]);
-  assert.equal(countClassEntries(zip), 2);
+  assert.equal(await countClassEntries(zip), 2);
 });
 
-test('returns zero for an archive without classes', () => {
-  assert.equal(countClassEntries(buildZip(['META-INF/MANIFEST.MF'])), 0);
+test('returns zero for an archive without classes', async () => {
+  assert.equal(await countClassEntries(buildZip(['META-INF/MANIFEST.MF'])), 0);
 });
 
-test('returns null for non-zip data', () => {
-  assert.equal(countClassEntries(Buffer.alloc(100)), null);
-  assert.equal(countClassEntries(Buffer.alloc(4)), null);
+test('returns null for non-zip data', async () => {
+  assert.equal(await countClassEntries(Buffer.alloc(100)), null);
+  assert.equal(await countClassEntries(Buffer.alloc(4)), null);
 });
 
-test('returns null when the central directory is corrupt', () => {
+test('returns null when the central directory is corrupt', async () => {
   const zip = buildZip(['a.class']);
   zip.writeUInt32LE(0xdeadbeef, 10);
-  assert.equal(countClassEntries(zip), null);
+  assert.equal(await countClassEntries(zip), null);
 });
 
-test('returns null when trailing data follows the end record', () => {
+test('returns null when trailing data follows the end record', async () => {
   const zip = buildZip(['a.class']);
-  assert.equal(countClassEntries(Buffer.concat([zip, Buffer.from('trailing')])), null);
+  assert.equal(await countClassEntries(Buffer.concat([zip, Buffer.from('trailing')])), null);
 });
 
-test('returns null when a central directory record overflows the buffer', () => {
+test('returns null when a central directory record overflows the buffer', async () => {
   const zip = buildZip(['a.class']);
   zip.writeUInt16LE(0xffff, 10 + 28);
-  assert.equal(countClassEntries(zip), null);
+  assert.equal(await countClassEntries(zip), null);
 });

--- a/.github/package-lock.json
+++ b/.github/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "diff": "9.0.0"
+        "diff": "9.0.0",
+        "yauzl": "3.4.0"
       }
     },
     "node_modules/diff": {
@@ -19,6 +20,24 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/.github/package.json
+++ b/.github/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "type": "commonjs",
   "dependencies": {
-    "diff": "9.0.0"
+    "diff": "9.0.0",
+    "yauzl": "3.4.0"
   }
 }


### PR DESCRIPTION
## Summary

Replaces the hand-rolled central-directory walker in `lib/zip.js` with the
maintained `yauzl` package (`yauzl@3.4.0`, MIT, sole dependency `pend`),
using its Promise APIs: `fromBufferPromise` plus the `eachEntry` async
iterator.

- `countClassEntries` and `collectJars` become `async`; `collect` awaits both
  jar walks in parallel. No other call sites exist.
- The `null`-on-invalid contract is preserved: non-zip data, corrupt central
  directories, trailing data after the end record, and overflowing records
  all still map to `null` — the existing `zip.test.js` cases pin this, and
  every fixture was verified against yauzl before landing.
- Test assertions are unchanged; the tests only became `async`/`await`.
- Net −23 lines of hand-rolled ZIP parsing.
- No workflow changes: the `npm ci` step added for the previous PR already
  covers the PR feedback job that runs this code.

## Validation

- `node --test` suite: 119/119 pass
- `git diff --check` clean
