### PR TITLE
fix(ci): trust the system CA in the release-please job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions: {}
+    env:
+      NODE_OPTIONS: --use-system-ca
     steps:
       - name: Generate Release Please App token
         id: release-please-app-token


### PR DESCRIPTION
## Summary

The Release Please job failed on the stack-merge push (run 31554008102) with an intermittent runner TLS error:

```
release-please failed: self-signed certificate; if the root CA is installed locally,
try running Node.js with --use-system-ca
```

This is the same error class PR #509 worked around by setting `NODE_OPTIONS: --use-system-ca` on the Node tooling workflows (qodana, qodana-trusted, pr-metrics-publish, qodana-publish). `release.yml` was the one workflow that lacked the workaround. This PR applies the same job-level env to the Release Please job.

## Gate

- `actionlint` clean
- `git diff --check` clean