### PR TITLE
perf(ci): save and restore the Gradle configuration cache

### DIFF
--- a/.github/actions/gradle-job/action.yml
+++ b/.github/actions/gradle-job/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: Publish a Gradle Build Scan (slow — disables effective local build-cache reuse). Default off.
     required: false
     default: 'false'
+  cache-encryption-key:
+    description: Base64 AES key that encrypts the Gradle configuration cache for save/restore.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -22,6 +26,7 @@ runs:
       with:
         java-version: ${{ inputs.java-version }}
         build-scan-publish: ${{ inputs.build-scan }}
+        cache-encryption-key: ${{ inputs.cache-encryption-key }}
 
     - name: Run Gradle
       id: gradle

--- a/.github/actions/setup-jdk-gradle/action.yml
+++ b/.github/actions/setup-jdk-gradle/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Publish a Gradle Build Scan (Develocity injection). Off by default — turns off local build-cache hits.
     required: false
     default: 'false'
+  cache-encryption-key:
+    description: Base64 AES key that encrypts the Gradle configuration cache for save/restore.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -27,7 +31,10 @@ runs:
         build-scan-publish: true
         build-scan-terms-of-use-url: https://gradle.com/terms-of-service
         build-scan-terms-of-use-agree: 'yes'
+        cache-encryption-key: ${{ inputs.cache-encryption-key }}
 
     - name: Set up Gradle
       if: inputs.build-scan-publish != 'true'
       uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+      with:
+        cache-encryption-key: ${{ inputs.cache-encryption-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
         uses: ./.github/actions/gradle-job
         with:
           tasks: spotlessCheck ktlintCheck
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
   lint-actions:
     name: Lint (Actions)
@@ -280,6 +281,7 @@ jobs:
         uses: ./.github/actions/gradle-job
         with:
           tasks: ${{ steps.tasks.outputs.tasks }}
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Publish JUnit test report
         if: always()
@@ -371,6 +373,8 @@ jobs:
 
       - name: Set up JDK and Gradle
         uses: ./.github/actions/setup-jdk-gradle
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Download test results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -429,6 +433,7 @@ jobs:
         uses: ./.github/actions/gradle-job
         with:
           tasks: :koverXmlReport :koverHtmlReport :koverVerify -Pkover.externalBinariesDir=modules
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Collect CI metrics
         run: bash .github/scripts/collect-ci-metrics.sh
@@ -502,6 +507,8 @@ jobs:
 
       - name: Set up JDK and Gradle
         uses: ./.github/actions/setup-jdk-gradle
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Generate Dokka
         run: ./gradlew dokkaGenerate
@@ -618,6 +625,7 @@ jobs:
         uses: ./.github/actions/setup-jdk-gradle
         with:
           build-scan-publish: 'false'
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build base jars if still missing
         if: steps.need-base-jars.outputs.needed == 'true'
@@ -665,6 +673,8 @@ jobs:
 
       - name: Set up JDK and Gradle
         uses: ./.github/actions/setup-jdk-gradle
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Resolve Minecraft fixture cache key
         id: fixture

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -193,6 +193,8 @@ jobs:
       - name: Set up JDK and Gradle
         if: matrix.build-mode == 'manual'
         uses: ./.github/actions/setup-jdk-gradle
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build for CodeQL
         if: matrix.build-mode == 'manual'

--- a/.github/workflows/qodana-trusted.yml
+++ b/.github/workflows/qodana-trusted.yml
@@ -45,6 +45,7 @@ jobs:
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           cache-read-only: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Restore the Qodana IDE distribution
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -126,6 +126,7 @@ jobs:
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           cache-read-only: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Restore the Qodana IDE distribution
         if: needs.register.outputs.source_kind == 'code'


### PR DESCRIPTION
## What and why

`gradle/actions/setup-gradle` does not save or restore the Gradle configuration cache unless `cache-encryption-key` is provided (per its action.yml: "Configuration-cache data will not be saved/restored without an encryption key being provided"). This repo sets no such key, so every Gradle job reconfigures the 8-module build from scratch on every run — verified: zero "Reusing configuration cache" lines across six CI jobs (3 CodeQL runs, Build runtime, Dokka, Lint Kotlin).

For the CodeQL build that is ~25s of the ~95s build step; every other Gradle job pays the same tax.

## Change

- Added `GRADLE_ENCRYPTION_KEY` repo secret (base64 AES key, `openssl rand -base64 16`).
- `setup-jdk-gradle` and `gradle-job` composite actions: new `cache-encryption-key` input, passed to setup-gradle. (Composite actions cannot read the `secrets` context directly, so callers supply the secret as an input.)
- All 10 Gradle call sites pass the secret: 7× ci.yml (4 direct + 3 via gradle-job), 1× codeql.yml, 2× qodana (direct setup-gradle calls).

## Notes

- Fork PRs: secrets are unavailable to fork PRs, so the value evaluates empty and behaviour is unchanged (no config cache, no failure). Same-repo PRs and master pushes get the save/restore.
- The CodeQL build keeps its own config-cache entry (keyed on its `-P` flags); it will now be reused across CodeQL runs.
- Expected saving: ~20s on the CodeQL build step and comparable on every other Gradle job.

## Verification

- `actionlint` clean on ci.yml, codeql.yml, qodana.yml, qodana-trusted.yml.
- `git diff --check` clean.
- First CI run after merge proves it: master push saves the config cache; the next run logs "Reusing configuration cache".
