### PR TITLE
fix(ci): run gating workflows for every pull request

### DIFF
--- a/.github/scripts/qodana-workflow-security.test.js
+++ b/.github/scripts/qodana-workflow-security.test.js
@@ -36,7 +36,6 @@ test('the Qodana scan workflow is read-only and disables GitHub side effects', (
   const analyse = readJob(workflow, 'analyse');
 
   assert.match(workflow, /pull_request_target:/);
-  assert.match(workflow, /branches: \[master\]/);
   assert.match(workflow, /types: \[opened, synchronize, reopened\]/);
   assert.match(workflow, /group: qodana-\$\{\{ github\.event\.pull_request\.number \}\}/);
   assert.doesNotMatch(workflow, /workflow_run:/);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, reopened]
   push:
     branches: [master]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,6 @@ name: CodeQL
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, reopened]
   push:
     branches: [master]

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -2,7 +2,6 @@ name: Qodana
 
 on:
   pull_request_target:
-    branches: [master]
     types: [opened, synchronize, reopened]
 
 permissions: {}


### PR DESCRIPTION
## Summary

`ci.yml`, `codeql.yml`, and `qodana.yml` restricted their `pull_request` / `pull_request_target` triggers to `branches: [master]`.

For PRs in a GitHub stack this worked: GitHub evaluates stacked PRs against the trunk of the stack (master), so the filters passed. But a PR that is **not** in a stack silently got no CI run. Its required **Status** check (the merge gate from `ci.yml`) could never appear, so the PR was blocked with no signal. This happened to PR #550: it was created outside the stack, and no CI ran on it until it joined the stack.

## Fix

Remove the `branches: [master]` restriction from the three triggers. Every PR now triggers the gating workflows. The internal path filters already decide the heavy work and fail closed:

- `ci.yml`: Triage classifies the change (code vs docs-only vs release-only) and the path filter decides.
- `codeql.yml`: Gate + Detect changes apply the same path filter.
- `qodana.yml`: the register job resolves the source kind and path classification in `qodana-source.ts`.

`docs/CI.md` already states that pull requests run the complete pipeline, so no documentation change is needed. `release-provenance.yml` is intentionally left unchanged: it is for release-please PRs only and its jobs carry hard trust conditions.

## Gate

- `actionlint` clean on all three workflows
- `git diff --check` clean