### PR TITLE
perf(ci): run jobs on arm64 hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
   triage:
     name: Triage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     permissions:
       actions: read
@@ -165,7 +165,7 @@ jobs:
     name: Lint (Kotlin)
     needs: [triage]
     if: needs.triage.outputs.run == 'true' && needs.triage.outputs.code == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -184,7 +184,7 @@ jobs:
     name: Lint (Actions)
     needs: [triage]
     if: needs.triage.outputs.run == 'true' && needs.triage.outputs.code == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
       - name: Checkout
@@ -235,7 +235,7 @@ jobs:
             tasks: :minimessage:koverBinaryReport :serializer:koverBinaryReport :minimessage:jar :serializer:jar
           - shard: runtime
             tasks: :coroutines:koverBinaryReport :paper:koverBinaryReport :test:koverBinaryReport :test-snapshot:koverBinaryReport :bom:build :coroutines:jar :paper:jar :test:jar :test-snapshot:jar
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     permissions:
       checks: write
@@ -361,7 +361,7 @@ jobs:
     name: Aggregate
     needs: [build]
     if: needs.build.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     permissions:
       contents: read
@@ -495,7 +495,7 @@ jobs:
     name: Dokka
     needs: [triage]
     if: needs.triage.outputs.run == 'true' && needs.triage.outputs.code == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     permissions:
       contents: read
@@ -529,7 +529,7 @@ jobs:
       && github.event_name == 'pull_request'
       && needs.aggregate.result != 'cancelled'
       && needs.aggregate.result != 'skipped'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 25
     permissions:
       actions: read
@@ -660,7 +660,7 @@ jobs:
     name: Vanilla conformance
     needs: [triage]
     if: needs.triage.outputs.run == 'true' && needs.triage.outputs.vanilla == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     permissions:
       checks: write
@@ -717,7 +717,7 @@ jobs:
   dependencies:
     name: Dependencies
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -734,7 +734,7 @@ jobs:
   commits:
     name: Commits
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -764,7 +764,7 @@ jobs:
     name: Status
     if: always()
     needs: [triage, lint-kotlin, lint-actions, build, aggregate, dokka, vanilla, dependencies]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
       - name: Evaluate

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -19,7 +19,7 @@ jobs:
       && (github.event.review.state == 'approved'
       || github.event.review.state == 'changes_requested'
       || github.event.review.state == 'dismissed'))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/pr-metrics-publish.yml
+++ b/.github/workflows/pr-metrics-publish.yml
@@ -23,7 +23,7 @@ jobs:
   publish:
     name: Publish PR metrics
     if: github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     permissions:
       actions: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
   # ─── Title validation ────────────────────────────────────────────────────────
   title:
     name: Title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     permissions:
       contents: read
@@ -44,7 +44,7 @@ jobs:
   # ─── Commit subjects ────────────────────────────────────────────────────────
   commits:
     name: Commits
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     permissions:
       contents: read
@@ -77,7 +77,7 @@ jobs:
   labels:
     name: Labels
     if: github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/qodana-publish.yml
+++ b/.github/workflows/qodana-publish.yml
@@ -18,7 +18,7 @@ jobs:
   publish:
     name: Publish Qodana result
     if: github.event.workflow_run.conclusion != 'skipped'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     permissions:
       actions: read


### PR DESCRIPTION
## What and why

GitHub arm64 hosted runners are free in public repositories and generally available (GA 2025-08-07). They use Graviton-class CPUs — GitHub measured up to 40% faster per-core than the x64 standard runners — which directly shrinks the Gradle build and test jobs that dominate CI wall-clock.

## Change

Switched `runs-on` to `ubuntu-24.04-arm` for every per-PR / per-push job across 5 workflows (17 jobs):

- ci.yml (11 jobs) — the Gradle build, test, lint, and gate jobs.
- pr.yml (3 jobs) — Title / Commits / Labels validation.
- maintainer-approval.yml (1 job).
- pr-metrics-publish.yml (1 job).
- qodana-publish.yml (1 job).

## Deliberately not switched

| Workflow | Reason |
|---|---|
| codeql.yml | CodeQL has no linux/arm64 support — the CLI bundle is x64-only; support PR github/codeql-action#4072 is still open. The action "does not work at all today" on arm64 runners. |
| qodana.yml, qodana-trusted.yml | JetBrains qodana-action on linux/arm64 is unverified; these jobs are not a wall-clock concern. Can follow up. |
| release.yml, release-provenance.yml | Release path, security-sensitive, runs rarely; zero wall-clock benefit. |
| scorecard.yml | Monthly scheduled scan; zero benefit. |

## Verification

- `actionlint` clean on all five workflows.
- `git diff --check` clean.
- CI on this PR runs the whole pipeline on arm64 end to end — the Gradle jobs will log the platform at job start. Watch the java-kotlin CodeQL job stays on x64.

## Risks

- First PR exercising the arm64 images; if any job misbehaves it fails loudly here, and reverting is a one-line-per-job change.
- arm64 images track the same runner-images release cadence as x64.
