### PR TITLE
fix(ci): enforce aggregate status policy

### DIFF
--- a/.agents/skills/fixing-ci-failures/SKILL.md
+++ b/.agents/skills/fixing-ci-failures/SKILL.md
@@ -17,14 +17,14 @@ reproduce the failure locally. Do not push a commit only to start the check agai
 
 | Red check | Cause | Fix |
 |---|---|---|
-| **Status** (aggregator) | Lint, Build, or Dependencies failed | Open the failed nested job below |
+| **Status** (aggregator) | One or more owned results failed, were cancelled, were missing, or were invalid | Read every named result in the Status error, then open each failed nested job |
 | Lint: declaration check | More than one top-level class/interface/object in a main-source file | Split the file. Refer to section 5 of AGENTS.md. Reproduce with `.github/scripts/check-one-declaration-per-file.sh`. |
 | Lint | `spotlessCheck` / `ktlintCheck` | Run `./gradlew ktlintFormat` or `spotlessApply`, and commit the result. Continuation indents have eight spaces. The ktlint indent rule is disabled, so use the IDE or edit indentation manually. |
 | Build: test failure | Kotest suite failed | Run `./gradlew test` locally. Failed-run artefacts include HTML test reports. |
 | Build: `koverVerify` | Aggregated line coverage below 85 percent | Add tests. Do not decrease the threshold. Run `./gradlew koverHtmlReport` and open `build/reports/kover/html/index.html` to find uncovered lines. Refer to the policy in `.github/CONTRIBUTING.md` before you increase the threshold. |
 | Build: compile | Public API frequently has no visibility or return type | Add explicit modifiers and KDoc. Refer to `documenting-public-api`. |
 | **Title** / **Commits** | Does not match `verb(area): something` | Edit the pull-request title. For commits, use `git rebase` and force-push the feature branch. The pattern is `^[a-z]+\([a-z0-9][a-z0-9-]*\): \S.*$`. |
-| **Dependencies** | New or updated dependency has a moderate or higher advisory | Update to a corrected version, replace the dependency, or give a justification. This check starts on each pull request. |
+| **Dependencies** | A code pull request has a moderate or higher dependency advisory | Update to a corrected version, replace the dependency, or give a justification. `Status` owns this result for code pull requests. |
 
 ## Known non-errors
 
@@ -63,3 +63,5 @@ fixtures. The cache uses the server bundle SHA-1. You can start the check again 
 - A documentation-only pull request correctly skips resource-intensive jobs. A green Status check with skipped jobs is
   correct. Markdown under `modules/**` uses the documentation path only when the file is the module root
   `README.md`; other module paths count as code.
+- `Status` evaluates one event and path policy. A skipped job is valid only when that policy permits it. A failure,
+  cancellation, missing result, or unknown result is not valid. Read all named failures before you rerun a job.

--- a/.github/scripts/ci-gate.ts
+++ b/.github/scripts/ci-gate.ts
@@ -159,6 +159,7 @@ async function decideGate({
     core.setOutput('run', 'false');
     core.setOutput('release_only', 'true');
     core.setOutput('release_candidate', 'true');
+    core.setOutput('documentation_only', 'false');
     return;
   }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,7 +788,7 @@ jobs:
         run: npm run build
 
       - name: Evaluate
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TRIAGE_RUN: ${{ needs.triage.outputs.run }}
           TRIAGE_RELEASE_ONLY: ${{ needs.triage.outputs.release_only }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -716,25 +716,20 @@ jobs:
 
   dependencies:
     name: Dependencies
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - name: Checkout
-        if: github.event_name == 'pull_request'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Run dependency review
-        if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
           fail-on-scopes: runtime,development,unknown
-
-      - name: Report dependency review not applicable
-        if: github.event_name != 'pull_request'
-        run: echo "Dependency review is not applicable outside pull requests."
 
   commits:
     name: Commits

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -765,10 +765,37 @@ jobs:
     if: always()
     needs: [triage, lint-kotlin, lint-actions, build, aggregate, dokka, vanilla, dependencies]
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .github/package-lock.json
+
+      - name: Install CI tooling dependencies
+        working-directory: .github
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Build CI tooling
+        working-directory: .github
+        run: npm run build
+
       - name: Evaluate
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b # v9.0.0
         env:
+          TRIAGE_RUN: ${{ needs.triage.outputs.run }}
+          TRIAGE_RELEASE_ONLY: ${{ needs.triage.outputs.release_only }}
+          TRIAGE_RELEASE_CANDIDATE: ${{ needs.triage.outputs.release_candidate }}
+          TRIAGE_DOCUMENTATION_ONLY: ${{ needs.triage.outputs.documentation_only }}
+          TRIAGE_CODE: ${{ needs.triage.outputs.code }}
+          TRIAGE_VANILLA: ${{ needs.triage.outputs.vanilla }}
           TRIAGE_RESULT: ${{ needs.triage.result }}
           LINT_KOTLIN_RESULT: ${{ needs.lint-kotlin.result }}
           LINT_ACTIONS_RESULT: ${{ needs.lint-actions.result }}
@@ -776,70 +803,34 @@ jobs:
           AGGREGATE_RESULT: ${{ needs.aggregate.result }}
           DOKKA_RESULT: ${{ needs.dokka.result }}
           VANILLA_RESULT: ${{ needs.vanilla.result }}
-          DEPS_RESULT: ${{ needs.dependencies.result }}
-          TRIAGE_RUN: ${{ needs.triage.outputs.run }}
-          CODE_CHANGED: ${{ needs.triage.outputs.code }}
-        run: |
-          set -euo pipefail
-          triage="$TRIAGE_RESULT"
-          lint_kotlin="$LINT_KOTLIN_RESULT"
-          lint_actions="$LINT_ACTIONS_RESULT"
-          build="$BUILD_RESULT"
-          aggregate="$AGGREGATE_RESULT"
-          dokka="$DOKKA_RESULT"
-          vanilla="$VANILLA_RESULT"
-          deps="$DEPS_RESULT"
-          run="$TRIAGE_RUN"
-          code="$CODE_CHANGED"
+          DEPENDENCIES_RESULT: ${{ needs.dependencies.result }}
+        with:
+          script: |
+            const { evaluateCiStatus } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/ci-status.js`);
 
-          if [[ "$triage" == "failure" || "$triage" == "cancelled" ]]; then
-            echo "::error::Triage failed ($triage)"
-            exit 1
-          fi
-
-          if [[ "$run" != "true" ]]; then
-            echo "::notice::Skipped (trusted pure Release Please PR)."
-            exit 0
-          fi
-
-          if [[ "$code" != "true" ]]; then
-            echo "::notice::Skipped (no code paths changed)."
-            exit 0
-          fi
-
-          if [[ "$lint_kotlin" != "success" ]]; then
-            echo "::error::Lint (Kotlin): $lint_kotlin"
-            exit 1
-          fi
-
-          if [[ "$lint_actions" != "success" ]]; then
-            echo "::error::Lint (Actions): $lint_actions"
-            exit 1
-          fi
-
-          if [[ "$build" != "success" ]]; then
-            echo "::error::Build: $build"
-            exit 1
-          fi
-
-          if [[ "$aggregate" != "success" ]]; then
-            echo "::error::Aggregate: $aggregate"
-            exit 1
-          fi
-
-          if [[ "$dokka" != "success" && "$dokka" != "skipped" ]]; then
-            echo "::error::Dokka: $dokka"
-            exit 1
-          fi
-
-          if [[ "$vanilla" != "success" && "$vanilla" != "skipped" ]]; then
-            echo "::error::Vanilla conformance: $vanilla"
-            exit 1
-          fi
-
-          if [[ "$deps" != "success" && "$deps" != "skipped" ]]; then
-            echo "::error::Dependencies: $deps"
-            exit 1
-          fi
-
-          echo "::notice::All required checks passed."
+            try {
+              const evaluation = evaluateCiStatus({
+                eventName: context.eventName,
+                triage: {
+                  run: process.env.TRIAGE_RUN,
+                  releaseOnly: process.env.TRIAGE_RELEASE_ONLY,
+                  releaseCandidate: process.env.TRIAGE_RELEASE_CANDIDATE,
+                  documentationOnly: process.env.TRIAGE_DOCUMENTATION_ONLY,
+                  code: process.env.TRIAGE_CODE || undefined,
+                  vanilla: process.env.TRIAGE_VANILLA || undefined,
+                },
+                results: {
+                  triage: process.env.TRIAGE_RESULT,
+                  lintKotlin: process.env.LINT_KOTLIN_RESULT,
+                  lintActions: process.env.LINT_ACTIONS_RESULT,
+                  build: process.env.BUILD_RESULT,
+                  aggregate: process.env.AGGREGATE_RESULT,
+                  dokka: process.env.DOKKA_RESULT,
+                  vanilla: process.env.VANILLA_RESULT,
+                  dependencies: process.env.DEPENDENCIES_RESULT,
+                },
+              });
+              core.notice(evaluation.summary);
+            } catch (error) {
+              core.setFailed(error instanceof Error ? error.message : String(error));
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -716,20 +716,25 @@ jobs:
 
   dependencies:
     name: Dependencies
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
       - name: Checkout
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Run dependency review
+        if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
           fail-on-scopes: runtime,development,unknown
+
+      - name: Report dependency review not applicable
+        if: github.event_name != 'pull_request'
+        run: echo "Dependency review is not applicable outside pull requests."
 
   commits:
     name: Commits

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -51,7 +51,7 @@ CI
 │   └─ Release attestation (trusted release-please PRs)
 │
 └─ Status (required merge-gate check) ─────────────────────────────
-    └─ Aggregates Tier 1 + Vanilla + Dependencies
+    └─ Evaluates Triage, lint, Build, Aggregate, Dokka, Vanilla, and Dependencies
 
 Qodana security pipeline (parallel with CI)
 ├─ Qodana            (pull_request_target, read-only PR-head analysis or trusted attestation artefact)
@@ -67,7 +67,29 @@ All heavy CI jobs (`Lint`, `Build` shards, `Vanilla`, `Dokka`) start in parallel
 from the default branch. A documentation-only pull request receives a trusted QDJVM attestation. The attestation does
 not check out or analyse code. The scan may analyse code before CI finishes; results publish when the scan completes,
 and the merge stays gated on the `Status` check. `Aggregate` consumes the shard coverage hand-off without re-running
-tests. The Status job always starts. It reports one required check that controls merges.
+tests. The `Status` job always starts. It evaluates every owned job result before it reports one required check.
+
+### Status policy
+
+`Status` is the required merge check for the CI jobs that it owns. It uses the event and path flags from `Triage` to
+select one policy row. A required job must report `success`. An optional job may report `success` or `skipped`. A
+`failure`, `cancelled`, missing, or unknown result fails `Status`. The evaluator reports every invalid result in one
+message.
+
+| Event and path | Required jobs | Jobs that may be skipped |
+|----------------|---------------|--------------------------|
+| Trusted Release Please pull request | `Triage` | Kotlin lint, Actions lint, Build, Aggregate, Dokka, Vanilla, Dependencies |
+| Documentation-only pull request | `Triage` | Kotlin lint, Actions lint, Build, Aggregate, Dokka, Vanilla, Dependencies |
+| Code pull request without Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Dependencies | Vanilla |
+| Code pull request with Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla, Dependencies | None |
+| Push without code paths | `Triage` | All other owned jobs |
+| Push with code and without Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka | Vanilla, Dependencies |
+| Push with code and Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla | Dependencies |
+| Merge group, schedule, or manual run | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla | Dependencies |
+
+Dependency review applies to pull requests. `Status` accepts a skipped `Dependencies` job on other events because
+GitHub does not provide pull-request dependency changes for those events. This policy does not add another dependency
+scanner.
 
 Each Build shard executes its tests under Kover and uploads a `kover-handoff-<shard>` artefact with the binary `.ic`
 reports and the compiled classes. `Aggregate` restores that data and generates the XML/HTML reports and the `koverVerify`
@@ -261,7 +283,7 @@ and dependent module compilation.
 The CI configuration supports a merge queue. Both `ci.yml` and `pr.yml` listen for `merge_group`. Queue batches do not
 use the path filter. They start the full pipeline, which includes Vanilla conformance. The Title and Commits jobs report
 successful placeholders to keep their required checks present. Dependency review operates only on pull requests. The
-Status job accepts a skipped dependency review on other events.
+`Status` accepts a skipped dependency review on other events.
 
 When the account supports the feature, enable the queue in the **Master** ruleset or in branch protection. Configure
 `merge_queue` and squash merges. Until then, use the usual pull-request squash merge.
@@ -351,7 +373,7 @@ The Title and Commits jobs are required status checks.
 | **pr-metrics-comment** | `.github/actions/pr-metrics-comment` | CI (PR feedback): computes one bounded metrics result artefact |
 
 Before Spotless and ktlint, Lint starts two additional checks. The declaration script permits one top-level type in
-each main-source file. The `pr-metrics-comment` tests use `node --test`.
+each main-source file. The `ci-status` and `pr-metrics-comment` tests use `node --test`.
 
 PR feedback does not control a merge because it uses `continue-on-error`. A failure does not fail Build or Status. The
 repository automation tests use `node --test`.
@@ -361,6 +383,7 @@ repository automation tests use `node --test`.
 | Script | Role |
 |--------|------|
 | `ci-gate.ts` | Gate decision: pure-release, trusted provenance, `release-provenance.yml` polling (`decideGate`) |
+| `ci-status.ts` | Evaluates owned CI job results against the event and path policy |
 | `validate-conventional-title.sh` | Title/commit subject format |
 | `check-one-declaration-per-file.sh` | One top-level class/interface/object per main-source file |
 | `normalize-qodana-sarif.sh` | Fix 0-based SARIF regions and remove scanner-owned automation metadata before upload |
@@ -422,7 +445,7 @@ The **Master** repository ruleset protects the default branch. The rulesets API 
 - Block force pushes, branch deletion, and direct pushes. Update the branch only through a pull request.
 - Require one approval and a code-owner review. Dismiss stale reviews and resolve conversations. Permit only squash
   merges.
-- Require **Status**, **Title**, **Commits**, and **Dependencies**. Require them to be current with the base branch.
+- Require **Status**, **Title**, **Commits**, and **Maintainer approval**. Require them to be current with the base branch.
 - Block Qodana (`QDJVM`) alerts that have medium or higher security severity, or error severity. A pure release PR uses
   the release attestation after the gate verifies that no source files changed.
 - Permit maintainers to bypass the rules in an emergency.
@@ -458,10 +481,10 @@ Pull requests show many checks. Only the checks in the **Master** ruleset block 
 
 | Check | Merge gate | Notes |
 |-------|:----------:|-------|
-| **Status** | **Required** | Aggregates lint, build, Aggregate coverage, Dokka, vanilla, and dependencies. Green when skipped for docs-only or release-please changes |
+| **Status** | **Required** | Evaluates lint, build, Aggregate coverage, Dokka, Vanilla, and Dependencies against the event and path policy |
 | **Title** | **Required** | Conventional PR title (from `pr.yml`) |
 | **Commits** | **Required** | Conventional commit subjects (from `pr.yml`) |
-| **Dependencies** | **Required** | Dependency review |
+| **Dependencies** | No | Evaluated by `Status` for code pull requests; not applicable to other events |
 | Lint / Build | No | Under the Status aggregator |
 | PR feedback | No | Metrics comment only. Not part of Status |
 | Vanilla conformance | No | Under the Status aggregator. Uses a path filter |

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -45,7 +45,7 @@ CI
 │   └─ (Vanilla/Dokka already completed in Tier 1)
 │
 ├─ Policy (independent of tiers) ──────────────────────────────────
-│   ├─ Dependencies      (dependency-review-action, PRs only)
+│   ├─ Dependencies      (dependency-review-action on PRs; explicit success otherwise)
 │   ├─ Commits           (push-to-master subject validation)
 │   ├─ Release provenance (default-branch metadata check)
 │   └─ Release attestation (trusted release-please PRs)
@@ -83,13 +83,13 @@ message.
 | Code pull request without Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Dependencies | Vanilla |
 | Code pull request with Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla, Dependencies | None |
 | Push without code paths | `Triage` | All other owned jobs |
-| Push with code and without Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka | Vanilla, Dependencies |
-| Push with code and Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla | Dependencies |
-| Merge group, schedule, or manual run | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla | Dependencies |
+| Push with code and without Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Dependencies | Vanilla |
+| Push with code and Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla, Dependencies | None |
+| Merge group, schedule, or manual run | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla, Dependencies | None |
 
-Dependency review applies to pull requests. `Status` accepts a skipped `Dependencies` job on other events because
-GitHub does not provide pull-request dependency changes for those events. This policy does not add another dependency
-scanner.
+The `Dependencies` job runs on every supported event. It performs dependency review only for pull requests. On other
+events, it reports success because GitHub does not provide a pull-request dependency diff. This policy does not add
+another dependency scanner.
 
 Each Build shard executes its tests under Kover and uploads a `kover-handoff-<shard>` artefact with the binary `.ic`
 reports and the compiled classes. `Aggregate` restores that data and generates the XML/HTML reports and the `koverVerify`
@@ -282,8 +282,8 @@ and dependent module compilation.
 
 The CI configuration supports a merge queue. Both `ci.yml` and `pr.yml` listen for `merge_group`. Queue batches do not
 use the path filter. They start the full pipeline, which includes Vanilla conformance. The Title and Commits jobs report
-successful placeholders to keep their required checks present. Dependency review operates only on pull requests. The
-`Status` accepts a skipped dependency review on other events.
+successful placeholders to keep their required checks present. The Dependencies job reports successful not-applicable
+status on merge groups. `Status` requires that result.
 
 When the account supports the feature, enable the queue in the **Master** ruleset or in branch protection. Configure
 `merge_queue` and squash merges. Until then, use the usual pull-request squash merge.
@@ -445,7 +445,9 @@ The **Master** repository ruleset protects the default branch. The rulesets API 
 - Block force pushes, branch deletion, and direct pushes. Update the branch only through a pull request.
 - Require one approval and a code-owner review. Dismiss stale reviews and resolve conversations. Permit only squash
   merges.
-- Require **Status**, **Title**, **Commits**, and **Maintainer approval**. Require them to be current with the base branch.
+- Require **Status**, **Title**, **Commits**, **Dependencies**, and **Maintainer approval**. Require them to be current
+  with the base branch. After this change lands, remove the duplicate **Dependencies** requirement because `Status`
+  owns that result.
 - Block Qodana (`QDJVM`) alerts that have medium or higher security severity, or error severity. A pure release PR uses
   the release attestation after the gate verifies that no source files changed.
 - Permit maintainers to bypass the rules in an emergency.
@@ -484,7 +486,7 @@ Pull requests show many checks. Only the checks in the **Master** ruleset block 
 | **Status** | **Required** | Evaluates lint, build, Aggregate coverage, Dokka, Vanilla, and Dependencies against the event and path policy |
 | **Title** | **Required** | Conventional PR title (from `pr.yml`) |
 | **Commits** | **Required** | Conventional commit subjects (from `pr.yml`) |
-| **Dependencies** | No | Evaluated by `Status` for code pull requests; not applicable to other events |
+| **Dependencies** | **Required** | Dependency review for pull requests. The job reports successful not-applicable status on other events. Remove this separate requirement after the post-landing ruleset update. |
 | Lint / Build | No | Under the Status aggregator |
 | PR feedback | No | Metrics comment only. Not part of Status |
 | Vanilla conformance | No | Under the Status aggregator. Uses a path filter |

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -45,13 +45,13 @@ CI
 │   └─ (Vanilla/Dokka already completed in Tier 1)
 │
 ├─ Policy (independent of tiers) ──────────────────────────────────
-│   ├─ Dependencies      (dependency-review-action on PRs; explicit success otherwise)
+│   ├─ Dependencies      (dependency-review-action, PRs only)
 │   ├─ Commits           (push-to-master subject validation)
 │   ├─ Release provenance (default-branch metadata check)
 │   └─ Release attestation (trusted release-please PRs)
 │
 └─ Status (required merge-gate check) ─────────────────────────────
-    └─ Evaluates Triage, lint, Build, Aggregate, Dokka, Vanilla, and Dependencies
+    └─ Aggregates Tier 1 + Vanilla + Dependencies when applicable
 
 Qodana security pipeline (parallel with CI)
 ├─ Qodana            (pull_request_target, read-only PR-head analysis or trusted attestation artefact)
@@ -83,13 +83,12 @@ message.
 | Code pull request without Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Dependencies | Vanilla |
 | Code pull request with Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla, Dependencies | None |
 | Push without code paths | `Triage` | All other owned jobs |
-| Push with code and without Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Dependencies | Vanilla |
-| Push with code and Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla, Dependencies | None |
-| Merge group, schedule, or manual run | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla, Dependencies | None |
+| Push with code and without Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka | Vanilla, Dependencies |
+| Push with code and Vanilla paths | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla | Dependencies |
+| Merge group, schedule, or manual run | `Triage`, both lint jobs, Build, Aggregate, Dokka, Vanilla | Dependencies |
 
-The `Dependencies` job runs on every supported event. It performs dependency review only for pull requests. On other
-events, it reports success because GitHub does not provide a pull-request dependency diff. This policy does not add
-another dependency scanner.
+The `Dependencies` job runs only for pull requests. GitHub skips it on other events because dependency review requires
+a pull-request diff. `Status` permits that job to be skipped outside pull requests.
 
 Each Build shard executes its tests under Kover and uploads a `kover-handoff-<shard>` artefact with the binary `.ic`
 reports and the compiled classes. `Aggregate` restores that data and generates the XML/HTML reports and the `koverVerify`
@@ -282,8 +281,8 @@ and dependent module compilation.
 
 The CI configuration supports a merge queue. Both `ci.yml` and `pr.yml` listen for `merge_group`. Queue batches do not
 use the path filter. They start the full pipeline, which includes Vanilla conformance. The Title and Commits jobs report
-successful placeholders to keep their required checks present. The Dependencies job reports successful not-applicable
-status on merge groups. `Status` requires that result.
+successful placeholders to keep their required checks present. The Dependencies job is skipped because dependency review
+requires a pull-request diff. `Status` accepts that skipped result for merge groups.
 
 When the account supports the feature, enable the queue in the **Master** ruleset or in branch protection. Configure
 `merge_queue` and squash merges. Until then, use the usual pull-request squash merge.
@@ -446,8 +445,7 @@ The **Master** repository ruleset protects the default branch. The rulesets API 
 - Require one approval and a code-owner review. Dismiss stale reviews and resolve conversations. Permit only squash
   merges.
 - Require **Status**, **Title**, **Commits**, **Dependencies**, and **Maintainer approval**. Require them to be current
-  with the base branch. After this change lands, remove the duplicate **Dependencies** requirement because `Status`
-  owns that result.
+  with the base branch.
 - Block Qodana (`QDJVM`) alerts that have medium or higher security severity, or error severity. A pure release PR uses
   the release attestation after the gate verifies that no source files changed.
 - Permit maintainers to bypass the rules in an emergency.
@@ -486,7 +484,7 @@ Pull requests show many checks. Only the checks in the **Master** ruleset block 
 | **Status** | **Required** | Evaluates lint, build, Aggregate coverage, Dokka, Vanilla, and Dependencies against the event and path policy |
 | **Title** | **Required** | Conventional PR title (from `pr.yml`) |
 | **Commits** | **Required** | Conventional commit subjects (from `pr.yml`) |
-| **Dependencies** | **Required** | Dependency review for pull requests. The job reports successful not-applicable status on other events. Remove this separate requirement after the post-landing ruleset update. |
+| **Dependencies** | **Required** | Dependency review for pull requests. The job is skipped on other events. |
 | Lint / Build | No | Under the Status aggregator |
 | PR feedback | No | Metrics comment only. Not part of Status |
 | Vanilla conformance | No | Under the Status aggregator. Uses a path filter |


### PR DESCRIPTION
## Summary

Make the required `Status` check evaluate one explicit event/path policy. The workflow now checks every owned result before it passes. Missing, unknown, failed, and cancelled results fail closed. Update CI documentation and the failure guide to describe the policy.

## Related Issues

Closes #373

## Stack

This PR targets `test/issue-373/status-policy` and must be reviewed and merged above PR #563.

## Verification

- `npm run typecheck`
- `npm run build`
- `node --test scripts/ci-status.test.js scripts/pr-metrics-publisher.test.js scripts/qodana-*.test.js scripts/workflow-run-check.test.js actions/pr-metrics-comment/test/*.test.js`
- 362 tests passed
- `actionlint .github/workflows/ci.yml`
- Generated JavaScript remains ignored and untracked

The repository ruleset remains unchanged.