### PR TITLE
chore(opencode): add Adventure reference

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "references": {
+    "adventure": {
+      "repository": "PaperMC/adventure",
+      "branch": "main",
+      "description": "Authoritative Adventure API implementation and behavior"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a repository-local OpenCode configuration
- expose PaperMC Adventure as a named implementation reference
- keep models, plugins, MCP servers, and personal settings out of the repository

## Validation

- `opencode debug config`
- `git diff --check`