### PR TITLE
refactor(ci): validate metrics result JSON with zod v4

### DIFF
--- a/.github/actions/pr-metrics-comment/lib/collect.ts
+++ b/.github/actions/pr-metrics-comment/lib/collect.ts
@@ -23,7 +23,7 @@ function readCoverage(reportPath: string | undefined): CoverageData | null {
 function readMetrics(metricsPath: string | undefined): BuildMetrics | null {
   if (!metricsPath || !fs.existsSync(metricsPath)) return null;
   try {
-    return validateBuildMetrics(JSON.parse(fs.readFileSync(metricsPath, 'utf8')), 'build metrics');
+    return validateBuildMetrics(JSON.parse(fs.readFileSync(metricsPath, 'utf8')));
   } catch {
     return null;
   }

--- a/.github/actions/pr-metrics-comment/lib/metrics-result-contract.ts
+++ b/.github/actions/pr-metrics-comment/lib/metrics-result-contract.ts
@@ -4,8 +4,8 @@ export const MAX_RESULT_BYTES = 64 * 1024;
 export const MAX_MODULES = 32;
 export const MAX_DECLARATIONS = 100;
 export const MAX_REF_LENGTH = 200;
-const MAX_DECLARATION_LENGTH = 120;
-const MAX_COUNT = 1_000_000_000;
+export const MAX_DECLARATION_LENGTH = 120;
+export const MAX_COUNT = 1_000_000_000;
 export const MODULE_PATTERN = /^(?:[A-Za-z0-9_-]){1,32}(?![\s\S])/;
 export const REPOSITORY_PATTERN = /^(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)(?![\s\S])/;
 export const SHA_PATTERN = /^(?:[a-f0-9]){40}(?![\s\S])/;
@@ -36,39 +36,7 @@ const ZERO_WIDTH_CODE_POINTS = new Set([
 
 export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 
-export type JsonObject = { [key: string]: JsonValue };
-
-export function isObject(value: JsonValue | undefined): value is JsonObject {
-  return !!value && typeof value === 'object' && !Array.isArray(value);
-}
-
-export function exactKeys<T extends object>(
-  value: JsonValue,
-  expected: readonly string[],
-  label: string,
-): T {
-  if (!isObject(value)) throw new Error(`${label} must be an object`);
-  const actual = Object.keys(value).sort();
-  const keys = [...expected].sort();
-  if (actual.length !== keys.length || actual.some((key, index) => key !== keys[index])) {
-    throw new Error(`${label} has unexpected properties`);
-  }
-  return value as T;
-}
-
-export function boundedInteger(value: JsonValue, label: string, minimum = 0, maximum = MAX_COUNT): number {
-  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < minimum || value > maximum) {
-    throw new Error(`${label} must be an integer from ${minimum} to ${maximum}`);
-  }
-  return value;
-}
-
-export function boundedString(value: JsonValue, pattern: RegExp, label: string): string {
-  if (typeof value !== 'string' || !pattern.test(value)) throw new Error(`${label} has an invalid value`);
-  return value;
-}
-
-function hasUnsafeTextCharacter(value: string, allowBacktick: boolean): boolean {
+export function hasUnsafeTextCharacter(value: string, allowBacktick: boolean): boolean {
   for (const character of value) {
     const codePoint = character.codePointAt(0) ?? 0;
     if (codePoint <= CONTROL_CODE_POINT_MAX
@@ -83,20 +51,4 @@ function hasUnsafeTextCharacter(value: string, allowBacktick: boolean): boolean 
     }
   }
   return false;
-}
-
-export function boundedRef(value: JsonValue, label: string): string {
-  if (typeof value !== 'string' || value.length < 1 || value.length > MAX_REF_LENGTH
-    || hasUnsafeTextCharacter(value, true)) {
-    throw new Error(`${label} has an invalid value`);
-  }
-  return value;
-}
-
-export function boundedDeclaration(value: JsonValue, label: string): string {
-  if (typeof value !== 'string' || value.length < 1 || value.length > MAX_DECLARATION_LENGTH
-    || hasUnsafeTextCharacter(value, false)) {
-    throw new Error(`${label} has an invalid value`);
-  }
-  return value;
 }

--- a/.github/actions/pr-metrics-comment/lib/metrics-result-serialization.ts
+++ b/.github/actions/pr-metrics-comment/lib/metrics-result-serialization.ts
@@ -1,5 +1,5 @@
+import { z } from 'zod';
 import {
-  isObject,
   MAX_RESULT_BYTES,
   SCHEMA_VERSION,
   WORKFLOW_NAME,
@@ -39,28 +39,28 @@ function serializeJars(jars: Map<string, JarInfo>): JarValue[] {
   }));
 }
 
-type PullRequestBase = {
-  readonly repo: { readonly full_name: string };
-  readonly ref: string;
-  readonly sha: string;
-};
+const pullRequestPayloadSchema = z.object({
+  number: z.number(),
+  base: z.object({
+    repo: z.object({ full_name: z.string() }),
+    ref: z.string(),
+    sha: z.string(),
+  }),
+  head: z.object({
+    repo: z.object({ full_name: z.string() }),
+    ref: z.string(),
+    sha: z.string(),
+  }),
+});
 
-type PullRequestPayload = {
-  readonly number: number;
-  readonly base: PullRequestBase;
-  readonly head: PullRequestBase;
-};
+type PullRequestPayload = z.infer<typeof pullRequestPayloadSchema>;
 
 function requirePullRequest(context: ActionContext['context']): PullRequestPayload {
-  const pullRequest = context.payload?.pull_request;
-  if (!isObject(pullRequest)
-    || !isObject(pullRequest.base)
-    || !isObject(pullRequest.base.repo)
-    || !isObject(pullRequest.head)
-    || !isObject(pullRequest.head.repo)) {
+  const parsed = pullRequestPayloadSchema.safeParse(context.payload?.pull_request);
+  if (!parsed.success) {
     throw new Error('serializeMetricsResult requires a pull_request payload with base and head repositories');
   }
-  return pullRequest as PullRequestPayload;
+  return parsed.data;
 }
 
 export interface SerializeMetricsResultOptions {

--- a/.github/actions/pr-metrics-comment/lib/metrics-result-validation.ts
+++ b/.github/actions/pr-metrics-comment/lib/metrics-result-validation.ts
@@ -1,203 +1,156 @@
+import { z } from 'zod';
 import {
+  MAX_COUNT,
   MAX_DECLARATIONS,
+  MAX_DECLARATION_LENGTH,
   MAX_MODULES,
+  MAX_REF_LENGTH,
   MODULE_PATTERN,
   REPOSITORY_PATTERN,
   SCHEMA_VERSION,
   SHA_PATTERN,
   WORKFLOW_NAME,
-  boundedDeclaration,
-  boundedInteger,
-  boundedRef,
-  boundedString,
-  exactKeys,
+  hasUnsafeTextCharacter,
 } from './metrics-result-contract.js';
 import type { JsonValue } from './metrics-result-contract.js';
 
-type CoverageModuleValue = {
-  readonly name: string;
-  readonly missed: number;
-  readonly covered: number;
-};
-
-export type CoverageValue = {
-  readonly modules: CoverageModuleValue[];
-  readonly totalMissed: number;
-  readonly totalCovered: number;
-};
-
-export type JarValue = {
-  readonly module: string;
-  readonly size: number;
-  readonly classes: number | null;
-};
-
-export type BuildMetrics = {
-  readonly tests: number;
-  readonly skipped: number;
-  readonly durationSeconds: number | null;
-};
-
-type PatchCoverageValue = {
-  readonly covered: number;
-  readonly missed: number;
-};
-
-type ApiSurfaceValue = {
-  readonly added: string[];
-  readonly removed: string[];
-};
-
-type ProvenanceValue = {
-  readonly repository: string;
-  readonly workflow: string;
-  readonly event: string;
-  readonly runId: number;
-  readonly runAttempt: number;
-  readonly pullRequest: number;
-  readonly baseRepository: string;
-  readonly baseRef: string;
-  readonly baseSha: string;
-  readonly headRepository: string;
-  readonly headRef: string;
-  readonly headSha: string;
-};
-
-export type MetricsResultValue = {
-  readonly schemaVersion: number;
-  readonly provenance: ProvenanceValue;
-  readonly metrics: {
-    readonly headCoverage: CoverageValue | null;
-    readonly baseCoverage: CoverageValue | null;
-    readonly headJars: JarValue[];
-    readonly baseJars: JarValue[];
-    readonly headMetrics: BuildMetrics | null;
-    readonly baseMetrics: BuildMetrics | null;
-    readonly patchCoverage: PatchCoverageValue | null;
-    readonly apiSurface: ApiSurfaceValue | null;
-  };
-};
-
-function validateCoverage(value: JsonValue, label: string): CoverageValue | null {
-  if (value == null) return null;
-  const checked = exactKeys<CoverageValue>(value, ['modules', 'totalMissed', 'totalCovered'], label);
-  if (!Array.isArray(checked.modules)) throw new Error(`${label}.modules must be an array`);
-  if (checked.modules.length > MAX_MODULES) throw new Error(`${label}.modules has too many entries`);
-  const names = new Set<string>();
-  for (const [index, module] of checked.modules.entries()) {
-    const checkedModule = exactKeys<CoverageModuleValue>(module, ['name', 'missed', 'covered'], `${label}.modules[${index}]`);
-    const moduleName = boundedString(checkedModule.name, MODULE_PATTERN, `${label}.modules[${index}].name`);
-    if (names.has(moduleName)) throw new Error(`${label}.modules contains a duplicate name`);
-    names.add(moduleName);
-    boundedInteger(checkedModule.missed, `${label}.modules[${index}].missed`);
-    boundedInteger(checkedModule.covered, `${label}.modules[${index}].covered`);
+function parseOrThrow<T>(schema: z.ZodType<T>, value: unknown): T {
+  const result = schema.safeParse(value, {
+    error: (issue) => {
+      switch (issue.code) {
+        case 'unrecognized_keys':
+          return 'has unexpected properties';
+        case 'invalid_type':
+          if (issue.expected === 'array') return 'must be an array';
+          if (issue.expected === 'int') return 'must be an integer';
+          if (issue.expected === 'object') return 'must be an object';
+          if (issue.expected === 'string') return 'must be a string';
+          return issue.message;
+        case 'too_small':
+        case 'too_big': {
+          if (issue.origin === 'array') return 'has too many entries';
+          if (issue.origin === 'number') {
+            const minimum = 'minimum' in issue ? issue.minimum : 0;
+            const maximum = 'maximum' in issue ? issue.maximum : Number.MAX_SAFE_INTEGER;
+            return `must be an integer from ${minimum} to ${maximum}`;
+          }
+          if (issue.origin === 'string') return 'has an invalid value';
+          return issue.message;
+        }
+        case 'invalid_format':
+          return 'has an invalid value';
+        default:
+          return issue.message;
+      }
+    },
+  });
+  if (!result.success) {
+    throw new Error(result.error.issues
+      .map((issue) => {
+        const path = issue.path.join('.');
+        return path.length > 0 ? `${path} ${issue.message}` : issue.message;
+      })
+      .join('; '));
   }
-  boundedInteger(checked.totalMissed, `${label}.totalMissed`);
-  boundedInteger(checked.totalCovered, `${label}.totalCovered`);
-  return checked;
+  return value as T;
 }
 
-function validateJars(value: JsonValue, label: string): JarValue[] {
-  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
-  if (value.length > MAX_MODULES) throw new Error(`${label} has too many entries`);
-  const names = new Set<string>();
-  const jars: JarValue[] = [];
-  for (const [index, jar] of value.entries()) {
-    const checkedJar = exactKeys<JarValue>(jar, ['module', 'size', 'classes'], `${label}[${index}]`);
-    const jarModule = boundedString(checkedJar.module, MODULE_PATTERN, `${label}[${index}].module`);
-    if (names.has(jarModule)) throw new Error(`${label} contains a duplicate module`);
-    names.add(jarModule);
-    boundedInteger(checkedJar.size, `${label}[${index}].size`);
-    if (checkedJar.classes !== null) boundedInteger(checkedJar.classes, `${label}[${index}].classes`);
-    jars.push(checkedJar);
-  }
-  return jars;
-}
+const boundedCountSchema = z.number().int().min(0).max(MAX_COUNT);
 
-export function validateBuildMetrics(value: JsonValue, label: string): BuildMetrics | null {
+const moduleNameSchema = z.string().regex(MODULE_PATTERN);
+
+const coverageModuleSchema = z.strictObject({
+  name: moduleNameSchema,
+  missed: boundedCountSchema,
+  covered: boundedCountSchema,
+});
+
+const coverageSchema = z.strictObject({
+  modules: z.array(coverageModuleSchema).max(MAX_MODULES).refine(
+    (modules): boolean => new Set(modules.map((module) => module.name)).size === modules.length,
+    { message: 'contains a duplicate name' },
+  ),
+  totalMissed: boundedCountSchema,
+  totalCovered: boundedCountSchema,
+});
+
+const jarSchema = z.strictObject({
+  module: moduleNameSchema,
+  size: boundedCountSchema,
+  classes: z.number().int().min(0).max(MAX_COUNT).nullable(),
+});
+
+const jarsSchema = z.array(jarSchema).max(MAX_MODULES).refine(
+  (jars): boolean => new Set(jars.map((jar) => jar.module)).size === jars.length,
+  { message: 'contains a duplicate module' },
+);
+
+const buildMetricsSchema = z.strictObject({
+  tests: boundedCountSchema,
+  skipped: boundedCountSchema,
+  durationSeconds: z.number().int().min(0).max(MAX_COUNT).nullable(),
+});
+
+const patchCoverageSchema = z.strictObject({
+  covered: boundedCountSchema,
+  missed: boundedCountSchema,
+});
+
+const declarationSchema = z.string().min(1).max(MAX_DECLARATION_LENGTH).refine(
+  (value): boolean => !hasUnsafeTextCharacter(value, false),
+  { message: 'has an invalid value' },
+);
+
+const apiSurfaceSchema = z.strictObject({
+  added: z.array(declarationSchema).max(MAX_DECLARATIONS),
+  removed: z.array(declarationSchema).max(MAX_DECLARATIONS),
+});
+
+const refSchema = z.string().min(1).max(MAX_REF_LENGTH).refine(
+  (value): boolean => !hasUnsafeTextCharacter(value, true),
+  { message: 'has an invalid value' },
+);
+
+const provenanceSchema = z.strictObject({
+  repository: z.string().regex(REPOSITORY_PATTERN),
+  workflow: z.string().refine((value): boolean => value === WORKFLOW_NAME, { message: `must be ${WORKFLOW_NAME}` }),
+  event: z.string().refine((value): boolean => value === 'pull_request', { message: 'must be pull_request' }),
+  runId: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER),
+  runAttempt: z.number().int().min(1).max(1000),
+  pullRequest: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER),
+  baseRepository: z.string().regex(REPOSITORY_PATTERN),
+  baseRef: refSchema,
+  baseSha: z.string().regex(SHA_PATTERN),
+  headRepository: z.string().regex(REPOSITORY_PATTERN),
+  headRef: refSchema,
+  headSha: z.string().regex(SHA_PATTERN),
+});
+
+const metricsResultSchema = z.strictObject({
+  schemaVersion: z.literal(SCHEMA_VERSION),
+  provenance: provenanceSchema,
+  metrics: z.strictObject({
+    headCoverage: coverageSchema.nullable(),
+    baseCoverage: coverageSchema.nullable(),
+    headJars: jarsSchema,
+    baseJars: jarsSchema,
+    headMetrics: buildMetricsSchema.nullable(),
+    baseMetrics: buildMetricsSchema.nullable(),
+    patchCoverage: patchCoverageSchema.nullable(),
+    apiSurface: apiSurfaceSchema.nullable(),
+  }),
+});
+
+export type CoverageValue = z.infer<typeof coverageSchema>;
+export type JarValue = z.infer<typeof jarSchema>;
+export type BuildMetrics = z.infer<typeof buildMetricsSchema>;
+export type MetricsResultValue = z.infer<typeof metricsResultSchema>;
+
+export function validateBuildMetrics(value: JsonValue): BuildMetrics | null {
   if (value == null) return null;
-  const checked = exactKeys<BuildMetrics>(value, ['tests', 'skipped', 'durationSeconds'], label);
-  boundedInteger(checked.tests, `${label}.tests`);
-  boundedInteger(checked.skipped, `${label}.skipped`);
-  if (checked.durationSeconds !== null) boundedInteger(checked.durationSeconds, `${label}.durationSeconds`);
-  return checked;
-}
-
-function validatePatchCoverage(value: JsonValue): PatchCoverageValue | null {
-  if (value == null) return null;
-  const checked = exactKeys<PatchCoverageValue>(value, ['covered', 'missed'], 'metrics.patchCoverage');
-  boundedInteger(checked.covered, 'metrics.patchCoverage.covered');
-  boundedInteger(checked.missed, 'metrics.patchCoverage.missed');
-  return checked;
-}
-
-function validateApiSurface(value: JsonValue): ApiSurfaceValue | null {
-  if (value == null) return null;
-  const checked = exactKeys<ApiSurfaceValue>(value, ['added', 'removed'], 'metrics.apiSurface');
-  for (const name of ['added', 'removed'] as const) {
-    const declarations = checked[name];
-    if (!Array.isArray(declarations)) throw new Error(`metrics.apiSurface.${name} must be an array`);
-    if (declarations.length > MAX_DECLARATIONS) throw new Error(`metrics.apiSurface.${name} has too many entries`);
-    for (const [index, declaration] of declarations.entries()) {
-      boundedDeclaration(declaration, `metrics.apiSurface.${name}[${index}]`);
-    }
-  }
-  return checked;
-}
-
-function validateProvenance(value: JsonValue): ProvenanceValue {
-  const checked = exactKeys<ProvenanceValue>(value, [
-    'repository',
-    'workflow',
-    'event',
-    'runId',
-    'runAttempt',
-    'pullRequest',
-    'baseRepository',
-    'baseRef',
-    'baseSha',
-    'headRepository',
-    'headRef',
-    'headSha',
-  ], 'provenance');
-  boundedString(checked.repository, REPOSITORY_PATTERN, 'provenance.repository');
-  if (checked.workflow !== WORKFLOW_NAME) throw new Error(`provenance.workflow must be ${WORKFLOW_NAME}`);
-  if (checked.event !== 'pull_request') throw new Error('provenance.event must be pull_request');
-  boundedInteger(checked.runId, 'provenance.runId', 1, Number.MAX_SAFE_INTEGER);
-  boundedInteger(checked.runAttempt, 'provenance.runAttempt', 1, 1000);
-  boundedInteger(checked.pullRequest, 'provenance.pullRequest', 1, Number.MAX_SAFE_INTEGER);
-  boundedString(checked.baseRepository, REPOSITORY_PATTERN, 'provenance.baseRepository');
-  boundedRef(checked.baseRef, 'provenance.baseRef');
-  boundedString(checked.baseSha, SHA_PATTERN, 'provenance.baseSha');
-  boundedString(checked.headRepository, REPOSITORY_PATTERN, 'provenance.headRepository');
-  boundedRef(checked.headRef, 'provenance.headRef');
-  boundedString(checked.headSha, SHA_PATTERN, 'provenance.headSha');
-  return checked;
+  return parseOrThrow(buildMetricsSchema, value);
 }
 
 export function validateMetricsResult(value: JsonValue): MetricsResultValue {
-  const checked = exactKeys<MetricsResultValue>(value, ['schemaVersion', 'provenance', 'metrics'], 'metrics result');
-  if (checked.schemaVersion !== SCHEMA_VERSION) {
-    throw new Error(`Unsupported metrics result schema: ${checked.schemaVersion}`);
-  }
-  validateProvenance(checked.provenance);
-  const metrics = exactKeys<MetricsResultValue['metrics']>(checked.metrics, [
-    'headCoverage',
-    'baseCoverage',
-    'headJars',
-    'baseJars',
-    'headMetrics',
-    'baseMetrics',
-    'patchCoverage',
-    'apiSurface',
-  ], 'metrics');
-  validateCoverage(metrics.headCoverage, 'metrics.headCoverage');
-  validateCoverage(metrics.baseCoverage, 'metrics.baseCoverage');
-  validateJars(metrics.headJars, 'metrics.headJars');
-  validateJars(metrics.baseJars, 'metrics.baseJars');
-  validateBuildMetrics(metrics.headMetrics, 'metrics.headMetrics');
-  validateBuildMetrics(metrics.baseMetrics, 'metrics.baseMetrics');
-  validatePatchCoverage(metrics.patchCoverage);
-  validateApiSurface(metrics.apiSurface);
-  return checked;
+  return parseOrThrow(metricsResultSchema, value);
 }

--- a/.github/actions/pr-metrics-comment/lib/metrics-result-validation.ts
+++ b/.github/actions/pr-metrics-comment/lib/metrics-result-validation.ts
@@ -14,6 +14,15 @@ import {
 } from './metrics-result-contract.js';
 import type { JsonValue } from './metrics-result-contract.js';
 
+/**
+ * Parses `value` against `schema` and returns the original input reference on
+ * success, never the parsed output. Reference identity is a contract: the
+ * publisher asserts `validateMetricsResult(result) === result` in
+ * `pr-metrics-publisher.test.js`. This is sound while every schema is a plain
+ * shape and bounds check with no `.transform()`, `.default()`, `.prefault()`,
+ * or `.catch()` — the parsed output is structurally identical to the input. A
+ * schema that converts values must switch this function to `result.data`.
+ */
 function parseOrThrow<T>(schema: z.ZodType<T>, value: unknown): T {
   const result = schema.safeParse(value, {
     error: (issue) => {
@@ -27,16 +36,11 @@ function parseOrThrow<T>(schema: z.ZodType<T>, value: unknown): T {
           if (issue.expected === 'string') return 'must be a string';
           return issue.message;
         case 'too_small':
-        case 'too_big': {
+        case 'too_big':
           if (issue.origin === 'array') return 'has too many entries';
-          if (issue.origin === 'number') {
-            const minimum = 'minimum' in issue ? issue.minimum : 0;
-            const maximum = 'maximum' in issue ? issue.maximum : Number.MAX_SAFE_INTEGER;
-            return `must be an integer from ${minimum} to ${maximum}`;
-          }
           if (issue.origin === 'string') return 'has an invalid value';
           return issue.message;
-        }
+        case 'invalid_value':
         case 'invalid_format':
           return 'has an invalid value';
         default:
@@ -55,7 +59,19 @@ function parseOrThrow<T>(schema: z.ZodType<T>, value: unknown): T {
   return value as T;
 }
 
-const boundedCountSchema = z.number().int().min(0).max(MAX_COUNT);
+/**
+ * Builds an integer schema whose bound failures report the exact range in the
+ * message. Schema-level error messages take precedence over the parse-level
+ * map, so both `too_small` and `too_big` report the same literal.
+ */
+function boundedInt(minimum: number, maximum: number): z.ZodNumber {
+  const message = `must be an integer from ${minimum} to ${maximum}`;
+  return z.number().int()
+    .min(minimum, { error: () => message })
+    .max(maximum, { error: () => message });
+}
+
+const boundedCountSchema = boundedInt(0, MAX_COUNT);
 
 const moduleNameSchema = z.string().regex(MODULE_PATTERN);
 
@@ -77,7 +93,7 @@ const coverageSchema = z.strictObject({
 const jarSchema = z.strictObject({
   module: moduleNameSchema,
   size: boundedCountSchema,
-  classes: z.number().int().min(0).max(MAX_COUNT).nullable(),
+  classes: boundedInt(0, MAX_COUNT).nullable(),
 });
 
 const jarsSchema = z.array(jarSchema).max(MAX_MODULES).refine(
@@ -88,7 +104,7 @@ const jarsSchema = z.array(jarSchema).max(MAX_MODULES).refine(
 const buildMetricsSchema = z.strictObject({
   tests: boundedCountSchema,
   skipped: boundedCountSchema,
-  durationSeconds: z.number().int().min(0).max(MAX_COUNT).nullable(),
+  durationSeconds: boundedInt(0, MAX_COUNT).nullable(),
 });
 
 const patchCoverageSchema = z.strictObject({
@@ -115,9 +131,9 @@ const provenanceSchema = z.strictObject({
   repository: z.string().regex(REPOSITORY_PATTERN),
   workflow: z.string().refine((value): boolean => value === WORKFLOW_NAME, { message: `must be ${WORKFLOW_NAME}` }),
   event: z.string().refine((value): boolean => value === 'pull_request', { message: 'must be pull_request' }),
-  runId: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER),
-  runAttempt: z.number().int().min(1).max(1000),
-  pullRequest: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER),
+  runId: boundedInt(1, Number.MAX_SAFE_INTEGER),
+  runAttempt: boundedInt(1, 1000),
+  pullRequest: boundedInt(1, Number.MAX_SAFE_INTEGER),
   baseRepository: z.string().regex(REPOSITORY_PATTERN),
   baseRef: refSchema,
   baseSha: z.string().regex(SHA_PATTERN),

--- a/.github/actions/pr-metrics-comment/test/metrics-result.test.js
+++ b/.github/actions/pr-metrics-comment/test/metrics-result.test.js
@@ -79,6 +79,47 @@ test('rejects unknown report properties', () => {
   assert.throws(() => validateMetricsResult(result), /unexpected properties/);
 });
 
+test('reports the exact bound for too-small and too-big counters', () => {
+  const tooSmall = makeResult();
+  tooSmall.metrics.headCoverage.totalMissed = -1;
+  assert.throws(
+    () => validateMetricsResult(tooSmall),
+    /must be an integer from 0 to 1000000000/,
+  );
+
+  const tooBig = makeResult();
+  tooBig.metrics.headCoverage.totalMissed = 1000000001;
+  assert.throws(
+    () => validateMetricsResult(tooBig),
+    /must be an integer from 0 to 1000000000/,
+  );
+});
+
+test('reports the exact bound for run attempt numbers', () => {
+  const tooSmall = makeResult();
+  tooSmall.provenance.runAttempt = 0;
+  assert.throws(
+    () => validateMetricsResult(tooSmall),
+    /provenance\.runAttempt must be an integer from 1 to 1000/,
+  );
+
+  const tooBig = makeResult();
+  tooBig.provenance.runAttempt = 1001;
+  assert.throws(
+    () => validateMetricsResult(tooBig),
+    /provenance\.runAttempt must be an integer from 1 to 1000/,
+  );
+});
+
+test('rejects a mismatched schema version literal', () => {
+  const result = makeResult();
+  result.schemaVersion = 2;
+  assert.throws(
+    () => validateMetricsResult(result),
+    /schemaVersion has an invalid value/,
+  );
+});
+
 test('rejects unsafe declarations and oversized declaration lists', () => {
   const unsafe = makeResult();
   unsafe.metrics.apiSurface.added[0] = 'public fun visible(): String `malicious`';

--- a/.github/package-lock.json
+++ b/.github/package-lock.json
@@ -12,7 +12,8 @@
         "@xmldom/xmldom": "0.9.10",
         "adm-zip": "0.6.0",
         "diff": "9.0.0",
-        "yauzl": "3.4.0"
+        "yauzl": "3.4.0",
+        "zod": "4.4.3"
       },
       "devDependencies": {
         "@actions/core": "3.0.1",
@@ -760,6 +761,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/.github/package.json
+++ b/.github/package.json
@@ -12,7 +12,8 @@
     "@xmldom/xmldom": "0.9.10",
     "adm-zip": "0.6.0",
     "diff": "9.0.0",
-    "yauzl": "3.4.0"
+    "yauzl": "3.4.0",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@actions/core": "3.0.1",


### PR DESCRIPTION
## Summary

Replaces the hand-written JSON boundary validators in `actions/pr-metrics-comment/lib/` with [Zod v4](https://zod.dev) (pinned exact `4.4.3`, zero transitive deps) — the runtime-schema-library follow-up to the TypeScript migration on `chore/ci-typescript-lib`.

- **`metrics-result-contract.ts`** now holds only the constants, patterns, `JsonValue` type, and `hasUnsafeTextCharacter` — the hand-rolled `exactKeys`/`bounded*`/`isObject` validators are gone.
- **`metrics-result-validation.ts`** defines `strictObject` schemas for the whole result, provenances, coverage, jars, build metrics, patch coverage, and API surface. Types are derived with `z.infer`, so the types and the runtime checks can never drift again (that drift caused the `as unknown as` casts banned in the earlier PR). `validateMetricsResult`/`validateBuildMetrics` keep their signatures and return the original value reference, preserving identity semantics.
- **Error-message parity:** a scoped parse error-map preserves the contractually asserted messages (`must be an integer from 0 to 1000000000`, `headRef has an invalid value`, `has unexpected properties`, `provenance.workflow must be CI`, ...) — all 120 tests pass unchanged.
- **`metrics-result-serialization.ts`** validates the pull-request payload with a small Zod schema instead of the `isObject` shape chain.
- **`collect.ts`** drops the obsolete label argument to `validateBuildMetrics`.

## Dependency note

The composite action already loads `@xmldom/xmldom` and `diff` from `.github/node_modules` at runtime; Zod resolves the same way, so no new install mechanism.

## Validation

- `npm run typecheck` ✓ · `npm run build` ✓ · all 120 tests ✓ · `git diff --check` ✓
