### PR TITLE
refactor(ci): extract single-entry archives with yauzl

### DIFF
--- a/.github/scripts/pr-metrics-publisher-archive.js
+++ b/.github/scripts/pr-metrics-publisher-archive.js
@@ -7,7 +7,7 @@ const {
 } = require('./pr-metrics-publisher-contract.js');
 const { extractSingleEntryArchive } = require('./shared/artifact-archive.js');
 
-function extractMetricsResultArchive(archive) {
+async function extractMetricsResultArchive(archive) {
     return extractSingleEntryArchive(archive, {
         errorPrefix: 'metrics artifact archive',
         expectedFileName: RESULT_FILE_NAME,

--- a/.github/scripts/pr-metrics-publisher.test.js
+++ b/.github/scripts/pr-metrics-publisher.test.js
@@ -279,7 +279,7 @@ describe('metrics artifact validation', () => {
 });
 
 describe('metrics archive extraction', () => {
-    test('extracts stored and deflated result archives', () => {
+    test('extracts stored and deflated result archives', async () => {
         const content = Buffer.from(
                 JSON.stringify(makeResult()),
                 'utf8',
@@ -287,7 +287,7 @@ describe('metrics archive extraction', () => {
 
         for (const compressionMethod of [0, 8]) {
             assert.deepEqual(
-                    extractMetricsResultArchive(
+                    await extractMetricsResultArchive(
                             makeZip(content, {
                                 compressionMethod,
                             }),
@@ -297,35 +297,33 @@ describe('metrics archive extraction', () => {
         }
     });
 
-    test('rejects an unexpected archive entry name', () => {
-        assert.throws(
-                () => {
-                    extractMetricsResultArchive(
-                            makeZip('{}', {
-                                fileName: 'other.json',
-                            }),
-                    );
-                },
+    test('rejects an unexpected archive entry name', async () => {
+        await assert.rejects(
+                extractMetricsResultArchive(
+                        makeZip('{}', {
+                            fileName: 'other.json',
+                        }),
+                ),
                 /must contain only/,
         );
     });
 
-    test('rejects an entry that expands beyond the result limit', () => {
+    test('rejects an entry that expands beyond the result limit', async () => {
         const archive = makeZip(
                 Buffer.alloc(MAX_RESULT_BYTES + 1, 0x78),
         );
 
         assert.ok(archive.length < MAX_ARTIFACT_BYTES);
 
-        assert.throws(
-                () => extractMetricsResultArchive(archive),
+        await assert.rejects(
+                extractMetricsResultArchive(archive),
                 /outside the size limit/,
         );
     });
 
-    test('rejects an archive larger than the artifact limit before parsing', () => {
-        assert.throws(
-                () => extractMetricsResultArchive(
+    test('rejects an archive larger than the artifact limit before parsing', async () => {
+        await assert.rejects(
+                extractMetricsResultArchive(
                         Buffer.alloc(MAX_ARTIFACT_BYTES + 1),
                 ),
                 /is not a ZIP archive/,

--- a/.github/scripts/qodana-publisher-archive.js
+++ b/.github/scripts/qodana-publisher-archive.js
@@ -7,7 +7,7 @@ const {
 } = require('./qodana-contract.js');
 const { extractSingleEntryArchive } = require('./shared/artifact-archive.js');
 
-function extractQodanaSarifArchive(archive) {
+async function extractQodanaSarifArchive(archive) {
   return extractSingleEntryArchive(archive, {
     errorPrefix: 'Qodana artifact archive',
     expectedFileName: QODANA_SARIF_FILE_NAME,

--- a/.github/scripts/qodana-security.test.js
+++ b/.github/scripts/qodana-security.test.js
@@ -6,6 +6,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
+const zlib = require('node:zlib');
 
 const {
   MAX_ARTIFACT_BYTES,
@@ -156,6 +157,40 @@ function makeStoredZip(content, fileName = 'qodana.sarif.json') {
   end.writeUInt32LE(centralDirectory.length, 12);
   end.writeUInt32LE(localHeader.length + content.length, 16);
   return Buffer.concat([localHeader, content, centralDirectory, end]);
+}
+
+function makeDeflateZip(content, declaredSize) {
+  const name = Buffer.from('qodana.sarif.json', 'utf8');
+  const compressed = zlib.deflateRawSync(content);
+
+  const localHeader = Buffer.alloc(30 + name.length);
+  localHeader.writeUInt32LE(0x04034b50, 0);
+  localHeader.writeUInt16LE(20, 4);
+  localHeader.writeUInt16LE(0, 6);
+  localHeader.writeUInt16LE(8, 8);
+  localHeader.writeUInt32LE(compressed.length, 18);
+  localHeader.writeUInt32LE(declaredSize, 22);
+  localHeader.writeUInt16LE(name.length, 26);
+  name.copy(localHeader, 30);
+
+  const centralDirectory = Buffer.alloc(46 + name.length);
+  centralDirectory.writeUInt32LE(0x02014b50, 0);
+  centralDirectory.writeUInt16LE(20, 4);
+  centralDirectory.writeUInt16LE(20, 6);
+  centralDirectory.writeUInt16LE(0, 8);
+  centralDirectory.writeUInt16LE(8, 10);
+  centralDirectory.writeUInt32LE(compressed.length, 20);
+  centralDirectory.writeUInt32LE(declaredSize, 24);
+  centralDirectory.writeUInt16LE(name.length, 28);
+  name.copy(centralDirectory, 46);
+
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(1, 8);
+  end.writeUInt16LE(1, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(localHeader.length + compressed.length, 16);
+  return Buffer.concat([localHeader, compressed, centralDirectory, end]);
 }
 
 function makePublicationGithub({
@@ -360,26 +395,26 @@ test('creates valid zero-result attestations from trusted code', () => {
   }
 });
 
-test('extracts exactly one bounded SARIF file from an artifact ZIP', () => {
+test('extracts exactly one bounded SARIF file from an artifact ZIP', async () => {
   const document = createAttestation({ sourceKind: 'documentation', headSha: HEAD_SHA });
   const content = Buffer.from(JSON.stringify(document));
   const archive = makeStoredZip(content);
-  assert.deepEqual(extractQodanaSarifArchive(archive), content);
-  assert.throws(
-    () => extractQodanaSarifArchive(makeStoredZip(content, '../qodana.sarif.json')),
+  assert.deepEqual(await extractQodanaSarifArchive(archive), content);
+  await assert.rejects(
+    extractQodanaSarifArchive(makeStoredZip(content, '../qodana.sarif.json')),
     /must contain only qodana\.sarif\.json/,
   );
 
   const duplicateEntryMetadata = Buffer.from(archive);
   duplicateEntryMetadata.writeUInt16LE(2, duplicateEntryMetadata.length - 14);
   duplicateEntryMetadata.writeUInt16LE(2, duplicateEntryMetadata.length - 12);
-  assert.throws(
-    () => extractQodanaSarifArchive(duplicateEntryMetadata),
+  await assert.rejects(
+    extractQodanaSarifArchive(duplicateEntryMetadata),
     /must contain exactly one file/,
   );
 });
 
-test('rejects archives whose entry metadata is internally inconsistent', () => {
+test('rejects archives whose entry metadata is internally inconsistent', async () => {
   const document = createAttestation({ sourceKind: 'documentation', headSha: HEAD_SHA });
   const content = Buffer.from(JSON.stringify(document));
   const archive = makeStoredZip(content);
@@ -387,23 +422,32 @@ test('rejects archives whose entry metadata is internally inconsistent', () => {
 
   const mismatchedSizes = Buffer.from(archive);
   mismatchedSizes.writeUInt32LE(content.length + 1, 18);
-  assert.throws(
-    () => extractQodanaSarifArchive(mismatchedSizes),
+  await assert.rejects(
+    extractQodanaSarifArchive(mismatchedSizes),
     /has inconsistent file sizes/,
   );
 
   const nonZeroDiskStart = Buffer.from(archive);
   nonZeroDiskStart.writeUInt16LE(1, centralDirectoryOffset + 34);
-  assert.throws(
-    () => extractQodanaSarifArchive(nonZeroDiskStart),
+  await assert.rejects(
+    extractQodanaSarifArchive(nonZeroDiskStart),
     /uses unsupported compression or metadata/,
   );
 
   const misplacedLocalHeader = Buffer.from(archive);
   misplacedLocalHeader.writeUInt32LE(centralDirectoryOffset, centralDirectoryOffset + 42);
-  assert.throws(
-    () => extractQodanaSarifArchive(misplacedLocalHeader),
+  await assert.rejects(
+    extractQodanaSarifArchive(misplacedLocalHeader),
     /has an invalid local file header offset/,
+  );
+});
+
+test('rejects a deflate entry that expands beyond its declared size', async () => {
+  const content = Buffer.alloc(64, 0x61);
+  const archive = makeDeflateZip(content, 4);
+  await assert.rejects(
+    extractQodanaSarifArchive(archive),
+    /cannot be parsed/,
   );
 });
 

--- a/.github/scripts/shared/artifact-archive.js
+++ b/.github/scripts/shared/artifact-archive.js
@@ -1,26 +1,24 @@
 'use strict';
 
-const zlib = require('node:zlib');
+const yauzl = require('yauzl');
 const { createValidators } = require('./validation.js');
 
 const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
 const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
-const LOCAL_FILE_SIGNATURE = 0x04034b50;
 
 const END_OF_CENTRAL_DIRECTORY_LENGTH = 22;
 const CENTRAL_DIRECTORY_HEADER_LENGTH = 46;
-const LOCAL_FILE_HEADER_LENGTH = 30;
 const MAX_ZIP_COMMENT_LENGTH = 0xffff;
 
 const ZIP64_16_BIT_VALUE = 0xffff;
 const ZIP64_32_BIT_VALUE = 0xffffffff;
-const ENCRYPTED_FLAG = 0x0001;
+const ZIP64_EXTRA_FIELD_ID = 0x0001;
 const DATA_DESCRIPTOR_FLAG = 0x0008;
 
 const STORED_COMPRESSION = 0;
 const DEFLATE_COMPRESSION = 8;
 
-function extractSingleEntryArchive(archive, {
+async function extractSingleEntryArchive(archive, {
   errorPrefix,
   expectedFileName,
   maxArchiveBytes,
@@ -45,190 +43,9 @@ function extractSingleEntryArchive(archive, {
     throw new Error(`${errorPrefix} ${message}`);
   }
 
-  function assertRange(value, offset, length, label) {
-    if (!Number.isSafeInteger(offset)
-      || !Number.isSafeInteger(length)
-      || offset < 0
-      || length < 0
-      || offset + length > value.length) {
-      rejectArchive(`${label} is outside the archive`);
-    }
-  }
-
-  function findEndOfCentralDirectory() {
-    const firstOffset = Math.max(
-      0,
-      archive.length - END_OF_CENTRAL_DIRECTORY_LENGTH - MAX_ZIP_COMMENT_LENGTH,
-    );
-
-    for (
-      let offset = archive.length - END_OF_CENTRAL_DIRECTORY_LENGTH;
-      offset >= firstOffset;
-      offset -= 1
-    ) {
-      if (archive.readUInt32LE(offset) !== END_OF_CENTRAL_DIRECTORY_SIGNATURE) continue;
-
-      const commentLength = archive.readUInt16LE(offset + 20);
-
-      if (offset + END_OF_CENTRAL_DIRECTORY_LENGTH + commentLength === archive.length) return offset;
-    }
-
-    rejectArchive('has no valid end record');
-  }
-
-  function readCentralDirectoryEntry() {
-    const endOffset = findEndOfCentralDirectory();
-
-    const diskNumber = archive.readUInt16LE(endOffset + 4);
-    const centralDirectoryDisk = archive.readUInt16LE(endOffset + 6);
-    const entriesOnDisk = archive.readUInt16LE(endOffset + 8);
-    const totalEntries = archive.readUInt16LE(endOffset + 10);
-    const centralDirectorySize = archive.readUInt32LE(endOffset + 12);
-    const centralDirectoryOffset = archive.readUInt32LE(endOffset + 16);
-
-    const usesZip64 = entriesOnDisk === ZIP64_16_BIT_VALUE
-      || totalEntries === ZIP64_16_BIT_VALUE
-      || centralDirectorySize === ZIP64_32_BIT_VALUE
-      || centralDirectoryOffset === ZIP64_32_BIT_VALUE;
-
-    if (diskNumber !== 0 || centralDirectoryDisk !== 0 || usesZip64) {
-      rejectArchive('uses unsupported ZIP64 or multi-disk metadata');
-    }
-
-    if (entriesOnDisk !== 1 || totalEntries !== 1) rejectArchive('must contain exactly one file');
-
-    assertRange(archive, centralDirectoryOffset, centralDirectorySize, 'central directory');
-
-    if (centralDirectoryOffset + centralDirectorySize !== endOffset) rejectArchive('has a misplaced central directory');
-
-    if (centralDirectorySize < CENTRAL_DIRECTORY_HEADER_LENGTH
-      || archive.readUInt32LE(centralDirectoryOffset) !== CENTRAL_DIRECTORY_SIGNATURE) {
-      rejectArchive('has an invalid central directory');
-    }
-
-    const fileNameLength = archive.readUInt16LE(centralDirectoryOffset + 28);
-    const extraLength = archive.readUInt16LE(centralDirectoryOffset + 30);
-    const commentLength = archive.readUInt16LE(centralDirectoryOffset + 32);
-    const recordLength = CENTRAL_DIRECTORY_HEADER_LENGTH
-      + fileNameLength
-      + extraLength
-      + commentLength;
-
-    if (recordLength !== centralDirectorySize) rejectArchive('has an invalid central directory record');
-
-    const fileNameOffset = centralDirectoryOffset + CENTRAL_DIRECTORY_HEADER_LENGTH;
-    assertRange(archive, fileNameOffset, fileNameLength, 'file name');
-
-    const fileName = archive.subarray(fileNameOffset, fileNameOffset + fileNameLength);
-
-    if (!fileName.equals(expectedName)) rejectArchive(`must contain only ${expectedName.toString('utf8')}`);
-
-    const flags = archive.readUInt16LE(centralDirectoryOffset + 8);
-    const compressionMethod = archive.readUInt16LE(centralDirectoryOffset + 10);
-    const compressedSize = archive.readUInt32LE(centralDirectoryOffset + 20);
-    const uncompressedSize = archive.readUInt32LE(centralDirectoryOffset + 24);
-    const diskStart = archive.readUInt16LE(centralDirectoryOffset + 34);
-    const localHeaderOffset = archive.readUInt32LE(centralDirectoryOffset + 42);
-
-    const unsupportedCompression = compressionMethod !== STORED_COMPRESSION
-      && compressionMethod !== DEFLATE_COMPRESSION;
-
-    const usesZip64Entry = compressedSize === ZIP64_32_BIT_VALUE
-      || uncompressedSize === ZIP64_32_BIT_VALUE
-      || localHeaderOffset === ZIP64_32_BIT_VALUE;
-
-    if ((flags & ENCRYPTED_FLAG) !== 0
-      || unsupportedCompression
-      || usesZip64Entry
-      || diskStart !== 0) {
-      rejectArchive('uses unsupported compression or metadata');
-    }
-
-    if (compressedSize < 1
-      || compressedSize > archive.length
-      || uncompressedSize < 1
-      || uncompressedSize > maxBytes) {
-      rejectArchive('contains an entry outside the size limit');
-    }
-
-    if (localHeaderOffset >= centralDirectoryOffset) rejectArchive('has an invalid local file header offset');
-
-    return {
-      centralDirectoryOffset,
-      compressedSize,
-      compressionMethod,
-      fileName,
-      flags,
-      localHeaderOffset,
-      uncompressedSize,
-    };
-  }
-
-  function readCompressedData(entry) {
-    assertRange(archive, entry.localHeaderOffset, LOCAL_FILE_HEADER_LENGTH, 'local file header');
-
-    if (archive.readUInt32LE(entry.localHeaderOffset) !== LOCAL_FILE_SIGNATURE) {
-      rejectArchive('has an invalid local file header');
-    }
-
-    const localFlags = archive.readUInt16LE(entry.localHeaderOffset + 6);
-    const localCompressionMethod = archive.readUInt16LE(entry.localHeaderOffset + 8);
-    const localCompressedSize = archive.readUInt32LE(entry.localHeaderOffset + 18);
-    const localUncompressedSize = archive.readUInt32LE(entry.localHeaderOffset + 22);
-    const localFileNameLength = archive.readUInt16LE(entry.localHeaderOffset + 26);
-    const localExtraLength = archive.readUInt16LE(entry.localHeaderOffset + 28);
-
-    if (localFlags !== entry.flags || localCompressionMethod !== entry.compressionMethod) {
-      rejectArchive('has inconsistent file metadata');
-    }
-
-    if ((localFlags & DATA_DESCRIPTOR_FLAG) === 0
-      && (localCompressedSize !== entry.compressedSize
-        || localUncompressedSize !== entry.uncompressedSize)) {
-      rejectArchive('has inconsistent file sizes');
-    }
-
-    const localFileNameOffset = entry.localHeaderOffset + LOCAL_FILE_HEADER_LENGTH;
-
-    assertRange(
-      archive,
-      localFileNameOffset,
-      localFileNameLength + localExtraLength,
-      'local file name',
-    );
-
-    const localFileName = archive.subarray(
-      localFileNameOffset,
-      localFileNameOffset + localFileNameLength,
-    );
-
-    if (!localFileName.equals(entry.fileName)) rejectArchive('has inconsistent file names');
-
-    const compressedDataOffset = localFileNameOffset + localFileNameLength + localExtraLength;
-
-    assertRange(archive, compressedDataOffset, entry.compressedSize, 'compressed data');
-
-    if (compressedDataOffset + entry.compressedSize > entry.centralDirectoryOffset) {
-      rejectArchive('has compressed data outside the file entry');
-    }
-
-    return archive.subarray(
-      compressedDataOffset,
-      compressedDataOffset + entry.compressedSize,
-    );
-  }
-
-  function decompressEntry(compressedData, entry) {
-    try {
-      if (entry.compressionMethod === STORED_COMPRESSION) return Buffer.from(compressedData);
-
-      return zlib.inflateRawSync(compressedData, {
-        maxOutputLength: maxBytes,
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      rejectArchive(`cannot be decompressed: ${message}`);
-    }
+  function rejectParse(error) {
+    const message = error instanceof Error ? error.message : String(error);
+    rejectArchive(`cannot be parsed: ${message}`);
   }
 
   if (!Buffer.isBuffer(archive)
@@ -237,15 +54,165 @@ function extractSingleEntryArchive(archive, {
     rejectArchive('is not a ZIP archive');
   }
 
-  const entry = readCentralDirectoryEntry();
-  const compressedData = readCompressedData(entry);
-  const result = decompressEntry(compressedData, entry);
+  const { centralDirectoryOffset } = readEndOfCentralDirectory(archive, rejectArchive);
 
-  if (result.length !== entry.uncompressedSize || result.length > maxBytes) {
-    rejectArchive('decompresses to an invalid size');
+  let zipfile;
+  try {
+    zipfile = await yauzl.fromBufferPromise(archive, { decodeStrings: false });
+  } catch (error) {
+    rejectParse(error);
   }
 
+  if (zipfile.entryCount !== 1) rejectArchive('must contain exactly one file');
+
+  let entry;
+  try {
+    for await (const candidate of zipfile.eachEntry()) {
+      entry = candidate;
+      break;
+    }
+  } catch (error) {
+    rejectParse(error);
+  }
+
+  if (!entry.fileNameRaw.equals(expectedName)) {
+    rejectArchive(`must contain only ${expectedName.toString('utf8')}`);
+  }
+
+  if (entry.isEncrypted()
+    || (entry.compressionMethod !== STORED_COMPRESSION
+      && entry.compressionMethod !== DEFLATE_COMPRESSION)) {
+    rejectArchive('uses unsupported compression or metadata');
+  }
+
+  if (entry.extraFields.some((field) => field.id === ZIP64_EXTRA_FIELD_ID)) {
+    rejectArchive('uses unsupported ZIP64 or multi-disk metadata');
+  }
+
+  if (entry.compressedSize < 1
+    || entry.compressedSize > archive.length
+    || entry.uncompressedSize < 1
+    || entry.uncompressedSize > maxBytes) {
+    rejectArchive('contains an entry outside the size limit');
+  }
+
+  if (entry.relativeOffsetOfLocalHeader >= centralDirectoryOffset) {
+    rejectArchive('has an invalid local file header offset');
+  }
+
+  let localHeader;
+  try {
+    localHeader = await zipfile.readLocalFileHeaderPromise(entry);
+  } catch (error) {
+    rejectParse(error);
+  }
+
+  if (localHeader.generalPurposeBitFlag !== entry.generalPurposeBitFlag
+    || localHeader.compressionMethod !== entry.compressionMethod) {
+    rejectArchive('has inconsistent file metadata');
+  }
+
+  if ((localHeader.generalPurposeBitFlag & DATA_DESCRIPTOR_FLAG) === 0
+    && (localHeader.compressedSize !== entry.compressedSize
+      || localHeader.uncompressedSize !== entry.uncompressedSize)) {
+    rejectArchive('has inconsistent file sizes');
+  }
+
+  if (!localHeader.fileName.equals(entry.fileNameRaw)) {
+    rejectArchive('has inconsistent file names');
+  }
+
+  if (localHeader.fileDataStart + entry.compressedSize > centralDirectoryOffset) {
+    rejectArchive('has compressed data outside the file entry');
+  }
+
+  const chunks = [];
+  let total = 0;
+  try {
+    const readStream = await zipfile.openReadStreamPromise(entry);
+    for await (const chunk of readStream) {
+      if (total + chunk.length > maxBytes) rejectArchive('decompresses to an invalid size');
+      chunks.push(chunk);
+      total += chunk.length;
+    }
+  } catch (error) {
+    rejectParse(error);
+  }
+
+  const result = Buffer.concat(chunks, total);
+  if (result.length !== entry.uncompressedSize) rejectArchive('decompresses to an invalid size');
+
   return result;
+}
+
+function readEndOfCentralDirectory(archive, rejectArchive) {
+  const firstOffset = Math.max(
+    0,
+    archive.length - END_OF_CENTRAL_DIRECTORY_LENGTH - MAX_ZIP_COMMENT_LENGTH,
+  );
+
+  let endOffset = -1;
+  for (
+    let offset = archive.length - END_OF_CENTRAL_DIRECTORY_LENGTH;
+    offset >= firstOffset;
+    offset -= 1
+  ) {
+    if (archive.readUInt32LE(offset) !== END_OF_CENTRAL_DIRECTORY_SIGNATURE) continue;
+
+    const commentLength = archive.readUInt16LE(offset + 20);
+
+    if (offset + END_OF_CENTRAL_DIRECTORY_LENGTH + commentLength === archive.length) {
+      endOffset = offset;
+      break;
+    }
+  }
+
+  if (endOffset < 0) rejectArchive('has no valid end record');
+
+  const diskNumber = archive.readUInt16LE(endOffset + 4);
+  const centralDirectoryDisk = archive.readUInt16LE(endOffset + 6);
+  const entriesOnDisk = archive.readUInt16LE(endOffset + 8);
+  const totalEntries = archive.readUInt16LE(endOffset + 10);
+  const centralDirectorySize = archive.readUInt32LE(endOffset + 12);
+  const centralDirectoryOffset = archive.readUInt32LE(endOffset + 16);
+
+  const usesZip64 = entriesOnDisk === ZIP64_16_BIT_VALUE
+    || totalEntries === ZIP64_16_BIT_VALUE
+    || centralDirectorySize === ZIP64_32_BIT_VALUE
+    || centralDirectoryOffset === ZIP64_32_BIT_VALUE;
+
+  if (diskNumber !== 0 || centralDirectoryDisk !== 0 || usesZip64) {
+    rejectArchive('uses unsupported ZIP64 or multi-disk metadata');
+  }
+
+  if (entriesOnDisk !== 1 || totalEntries !== 1) rejectArchive('must contain exactly one file');
+
+  if (centralDirectoryOffset + centralDirectorySize > archive.length) {
+    rejectArchive('central directory is outside the archive');
+  }
+
+  if (centralDirectoryOffset + centralDirectorySize !== endOffset) rejectArchive('has a misplaced central directory');
+
+  if (centralDirectorySize < CENTRAL_DIRECTORY_HEADER_LENGTH
+    || archive.readUInt32LE(centralDirectoryOffset) !== CENTRAL_DIRECTORY_SIGNATURE) {
+    rejectArchive('has an invalid central directory');
+  }
+
+  const fileNameLength = archive.readUInt16LE(centralDirectoryOffset + 28);
+  const extraLength = archive.readUInt16LE(centralDirectoryOffset + 30);
+  const commentLength = archive.readUInt16LE(centralDirectoryOffset + 32);
+  const recordLength = CENTRAL_DIRECTORY_HEADER_LENGTH
+    + fileNameLength
+    + extraLength
+    + commentLength;
+
+  if (recordLength !== centralDirectorySize) rejectArchive('has an invalid central directory record');
+
+  const diskStart = archive.readUInt16LE(centralDirectoryOffset + 34);
+
+  if (diskStart !== 0) rejectArchive('uses unsupported compression or metadata');
+
+  return { centralDirectoryOffset };
 }
 
 module.exports = { extractSingleEntryArchive };

--- a/.github/scripts/shared/artifact-download.js
+++ b/.github/scripts/shared/artifact-download.js
@@ -167,7 +167,7 @@ async function downloadSingleFileArtifact({
   });
 
   const archive = await readResponseBytes(archiveResponse, maxArchiveBytes, label);
-  const result = extractSingleEntryArchive(archive, {
+  const result = await extractSingleEntryArchive(archive, {
     errorPrefix: `${label} archive`,
     expectedFileName: fileName,
     maxArchiveBytes,

--- a/.github/workflows/qodana-publish.yml
+++ b/.github/workflows/qodana-publish.yml
@@ -32,6 +32,10 @@ jobs:
           ref: ${{ github.sha }}
           persist-credentials: false
 
+      - name: Install CI tooling dependencies
+        working-directory: .github
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
       - name: Validate the current Qodana source
         id: publication
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Summary

Replaces the hand-rolled ZIP parser in `shared/artifact-archive.js` with the
maintained `yauzl` package, using its Promise APIs (`fromBufferPromise`,
`eachEntry`, `readLocalFileHeaderPromise`, `openReadStreamPromise`).
Every security invariant of the previous extractor is preserved:

- **EOCD preflight** (kept, hand-rolled): rejects multi-disk and ZIP64
  metadata, requires exactly one record ending exactly at the buffer end, and
  validates central-directory placement, signature, record length, and disk
  start.
- **Exact raw filename match**: `decodeStrings` is off, so yauzl performs no
  path decoding or validation of its own and the entry is matched by raw
  `fileNameRaw` bytes against the expected name.
- **Rejections before any stream opens**: encryption, non-stored/deflate
  compression, ZIP64 extra fields, and sizes outside the configured limits.
- **Local/central consistency** via `readLocalFileHeaderPromise`: flags,
  compression method, sizes when no data descriptor is present, and file
  name. **Bit 3 / data descriptors remain accepted**, as before.
- **Bounded output**: the stream is collected through a cap that rejects
  before appending a chunk that would exceed `maxBytes`; yauzl's entry-size
  validation catches entries that decompress beyond their declared size.
- **Stable error contract**: all yauzl failures map to a
  `<errorPrefix> cannot be parsed` category — dependency-specific text never
  forms part of the public contract.

`extractSingleEntryArchive`, the publisher wrappers, and the download path
become `async`; tests convert `assert.throws` to `await assert.rejects`.
A new dishonest-size test pins the decompression-bound rejection.

Adds the `npm ci` step to Qodana publication, the last job that runs this
code. CRC32 is not verified (it was not before, either).

## Validation

- `node --test` suite: 120/120 pass
- `actionlint` clean
- `git diff --check` clean
