### PR TITLE
test(ci): build zip fixtures with adm-zip

### DIFF
--- a/.github/actions/pr-metrics-comment/test/helpers/zip-fixture.js
+++ b/.github/actions/pr-metrics-comment/test/helpers/zip-fixture.js
@@ -1,23 +1,13 @@
 'use strict';
 
-function centralEntry(name) {
-  const nameBytes = Buffer.from(name, 'utf8');
-  const header = Buffer.alloc(46);
-  header.writeUInt32LE(0x02014b50, 0);
-  header.writeUInt16LE(nameBytes.length, 28);
-  return Buffer.concat([header, nameBytes]);
-}
+const AdmZip = require('adm-zip');
 
 function buildZip(names) {
-  const localPart = Buffer.alloc(10, 1);
-  const centralDirectory = Buffer.concat(names.map(centralEntry));
-  const eocd = Buffer.alloc(22);
-  eocd.writeUInt32LE(0x06054b50, 0);
-  eocd.writeUInt16LE(names.length, 8);
-  eocd.writeUInt16LE(names.length, 10);
-  eocd.writeUInt32LE(centralDirectory.length, 12);
-  eocd.writeUInt32LE(localPart.length, 16);
-  return Buffer.concat([localPart, centralDirectory, eocd]);
+  const zip = new AdmZip();
+  for (const name of names) {
+    zip.addFile(name, Buffer.alloc(0));
+  }
+  return zip.toBuffer();
 }
 
 module.exports = { buildZip };

--- a/.github/actions/pr-metrics-comment/test/zip.test.js
+++ b/.github/actions/pr-metrics-comment/test/zip.test.js
@@ -26,7 +26,8 @@ test('returns null for non-zip data', async () => {
 
 test('returns null when the central directory is corrupt', async () => {
   const zip = buildZip(['a.class']);
-  zip.writeUInt32LE(0xdeadbeef, 10);
+  const centralDirectoryOffset = zip.readUInt32LE(zip.length - 6);
+  zip.writeUInt32LE(0xdeadbeef, centralDirectoryOffset);
   assert.equal(await countClassEntries(zip), null);
 });
 
@@ -37,6 +38,7 @@ test('returns null when trailing data follows the end record', async () => {
 
 test('returns null when a central directory record overflows the buffer', async () => {
   const zip = buildZip(['a.class']);
-  zip.writeUInt16LE(0xffff, 10 + 28);
+  const centralDirectoryOffset = zip.readUInt32LE(zip.length - 6);
+  zip.writeUInt16LE(0xffff, centralDirectoryOffset + 28);
   assert.equal(await countClassEntries(zip), null);
 });

--- a/.github/package-lock.json
+++ b/.github/package-lock.json
@@ -9,8 +9,18 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "adm-zip": "0.6.0",
         "diff": "9.0.0",
         "yauzl": "3.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/diff": {

--- a/.github/package.json
+++ b/.github/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "type": "commonjs",
   "dependencies": {
+    "adm-zip": "0.6.0",
     "diff": "9.0.0",
     "yauzl": "3.4.0"
   }

--- a/.github/scripts/pr-metrics-publisher-test-fixtures.js
+++ b/.github/scripts/pr-metrics-publisher-test-fixtures.js
@@ -3,7 +3,7 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const zlib = require('node:zlib');
+const AdmZip = require('adm-zip');
 const { serializeMetricsResult } = require('../actions/pr-metrics-comment/lib/metrics-result.js');
 const {
     RESULT_ARTIFACT_PREFIX,
@@ -124,53 +124,13 @@ function makeZip(
             fileName = RESULT_FILE_NAME,
         } = {},
 ) {
-    const name = Buffer.from(fileName, 'utf8');
-
-    const uncompressed = Buffer.isBuffer(content)
-            ? content
-            : Buffer.from(content, 'utf8');
-
-    const compressed = compressionMethod === 8
-            ? zlib.deflateRawSync(uncompressed)
-            : uncompressed;
-
-    const local = Buffer.alloc(30 + name.length);
-
-    local.writeUInt32LE(0x04034b50, 0);
-    local.writeUInt16LE(20, 4);
-    local.writeUInt16LE(compressionMethod, 8);
-    local.writeUInt32LE(compressed.length, 18);
-    local.writeUInt32LE(uncompressed.length, 22);
-    local.writeUInt16LE(name.length, 26);
-
-    name.copy(local, 30);
-
-    const central = Buffer.alloc(46 + name.length);
-
-    central.writeUInt32LE(0x02014b50, 0);
-    central.writeUInt16LE(20, 4);
-    central.writeUInt16LE(20, 6);
-    central.writeUInt16LE(compressionMethod, 10);
-    central.writeUInt32LE(compressed.length, 20);
-    central.writeUInt32LE(uncompressed.length, 24);
-    central.writeUInt16LE(name.length, 28);
-
-    name.copy(central, 46);
-
-    const end = Buffer.alloc(22);
-
-    end.writeUInt32LE(0x06054b50, 0);
-    end.writeUInt16LE(1, 8);
-    end.writeUInt16LE(1, 10);
-    end.writeUInt32LE(central.length, 12);
-    end.writeUInt32LE(local.length + compressed.length, 16);
-
-    return Buffer.concat([
-        local,
-        compressed,
-        central,
-        end,
-    ]);
+    const zip = new AdmZip();
+    const entry = zip.addFile(
+            fileName,
+            Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf8'),
+    );
+    if (compressionMethod === 0) entry.header.method = 0;
+    return zip.toBuffer();
 }
 
 function makeWorkflowRunContext(run = makeInputs().run) {

--- a/.github/scripts/qodana-security.test.js
+++ b/.github/scripts/qodana-security.test.js
@@ -6,7 +6,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
-const zlib = require('node:zlib');
+const AdmZip = require('adm-zip');
 
 const {
   MAX_ARTIFACT_BYTES,
@@ -129,68 +129,24 @@ function makeGithub({
 
 function makeStoredZip(content, fileName = 'qodana.sarif.json') {
   const name = Buffer.from(fileName, 'utf8');
-  const localHeader = Buffer.alloc(30 + name.length);
-  localHeader.writeUInt32LE(0x04034b50, 0);
-  localHeader.writeUInt16LE(20, 4);
-  localHeader.writeUInt16LE(0, 6);
-  localHeader.writeUInt16LE(0, 8);
-  localHeader.writeUInt32LE(content.length, 18);
-  localHeader.writeUInt32LE(content.length, 22);
-  localHeader.writeUInt16LE(name.length, 26);
-  name.copy(localHeader, 30);
-
-  const centralDirectory = Buffer.alloc(46 + name.length);
-  centralDirectory.writeUInt32LE(0x02014b50, 0);
-  centralDirectory.writeUInt16LE(20, 4);
-  centralDirectory.writeUInt16LE(20, 6);
-  centralDirectory.writeUInt16LE(0, 8);
-  centralDirectory.writeUInt16LE(0, 10);
-  centralDirectory.writeUInt32LE(content.length, 20);
-  centralDirectory.writeUInt32LE(content.length, 24);
-  centralDirectory.writeUInt16LE(name.length, 28);
-  name.copy(centralDirectory, 46);
-
-  const end = Buffer.alloc(22);
-  end.writeUInt32LE(0x06054b50, 0);
-  end.writeUInt16LE(1, 8);
-  end.writeUInt16LE(1, 10);
-  end.writeUInt32LE(centralDirectory.length, 12);
-  end.writeUInt32LE(localHeader.length + content.length, 16);
-  return Buffer.concat([localHeader, content, centralDirectory, end]);
+  const zip = new AdmZip();
+  const entry = zip.addFile('x'.repeat(name.length), content);
+  entry.header.method = 0;
+  const archive = zip.toBuffer();
+  const centralDirectoryOffset = archive.readUInt32LE(archive.length - 6);
+  name.copy(archive, 30);
+  name.copy(archive, centralDirectoryOffset + 46);
+  return archive;
 }
 
 function makeDeflateZip(content, declaredSize) {
-  const name = Buffer.from('qodana.sarif.json', 'utf8');
-  const compressed = zlib.deflateRawSync(content);
-
-  const localHeader = Buffer.alloc(30 + name.length);
-  localHeader.writeUInt32LE(0x04034b50, 0);
-  localHeader.writeUInt16LE(20, 4);
-  localHeader.writeUInt16LE(0, 6);
-  localHeader.writeUInt16LE(8, 8);
-  localHeader.writeUInt32LE(compressed.length, 18);
-  localHeader.writeUInt32LE(declaredSize, 22);
-  localHeader.writeUInt16LE(name.length, 26);
-  name.copy(localHeader, 30);
-
-  const centralDirectory = Buffer.alloc(46 + name.length);
-  centralDirectory.writeUInt32LE(0x02014b50, 0);
-  centralDirectory.writeUInt16LE(20, 4);
-  centralDirectory.writeUInt16LE(20, 6);
-  centralDirectory.writeUInt16LE(0, 8);
-  centralDirectory.writeUInt16LE(8, 10);
-  centralDirectory.writeUInt32LE(compressed.length, 20);
-  centralDirectory.writeUInt32LE(declaredSize, 24);
-  centralDirectory.writeUInt16LE(name.length, 28);
-  name.copy(centralDirectory, 46);
-
-  const end = Buffer.alloc(22);
-  end.writeUInt32LE(0x06054b50, 0);
-  end.writeUInt16LE(1, 8);
-  end.writeUInt16LE(1, 10);
-  end.writeUInt32LE(centralDirectory.length, 12);
-  end.writeUInt32LE(localHeader.length + compressed.length, 16);
-  return Buffer.concat([localHeader, compressed, centralDirectory, end]);
+  const zip = new AdmZip();
+  zip.addFile('qodana.sarif.json', content);
+  const archive = zip.toBuffer();
+  const centralDirectoryOffset = archive.readUInt32LE(archive.length - 6);
+  archive.writeUInt32LE(declaredSize, 22);
+  archive.writeUInt32LE(declaredSize, centralDirectoryOffset + 24);
+  return archive;
 }
 
 function makePublicationGithub({


### PR DESCRIPTION
## Summary

Replaces the three hand-rolled zip writers in the CI test fixtures with the maintained `adm-zip` package (`adm-zip@0.6.0`, MIT, zero runtime dependencies).

- **`zip-fixture.js`** — the synthetic minimal-zip builder used by the enumeration tests becomes a real `AdmZip` archive.
- **`pr-metrics-publisher-test-fixtures.js`** — the `makeZip` result archive is built with `adm-zip`; the stored (method 0) variant forces the entry header method.
- **`qodana-security.test.js`** — `makeStoredZip`/`makeDeflateZip` are built with `adm-zip`.

All fixtures are now real, spec-conformant archives with genuine CRC32s and central directories, so the extractor's checks run against authentic input.

## Behaviour preserved

- **Corruption offsets re-derived** — the corrupt-central-directory and record-overflow tests in `zip.test.js` now read the central-directory offset from the end record (`zip.readUInt32LE(zip.length - 6)`) instead of assuming the old synthetic layout.
- **Path-traversal name** — adm-zip's `addFile` normalises `..` segments, so the `../qodana.sarif.json` fixture is produced by patching the raw name bytes into the local and central-directory headers over an equal-length placeholder. The extractor's raw-byte comparison still rejects it.
- **Dishonest declared size** — the deflate fixture still patches the declared uncompressed size in both headers, keeping the zip-bomb rejection test.
- **Stored-method acceptance** — the stored (method 0) extraction path is still exercised.

Every rejection test keeps its original assertion and message.

## Verification

- 120/120 Node tests pass, including all extraction security tests against the new fixtures.
- The fixtures were probed end-to-end through yauzl and the real extractor before landing.
