### PR TITLE
perf(ci): cache npm dependencies across tooling jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .github/package-lock.json
+
       - name: Install CI tooling dependencies
         working-directory: .github
         run: npm ci --ignore-scripts --no-audit --no-fund
@@ -183,6 +190,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .github/package-lock.json
 
       - name: Install CI tooling dependencies
         working-directory: .github
@@ -519,6 +533,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .github/package-lock.json
 
       - name: Install CI tooling dependencies
         working-directory: .github

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .github/package-lock.json
+
       - name: Install CI tooling dependencies
         working-directory: .github
         run: npm ci --ignore-scripts --no-audit --no-fund

--- a/.github/workflows/pr-metrics-publish.yml
+++ b/.github/workflows/pr-metrics-publish.yml
@@ -37,6 +37,13 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .github/package-lock.json
+
       - name: Install CI tooling dependencies
         working-directory: .github
         run: npm ci --ignore-scripts --no-audit --no-fund

--- a/.github/workflows/qodana-publish.yml
+++ b/.github/workflows/qodana-publish.yml
@@ -32,6 +32,13 @@ jobs:
           ref: ${{ github.sha }}
           persist-credentials: false
 
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .github/package-lock.json
+
       - name: Install CI tooling dependencies
         working-directory: .github
         run: npm ci --ignore-scripts --no-audit --no-fund

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -37,6 +37,13 @@ jobs:
           ref: ${{ github.sha }}
           persist-credentials: false
 
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .github/package-lock.json
+
       - name: Install CI tooling dependencies
         working-directory: .github
         run: npm ci --ignore-scripts --no-audit --no-fund
@@ -171,6 +178,13 @@ jobs:
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .github/package-lock.json
 
       - name: Install CI tooling dependencies
         working-directory: .github

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -393,6 +393,8 @@ the Qodana code-scan path remain dependency-free.
 `.github/actions/pr-metrics-comment/` in place with `tsc -p tsconfig.json`. The
 `tsconfig.json` uses NodeNext module resolution and full strict mode and emits no source
 maps. `npm run typecheck` runs `tsc --noEmit` to check types without emitting files.
+Node 22 is pinned and the npm store is cached through `actions/setup-node` in every job
+that installs the tooling.
 
 Every job that runs the tooling installs with `npm ci` and builds before it references a
 compiled script, so a fresh checkout — which contains no generated `.js` — always builds
@@ -480,6 +482,7 @@ Pull requests show many checks. Only the checks in the **Master** ruleset block 
 | PR metrics baselines | Uses the `actions/cache` key `ci-baseline-<sha>` on a master push. Downloads an artefact as a fallback. Rebuilds the JAR only as the last option |
 | Kover coverage hand-off | Shards upload `kover-handoff-<shard>`; Aggregate restores them and runs `:koverXmlReport :koverHtmlReport :koverVerify -Pkover.externalBinariesDir=modules`. No test re-run in Aggregate |
 | Qodana caches | The Qodana analyse jobs restore the Gradle caches read-only (`cache-read-only: true`) and restore and save the Qodana inspection cache (`use-caches: true`). The action installs the qodana CLI executable into the runner tool cache (`RUNNER_TOOL_CACHE/qodana/<version>/<arch>`); the IDE distribution (`qodana-jvm-community`) is a separate download that the `cache-dir` override pins inside `${{ runner.temp }}/qodana`, cached under `qodana-ide-<os>-v2026.2.0`. Only trusted triggers (push, schedule, dispatch) may write default-branch caches, so the trusted workflow saves the IDE distribution and pull-request-triggered runs restore it with `actions/cache/restore` |
+| npm tooling cache | The eight tooling jobs restore the npm store with `actions/setup-node` (`cache: npm`, keyed on `.github/package-lock.json`, Node 22 pinned). `npm ci` verifies lockfile integrity hashes, so a cached store cannot install wrong content |
 
 ### Artefacts
 


### PR DESCRIPTION
## Summary

Adds `actions/setup-node` with `cache: npm` to the eight jobs that install the CI tooling (Triage, Lint (Actions), PR feedback, CodeQL Gate, Qodana register, Qodana attestation, PR metrics publication, Qodana publication), keyed on `.github/package-lock.json`. Also pins Node 22 so the tooling runtime is deterministic across jobs and runners.

Measured before: `npm ci` 3-6s per job (Gate 3s, Triage 6s) on warm runners. The cache removes the cold-run spike (10-20s) and the network dependency from every PR and push.

## Security

`npm ci` verifies every package against the lockfile integrity hashes, so a cached store cannot install wrong content. `actions/cache` scopes entries by branch; trusted triggers write the default-branch cache. `--ignore-scripts` is unchanged.

## Files

- `.github/workflows/ci.yml` - Triage, Lint (Actions), PR feedback
- `.github/workflows/codeql.yml` - Gate
- `.github/workflows/qodana.yml` - register, attestation
- `.github/workflows/pr-metrics-publish.yml`, `.github/workflows/qodana-publish.yml`
- `docs/CI.md` - Performance table row + Node tooling note

## Gate

- `actionlint` clean on all five workflows
- `git diff --check` clean
