### PR TITLE
test(ci): define aggregate status policy

### DIFF
--- a/.github/scripts/ci-status.test.ts
+++ b/.github/scripts/ci-status.test.ts
@@ -7,7 +7,6 @@ import {
   STATUS_POLICY_ROWS,
   type CiStatusResults,
   type CiStatusInput,
-  type StatusJobName,
 } from './ci-status.js';
 
 const ALL_SUCCESS: CiStatusResults = {
@@ -21,24 +20,11 @@ const ALL_SUCCESS: CiStatusResults = {
   dependencies: 'success',
 };
 
-interface MutableCiStatusInput {
-  eventName: string;
-  triage: {
-    run?: string;
-    releaseOnly?: string;
-    releaseCandidate?: string;
-    documentationOnly?: string;
-    code?: string;
-    vanilla?: string;
-  };
-  results: CiStatusResults;
-}
-
 function booleanOutput(value: boolean): string {
   return value ? 'true' : 'false';
 }
 
-function fixtureForPolicy(policyName: string): MutableCiStatusInput {
+function fixtureForPolicy(policyName: string): CiStatusInput {
   const policy = STATUS_POLICY_ROWS.find((candidate) => candidate.name === policyName);
   assert.ok(policy, `missing policy fixture: ${policyName}`);
   const eventName = policy.events[0];
@@ -61,7 +47,7 @@ function fixtureForPolicy(policyName: string): MutableCiStatusInput {
   };
 }
 
-function copyInput(input: CiStatusInput | MutableCiStatusInput): MutableCiStatusInput {
+function copyInput(input: CiStatusInput): CiStatusInput {
   const results = input.results;
   return {
     eventName: input.eventName,

--- a/.github/scripts/ci-status.test.ts
+++ b/.github/scripts/ci-status.test.ts
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  evaluateCiStatus,
+  JOB_LABELS,
+  STATUS_JOB_NAMES,
+  STATUS_POLICY_ROWS,
+  type CiStatusInput,
+  type StatusJobName,
+} from './ci-status.js';
+
+const ALL_SUCCESS = Object.fromEntries(STATUS_JOB_NAMES.map((job) => [job, 'success'])) as Record<StatusJobName, string>;
+
+interface MutableCiStatusInput {
+  eventName: unknown;
+  triage: Record<string, unknown>;
+  results: Record<StatusJobName, unknown>;
+}
+
+function booleanOutput(value: boolean): string {
+  return value ? 'true' : 'false';
+}
+
+function fixtureForPolicy(policyName: string): MutableCiStatusInput {
+  const policy = STATUS_POLICY_ROWS.find((candidate) => candidate.name === policyName);
+  assert.ok(policy, `missing policy fixture: ${policyName}`);
+  const eventName = policy.events[0];
+  assert.ok(eventName);
+
+  const results = { ...ALL_SUCCESS };
+  for (const job of policy.optional) results[job] = 'skipped';
+
+  return {
+    eventName,
+    triage: {
+      run: booleanOutput(policy.run),
+      releaseOnly: booleanOutput(policy.releaseOnly),
+      releaseCandidate: booleanOutput(policy.name === 'trusted-release-pr'),
+      documentationOnly: booleanOutput(policy.documentationOnly),
+      ...(policy.code === undefined ? {} : { code: booleanOutput(policy.code) }),
+      ...(policy.vanilla === undefined ? {} : { vanilla: booleanOutput(policy.vanilla) }),
+    },
+    results,
+  };
+}
+
+function copyInput(input: CiStatusInput | MutableCiStatusInput): MutableCiStatusInput {
+  return {
+    eventName: input.eventName,
+    triage: { ...input.triage },
+    results: { ...input.results },
+  };
+}
+
+for (const policy of STATUS_POLICY_ROWS) {
+  test(`accepts the ${policy.name} policy row`, () => {
+    const input = fixtureForPolicy(policy.name);
+    const evaluation = evaluateCiStatus(input);
+
+    assert.equal(evaluation.policy, policy.name);
+    assert.deepEqual(evaluation.acceptedSkips, policy.optional);
+    assert.match(evaluation.summary, new RegExp(policy.name));
+  });
+}
+
+for (const policy of STATUS_POLICY_ROWS) {
+  for (const job of policy.required) {
+    test(`requires success for ${policy.name} ${job}`, () => {
+      const input = copyInput(fixtureForPolicy(policy.name));
+      input.results[job] = 'skipped';
+
+      assert.throws(
+        () => evaluateCiStatus(input),
+        (error: unknown) => error instanceof Error
+          && error.message.includes(`${JOB_LABELS[job]} result is skipped`),
+      );
+    });
+  }
+
+  for (const job of policy.optional) {
+    test(`accepts success for optional ${policy.name} ${job}`, () => {
+      const input = copyInput(fixtureForPolicy(policy.name));
+      input.results[job] = 'success';
+
+      assert.doesNotThrow(() => evaluateCiStatus(input));
+    });
+  }
+}
+
+for (const policy of STATUS_POLICY_ROWS) {
+  for (const job of STATUS_JOB_NAMES) {
+    for (const result of ['failure', 'cancelled']) {
+      test(`rejects ${result} from ${policy.name} ${job}`, () => {
+        const input = copyInput(fixtureForPolicy(policy.name));
+        input.results[job] = result;
+
+        assert.throws(
+          () => evaluateCiStatus(input),
+          (error: unknown) => error instanceof Error
+            && error.message.includes(`${JOB_LABELS[job]} result must not be ${result}`),
+        );
+      });
+    }
+  }
+}
+
+for (const job of STATUS_JOB_NAMES) {
+  for (const result of ['', 'unknown', undefined]) {
+    test(`rejects ${String(result)} as the ${job} result`, () => {
+      const input = copyInput(fixtureForPolicy('code-pr-without-vanilla'));
+        input.results[job] = result;
+
+        assert.throws(
+          () => evaluateCiStatus(input),
+          (error: unknown) => error instanceof Error
+            && error.message.includes(`${JOB_LABELS[job]} result is invalid`),
+        );
+    });
+  }
+}
+
+test('rejects an unknown event and still validates all job results', () => {
+  const input = copyInput(fixtureForPolicy('code-pr-without-vanilla'));
+  input.eventName = 'repository_dispatch';
+  input.results.build = 'failure';
+  input.results.aggregate = 'unknown';
+
+  assert.throws(
+    () => evaluateCiStatus(input),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /eventName must be one of/);
+      assert.match(error.message, /Build result must not be failure/);
+      assert.match(error.message, /Aggregate result is invalid/);
+      return true;
+    },
+  );
+});
+
+test('rejects a trusted release skip outside a pull request', () => {
+  const input = copyInput(fixtureForPolicy('trusted-release-pr'));
+  input.eventName = 'push';
+
+  assert.throws(
+    () => evaluateCiStatus(input),
+    /trusted release-only pull request/,
+  );
+});
+
+test('rejects a partial full-validation event', () => {
+  const input = copyInput(fixtureForPolicy('full-validation'));
+  input.triage.vanilla = 'false';
+
+  assert.throws(
+    () => evaluateCiStatus(input),
+    /do not match a supported Status policy row/,
+  );
+});
+
+test('rejects contradictory documentation flags', () => {
+  const input = copyInput(fixtureForPolicy('documentation-pr'));
+  input.triage.code = 'true';
+
+  assert.throws(
+    () => evaluateCiStatus(input),
+    /documentation-only pull requests cannot set code or vanilla to true/,
+  );
+});
+
+test('rejects missing path flags outside a trusted release pull request', () => {
+  const input = copyInput(fixtureForPolicy('code-pr-without-vanilla'));
+  delete input.triage.code;
+  delete input.triage.vanilla;
+
+  assert.throws(
+    () => evaluateCiStatus(input),
+    /triage\.code must be "true" or "false" \(got missing\)/,
+  );
+});
+
+test('reports multiple invalid job results in one error', () => {
+  const input = copyInput(fixtureForPolicy('code-pr-without-vanilla'));
+  input.results.build = 'failure';
+  input.results.aggregate = 'cancelled';
+  input.results.dokka = 'unknown';
+
+  assert.throws(
+    () => evaluateCiStatus(input),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Build result must not be failure/);
+      assert.match(error.message, /Aggregate result must not be cancelled/);
+      assert.match(error.message, /Dokka result is invalid/);
+      return true;
+    },
+  );
+});

--- a/.github/scripts/ci-status.test.ts
+++ b/.github/scripts/ci-status.test.ts
@@ -5,16 +5,33 @@ import {
   JOB_LABELS,
   STATUS_JOB_NAMES,
   STATUS_POLICY_ROWS,
+  type CiStatusResults,
   type CiStatusInput,
   type StatusJobName,
 } from './ci-status.js';
 
-const ALL_SUCCESS = Object.fromEntries(STATUS_JOB_NAMES.map((job) => [job, 'success'])) as Record<StatusJobName, string>;
+const ALL_SUCCESS: CiStatusResults = {
+  triage: 'success',
+  lintKotlin: 'success',
+  lintActions: 'success',
+  build: 'success',
+  aggregate: 'success',
+  dokka: 'success',
+  vanilla: 'success',
+  dependencies: 'success',
+};
 
 interface MutableCiStatusInput {
-  eventName: unknown;
-  triage: Record<string, unknown>;
-  results: Record<StatusJobName, unknown>;
+  eventName: string;
+  triage: {
+    run?: string;
+    releaseOnly?: string;
+    releaseCandidate?: string;
+    documentationOnly?: string;
+    code?: string;
+    vanilla?: string;
+  };
+  results: CiStatusResults;
 }
 
 function booleanOutput(value: boolean): string {
@@ -45,10 +62,20 @@ function fixtureForPolicy(policyName: string): MutableCiStatusInput {
 }
 
 function copyInput(input: CiStatusInput | MutableCiStatusInput): MutableCiStatusInput {
+  const results = input.results;
   return {
     eventName: input.eventName,
     triage: { ...input.triage },
-    results: { ...input.results },
+    results: {
+      triage: results?.triage,
+      lintKotlin: results?.lintKotlin,
+      lintActions: results?.lintActions,
+      build: results?.build,
+      aggregate: results?.aggregate,
+      dokka: results?.dokka,
+      vanilla: results?.vanilla,
+      dependencies: results?.dependencies,
+    },
   };
 }
 
@@ -71,7 +98,7 @@ for (const policy of STATUS_POLICY_ROWS) {
 
       assert.throws(
         () => evaluateCiStatus(input),
-        (error: unknown) => error instanceof Error
+        (error) => error instanceof Error
           && error.message.includes(`${JOB_LABELS[job]} result is skipped`),
       );
     });
@@ -96,7 +123,7 @@ for (const policy of STATUS_POLICY_ROWS) {
 
         assert.throws(
           () => evaluateCiStatus(input),
-          (error: unknown) => error instanceof Error
+          (error) => error instanceof Error
             && error.message.includes(`${JOB_LABELS[job]} result must not be ${result}`),
         );
       });
@@ -112,7 +139,7 @@ for (const job of STATUS_JOB_NAMES) {
 
         assert.throws(
           () => evaluateCiStatus(input),
-          (error: unknown) => error instanceof Error
+          (error) => error instanceof Error
             && error.message.includes(`${JOB_LABELS[job]} result is invalid`),
         );
     });
@@ -127,7 +154,7 @@ test('rejects an unknown event and still validates all job results', () => {
 
   assert.throws(
     () => evaluateCiStatus(input),
-    (error: unknown) => {
+    (error) => {
       assert.ok(error instanceof Error);
       assert.match(error.message, /eventName must be one of/);
       assert.match(error.message, /Build result must not be failure/);
@@ -186,7 +213,7 @@ test('reports multiple invalid job results in one error', () => {
 
   assert.throws(
     () => evaluateCiStatus(input),
-    (error: unknown) => {
+    (error) => {
       assert.ok(error instanceof Error);
       assert.match(error.message, /Build result must not be failure/);
       assert.match(error.message, /Aggregate result must not be cancelled/);

--- a/.github/scripts/ci-status.ts
+++ b/.github/scripts/ci-status.ts
@@ -17,7 +17,7 @@ const STATUS_JOB_NAMES = [
   'dependencies',
 ] as const;
 
-const JOB_LABELS: Record<StatusJobName, string> = {
+const JOB_LABELS = {
   triage: 'Triage',
   lintKotlin: 'Lint (Kotlin)',
   lintActions: 'Lint (Actions)',
@@ -26,7 +26,7 @@ const JOB_LABELS: Record<StatusJobName, string> = {
   dokka: 'Dokka',
   vanilla: 'Vanilla conformance',
   dependencies: 'Dependencies',
-};
+} as const satisfies { [Job in StatusJobName]: string };
 
 const WORKFLOW_RESULTS = ['success', 'failure', 'cancelled', 'skipped'] as const;
 
@@ -36,17 +36,23 @@ export type CiEvent = typeof SUPPORTED_EVENTS[number];
 export type StatusJobName = typeof STATUS_JOB_NAMES[number];
 export type WorkflowResult = typeof WORKFLOW_RESULTS[number];
 
+export interface CiStatusTriage {
+  run?: string;
+  releaseOnly?: string;
+  releaseCandidate?: string;
+  documentationOnly?: string;
+  code?: string;
+  vanilla?: string;
+}
+
+export type CiStatusResults = {
+  [Job in StatusJobName]: string | undefined;
+};
+
 export interface CiStatusInput {
-  readonly eventName: unknown;
-  readonly triage: {
-    readonly run?: unknown;
-    readonly releaseOnly?: unknown;
-    readonly releaseCandidate?: unknown;
-    readonly documentationOnly?: unknown;
-    readonly code?: unknown;
-    readonly vanilla?: unknown;
-  };
-  readonly results: Readonly<Record<StatusJobName, unknown>>;
+  eventName: string;
+  triage: CiStatusTriage;
+  results: CiStatusResults;
 }
 
 export interface CiStatusEvaluation {
@@ -173,21 +179,12 @@ export const STATUS_POLICY_ROWS: readonly StatusPolicyRow[] = [
   },
 ];
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function displayValue(value: unknown): string {
+function displayValue(value: string | undefined): string {
   if (value === undefined) return 'missing';
-  if (typeof value === 'string') return JSON.stringify(value);
-  try {
-    return JSON.stringify(value) ?? String(value);
-  } catch {
-    return String(value);
-  }
+  return JSON.stringify(value);
 }
 
-function parseEvent(value: unknown, errors: string[]): CiEvent | undefined {
+function parseEvent(value: string | undefined, errors: string[]): CiEvent | undefined {
   if (typeof value === 'string' && (SUPPORTED_EVENTS as readonly string[]).includes(value)) {
     return value as CiEvent;
   }
@@ -196,7 +193,7 @@ function parseEvent(value: unknown, errors: string[]): CiEvent | undefined {
 }
 
 function parseBooleanOutput(
-  value: unknown,
+  value: string | undefined,
   name: string,
   errors: string[],
   allowMissing = false,
@@ -208,26 +205,35 @@ function parseBooleanOutput(
   return undefined;
 }
 
-function parseResults(input: CiStatusInput, errors: string[]): Partial<Record<StatusJobName, WorkflowResult>> {
-  const results: Record<string, unknown> = isRecord(input?.results) ? input.results : {};
-  if (!isRecord(input?.results)) errors.push(`results must be an object (got ${displayValue(input?.results)})`);
-
-  const parsed: Partial<Record<StatusJobName, WorkflowResult>> = {};
-  for (const job of STATUS_JOB_NAMES) {
-    const value = results[job];
-    if (typeof value === 'string' && (WORKFLOW_RESULTS as readonly string[]).includes(value)) {
-      parsed[job] = value as WorkflowResult;
-    } else {
-      errors.push(`${JOB_LABELS[job]} result is invalid (got ${displayValue(value)})`);
-    }
+function parseResult(value: string | undefined, job: StatusJobName, errors: string[]): WorkflowResult | undefined {
+  if ((WORKFLOW_RESULTS as readonly string[]).includes(value ?? '')) {
+    return value as WorkflowResult;
   }
-  return parsed;
+  errors.push(`${JOB_LABELS[job]} result is invalid (got ${displayValue(value)})`);
+  return undefined;
+}
+
+type ParsedCiStatusResults = {
+  [Job in StatusJobName]: WorkflowResult | undefined;
+};
+
+function parseResults(input: CiStatusInput, errors: string[]): ParsedCiStatusResults {
+  const results = input.results;
+  return {
+    triage: parseResult(results.triage, 'triage', errors),
+    lintKotlin: parseResult(results.lintKotlin, 'lintKotlin', errors),
+    lintActions: parseResult(results.lintActions, 'lintActions', errors),
+    build: parseResult(results.build, 'build', errors),
+    aggregate: parseResult(results.aggregate, 'aggregate', errors),
+    dokka: parseResult(results.dokka, 'dokka', errors),
+    vanilla: parseResult(results.vanilla, 'vanilla', errors),
+    dependencies: parseResult(results.dependencies, 'dependencies', errors),
+  };
 }
 
 function resolveFlags(input: CiStatusInput, errors: string[]): ResolvedFlags | undefined {
-  const eventName = parseEvent(input?.eventName, errors);
-  const triage = isRecord(input?.triage) ? input.triage : {};
-  if (!isRecord(input?.triage)) errors.push(`triage outputs must be an object (got ${displayValue(input?.triage)})`);
+  const eventName = parseEvent(input.eventName, errors);
+  const triage = input.triage;
 
   const run = parseBooleanOutput(triage.run, 'triage.run', errors);
   const releaseOnly = parseBooleanOutput(triage.releaseOnly, 'triage.release_only', errors);
@@ -295,7 +301,7 @@ function findPolicy(flags: ResolvedFlags, errors: string[]): StatusPolicyRow | u
 
 function validateJobResults(
   row: StatusPolicyRow | undefined,
-  results: Partial<Record<StatusJobName, WorkflowResult>>,
+  results: ParsedCiStatusResults,
   errors: string[],
 ): StatusJobName[] {
   const acceptedSkips: StatusJobName[] = [];

--- a/.github/scripts/ci-status.ts
+++ b/.github/scripts/ci-status.ts
@@ -1,0 +1,353 @@
+const SUPPORTED_EVENTS = [
+  'pull_request',
+  'push',
+  'merge_group',
+  'schedule',
+  'workflow_dispatch',
+] as const;
+
+const STATUS_JOB_NAMES = [
+  'triage',
+  'lintKotlin',
+  'lintActions',
+  'build',
+  'aggregate',
+  'dokka',
+  'vanilla',
+  'dependencies',
+] as const;
+
+const JOB_LABELS: Record<StatusJobName, string> = {
+  triage: 'Triage',
+  lintKotlin: 'Lint (Kotlin)',
+  lintActions: 'Lint (Actions)',
+  build: 'Build',
+  aggregate: 'Aggregate',
+  dokka: 'Dokka',
+  vanilla: 'Vanilla conformance',
+  dependencies: 'Dependencies',
+};
+
+const WORKFLOW_RESULTS = ['success', 'failure', 'cancelled', 'skipped'] as const;
+
+const OPTIONAL_NON_TRIAGE_JOBS = STATUS_JOB_NAMES.filter((job) => job !== 'triage');
+
+export type CiEvent = typeof SUPPORTED_EVENTS[number];
+export type StatusJobName = typeof STATUS_JOB_NAMES[number];
+export type WorkflowResult = typeof WORKFLOW_RESULTS[number];
+
+export interface CiStatusInput {
+  readonly eventName: unknown;
+  readonly triage: {
+    readonly run?: unknown;
+    readonly releaseOnly?: unknown;
+    readonly releaseCandidate?: unknown;
+    readonly documentationOnly?: unknown;
+    readonly code?: unknown;
+    readonly vanilla?: unknown;
+  };
+  readonly results: Readonly<Record<StatusJobName, unknown>>;
+}
+
+export interface CiStatusEvaluation {
+  readonly policy: string;
+  readonly acceptedSkips: readonly StatusJobName[];
+  readonly summary: string;
+}
+
+interface ResolvedFlags {
+  readonly eventName: CiEvent;
+  readonly run: boolean;
+  readonly releaseOnly: boolean;
+  readonly releaseCandidate: boolean;
+  readonly documentationOnly: boolean;
+  readonly code: boolean | undefined;
+  readonly vanilla: boolean | undefined;
+}
+
+interface StatusPolicyRow {
+  readonly name: string;
+  readonly events: readonly CiEvent[];
+  readonly run: boolean;
+  readonly releaseOnly: boolean;
+  readonly documentationOnly: boolean;
+  readonly code: boolean | undefined;
+  readonly vanilla: boolean | undefined;
+  readonly required: readonly StatusJobName[];
+  readonly optional: readonly StatusJobName[];
+}
+
+const REQUIRED_TRIAGE: readonly StatusJobName[] = ['triage'];
+
+/**
+ * The event and path rows used by the required Status check.
+ */
+export const STATUS_POLICY_ROWS: readonly StatusPolicyRow[] = [
+  {
+    name: 'trusted-release-pr',
+    events: ['pull_request'],
+    run: false,
+    releaseOnly: true,
+    documentationOnly: false,
+    code: undefined,
+    vanilla: undefined,
+    required: REQUIRED_TRIAGE,
+    optional: OPTIONAL_NON_TRIAGE_JOBS,
+  },
+  {
+    name: 'documentation-pr',
+    events: ['pull_request'],
+    run: true,
+    releaseOnly: false,
+    documentationOnly: true,
+    code: false,
+    vanilla: false,
+    required: REQUIRED_TRIAGE,
+    optional: OPTIONAL_NON_TRIAGE_JOBS,
+  },
+  {
+    name: 'code-pr-without-vanilla',
+    events: ['pull_request'],
+    run: true,
+    releaseOnly: false,
+    documentationOnly: false,
+    code: true,
+    vanilla: false,
+    required: [...REQUIRED_TRIAGE, 'lintKotlin', 'lintActions', 'build', 'aggregate', 'dokka', 'dependencies'],
+    optional: ['vanilla'],
+  },
+  {
+    name: 'code-pr-with-vanilla',
+    events: ['pull_request'],
+    run: true,
+    releaseOnly: false,
+    documentationOnly: false,
+    code: true,
+    vanilla: true,
+    required: STATUS_JOB_NAMES,
+    optional: [],
+  },
+  {
+    name: 'push-without-code',
+    events: ['push'],
+    run: true,
+    releaseOnly: false,
+    documentationOnly: false,
+    code: false,
+    vanilla: false,
+    required: REQUIRED_TRIAGE,
+    optional: OPTIONAL_NON_TRIAGE_JOBS,
+  },
+  {
+    name: 'push-with-code-without-vanilla',
+    events: ['push'],
+    run: true,
+    releaseOnly: false,
+    documentationOnly: false,
+    code: true,
+    vanilla: false,
+    required: [...REQUIRED_TRIAGE, 'lintKotlin', 'lintActions', 'build', 'aggregate', 'dokka'],
+    optional: ['vanilla', 'dependencies'],
+  },
+  {
+    name: 'push-with-code-and-vanilla',
+    events: ['push'],
+    run: true,
+    releaseOnly: false,
+    documentationOnly: false,
+    code: true,
+    vanilla: true,
+    required: [...REQUIRED_TRIAGE, 'lintKotlin', 'lintActions', 'build', 'aggregate', 'dokka', 'vanilla'],
+    optional: ['dependencies'],
+  },
+  {
+    name: 'full-validation',
+    events: ['merge_group', 'schedule', 'workflow_dispatch'],
+    run: true,
+    releaseOnly: false,
+    documentationOnly: false,
+    code: true,
+    vanilla: true,
+    required: [...STATUS_JOB_NAMES].filter((job) => job !== 'dependencies'),
+    optional: ['dependencies'],
+  },
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function displayValue(value: unknown): string {
+  if (value === undefined) return 'missing';
+  if (typeof value === 'string') return JSON.stringify(value);
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function parseEvent(value: unknown, errors: string[]): CiEvent | undefined {
+  if (typeof value === 'string' && (SUPPORTED_EVENTS as readonly string[]).includes(value)) {
+    return value as CiEvent;
+  }
+  errors.push(`eventName must be one of ${SUPPORTED_EVENTS.join(', ')} (got ${displayValue(value)})`);
+  return undefined;
+}
+
+function parseBooleanOutput(
+  value: unknown,
+  name: string,
+  errors: string[],
+  allowMissing = false,
+): boolean | undefined {
+  if (value === undefined && allowMissing) return undefined;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  errors.push(`${name} must be "true" or "false" (got ${displayValue(value)})`);
+  return undefined;
+}
+
+function parseResults(input: CiStatusInput, errors: string[]): Partial<Record<StatusJobName, WorkflowResult>> {
+  const results: Record<string, unknown> = isRecord(input?.results) ? input.results : {};
+  if (!isRecord(input?.results)) errors.push(`results must be an object (got ${displayValue(input?.results)})`);
+
+  const parsed: Partial<Record<StatusJobName, WorkflowResult>> = {};
+  for (const job of STATUS_JOB_NAMES) {
+    const value = results[job];
+    if (typeof value === 'string' && (WORKFLOW_RESULTS as readonly string[]).includes(value)) {
+      parsed[job] = value as WorkflowResult;
+    } else {
+      errors.push(`${JOB_LABELS[job]} result is invalid (got ${displayValue(value)})`);
+    }
+  }
+  return parsed;
+}
+
+function resolveFlags(input: CiStatusInput, errors: string[]): ResolvedFlags | undefined {
+  const eventName = parseEvent(input?.eventName, errors);
+  const triage = isRecord(input?.triage) ? input.triage : {};
+  if (!isRecord(input?.triage)) errors.push(`triage outputs must be an object (got ${displayValue(input?.triage)})`);
+
+  const run = parseBooleanOutput(triage.run, 'triage.run', errors);
+  const releaseOnly = parseBooleanOutput(triage.releaseOnly, 'triage.release_only', errors);
+  const releaseCandidate = parseBooleanOutput(triage.releaseCandidate, 'triage.release_candidate', errors);
+  const documentationOnly = parseBooleanOutput(triage.documentationOnly, 'triage.documentation_only', errors);
+  const pathFlagsMayBeMissing = eventName === 'pull_request' && run === false && releaseOnly === true;
+  const code = parseBooleanOutput(triage.code, 'triage.code', errors, pathFlagsMayBeMissing);
+  const vanilla = parseBooleanOutput(triage.vanilla, 'triage.vanilla', errors, pathFlagsMayBeMissing);
+
+  if (
+    eventName === undefined
+    || run === undefined
+    || releaseOnly === undefined
+    || releaseCandidate === undefined
+    || documentationOnly === undefined
+  ) return undefined;
+
+  return {
+    eventName,
+    run,
+    releaseOnly,
+    releaseCandidate,
+    documentationOnly,
+    code,
+    vanilla,
+  };
+}
+
+function matchesPolicy(row: StatusPolicyRow, flags: ResolvedFlags): boolean {
+  return row.events.includes(flags.eventName)
+    && row.run === flags.run
+    && row.releaseOnly === flags.releaseOnly
+    && row.documentationOnly === flags.documentationOnly
+    && row.code === flags.code
+    && row.vanilla === flags.vanilla;
+}
+
+function findPolicy(flags: ResolvedFlags, errors: string[]): StatusPolicyRow | undefined {
+  if (flags.run === false) {
+    if (flags.eventName !== 'pull_request' || !flags.releaseOnly || !flags.releaseCandidate || flags.documentationOnly) {
+      errors.push('triage flags do not describe a trusted release-only pull request');
+    }
+    if (flags.code !== undefined || flags.vanilla !== undefined) {
+      errors.push('triage.code and triage.vanilla must be missing for a skipped trusted release-only pull request');
+    }
+  } else {
+    if (flags.releaseOnly) errors.push('triage.release_only must be false when CI runs');
+    if (flags.eventName === 'pull_request' && flags.documentationOnly && (flags.code || flags.vanilla)) {
+      errors.push('documentation-only pull requests cannot set code or vanilla to true');
+    }
+    if (flags.eventName !== 'pull_request' && flags.documentationOnly) {
+      errors.push('documentation_only is supported only for pull requests');
+    }
+    if (flags.code === false && flags.vanilla === true) {
+      errors.push('triage.vanilla cannot be true when triage.code is false');
+    }
+  }
+
+  const row = STATUS_POLICY_ROWS.find((candidate) => matchesPolicy(candidate, flags));
+  if (row === undefined) {
+    errors.push(`triage flags do not match a supported Status policy row (event ${flags.eventName})`);
+  }
+  return row;
+}
+
+function validateJobResults(
+  row: StatusPolicyRow | undefined,
+  results: Partial<Record<StatusJobName, WorkflowResult>>,
+  errors: string[],
+): StatusJobName[] {
+  const acceptedSkips: StatusJobName[] = [];
+  for (const job of STATUS_JOB_NAMES) {
+    const result = results[job];
+    if (result === undefined) continue;
+
+    if (result === 'failure' || result === 'cancelled') {
+      errors.push(`${JOB_LABELS[job]} result must not be ${result}`);
+      continue;
+    }
+    if (result === 'skipped') {
+      if (row?.optional.includes(job)) {
+        acceptedSkips.push(job);
+      } else if (row?.required.includes(job)) {
+        errors.push(`${JOB_LABELS[job]} result is skipped but the policy requires success`);
+      }
+    }
+  }
+  return acceptedSkips;
+}
+
+function createSummary(row: StatusPolicyRow, acceptedSkips: readonly StatusJobName[]): string {
+  if (acceptedSkips.length === 0) return `Status policy ${row.name} passed; no jobs were skipped.`;
+  const jobs = acceptedSkips.map((job) => JOB_LABELS[job]).join(', ');
+  return `Status policy ${row.name} passed; accepted skipped jobs: ${jobs}.`;
+}
+
+/**
+ * Evaluates the completed CI jobs against one event and path policy.
+ *
+ * @throws Error when the event, triage outputs, or owned job results do not describe a supported policy.
+ */
+export function evaluateCiStatus(input: CiStatusInput): CiStatusEvaluation {
+  const errors: string[] = [];
+  const flags = resolveFlags(input, errors);
+  const row = flags === undefined ? undefined : findPolicy(flags, errors);
+  const results = parseResults(input, errors);
+  const acceptedSkips = validateJobResults(row, results, errors);
+
+  if (errors.length > 0 || row === undefined) {
+    throw new Error(`CI Status policy rejected the workflow:\n- ${errors.join('\n- ')}`);
+  }
+
+  return {
+    policy: row.name,
+    acceptedSkips,
+    summary: createSummary(row, acceptedSkips),
+  };
+}
+
+export {
+  JOB_LABELS,
+  STATUS_JOB_NAMES,
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
         run: bash .github/scripts/check-one-declaration-per-file.sh
 
       - name: Test pr-metrics-comment action
-        run: node --test .github/actions/pr-metrics-comment/test/*.test.js .github/scripts/pr-metrics-publisher.test.js .github/scripts/qodana-*.test.js .github/scripts/workflow-run-check.test.js
+        run: node --test .github/actions/pr-metrics-comment/test/*.test.js .github/scripts/ci-status.test.js .github/scripts/pr-metrics-publisher.test.js .github/scripts/qodana-*.test.js .github/scripts/workflow-run-check.test.js
 
       - name: Verify generated JavaScript is not tracked
         run: |


### PR DESCRIPTION
## Summary

Add a pure, table-driven evaluator for the CI `Status` policy. Cover every event/path row, allowed skip, invalid result, and contradictory flag. Register the compiled test in the Actions lint job. This PR does not change the production `Status` decision.

## Related Issues

Related to #373

## Scope

- [x] GitHub Actions workflow test registration
- [x] CI policy tests
- [ ] Dependency bump
- [ ] Repository settings

## Verification

- `npm run typecheck`
- `npm run build`
- `node --test scripts/ci-status.test.js`
- 230 focused tests passed
- Generated JavaScript remains ignored and untracked

## Review Notes

PR #560 uses this evaluator. Keep this PR merged below PR #560 in the stack.