### PR TITLE
fix(ci): add trusted workflow check lifecycle

### DIFF
--- a/.github/scripts/shared/action-context.ts
+++ b/.github/scripts/shared/action-context.ts
@@ -20,3 +20,4 @@ export type WorkflowRunListItem = Awaited<ReturnType<Octokit['rest']['actions'][
 export type JobItem = Awaited<ReturnType<Octokit['rest']['actions']['listJobsForWorkflowRun']>>['data']['jobs'][number];
 export type WorkflowRunArtifact = Awaited<ReturnType<Octokit['rest']['actions']['listWorkflowRunArtifacts']>>['data']['artifacts'][number];
 export type CheckRunData = Awaited<ReturnType<Octokit['rest']['checks']['create']>>['data'];
+export type CheckRunListItem = Awaited<ReturnType<Octokit['rest']['checks']['listForRef']>>['data']['check_runs'][number];

--- a/.github/scripts/test-support/mocks.ts
+++ b/.github/scripts/test-support/mocks.ts
@@ -15,6 +15,7 @@ const TOOLING_ENDPOINTS = [
   'actions.listWorkflowRuns',
   'checks.create',
   'checks.get',
+  'checks.listForRef',
   'checks.update',
   'issues.createComment',
   'issues.listComments',

--- a/.github/scripts/test-support/mocks.ts
+++ b/.github/scripts/test-support/mocks.ts
@@ -28,7 +28,7 @@ const TOOLING_ENDPOINTS = [
 
 export interface TestGithubMock {
   rest: { [area: string]: { [method: string]: unknown } };
-  paginate?: (method: (...args: never[]) => unknown, ...parameters: never[]) => Promise<unknown>;
+  paginate?: (method: (...args: never[]) => object, ...parameters: never[]) => Promise<object[]>;
 }
 
 function mockEndpointValue(mock: TestGithubMock, endpoint: string): unknown {

--- a/.github/scripts/workflow-run-check.test.ts
+++ b/.github/scripts/workflow-run-check.test.ts
@@ -4,10 +4,12 @@ import {
   buildCheckExternalId,
   completeWorkflowCheck,
   createWorkflowCheck,
+  ensureWorkflowCheck,
+  findWorkflowCheck,
   workflowResultConclusion,
 } from './workflow-run-check.js';
 import type { WorkflowRunCheckContext } from './workflow-run-check.js';
-import { mockOctokit } from './test-support/mocks.js';
+import { asApiData, mockOctokit } from './test-support/mocks.js';
 
 const HEAD_SHA = 'a'.repeat(40);
 const CONTEXT: WorkflowRunCheckContext = {
@@ -37,6 +39,8 @@ interface CreatedCheckRecord {
   name: string;
   head_sha: string;
   external_id: string;
+  status?: string;
+  conclusion?: string | null;
   app: { slug: string };
 }
 
@@ -51,6 +55,8 @@ function makeGithub(): {
     name: 'Qodana / trusted ref',
     head_sha: HEAD_SHA,
     external_id: 'workflow-run-check:qodana-trusted:123:2:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    status: 'in_progress',
+    conclusion: null,
     app: { slug: 'github-actions' },
   };
   return {
@@ -71,6 +77,7 @@ function makeGithub(): {
             calls.push(['update', parameters]);
             return { data: { ...check, ...parameters } };
           },
+          listForRef: async () => ({ data: { check_runs: [] } }),
         },
       },
     }),
@@ -99,6 +106,8 @@ test('creates an in-progress check against the validated source SHA', async () =
     externalId,
     headSha: HEAD_SHA,
     name: fixture.check.name,
+    status: 'in_progress',
+    conclusion: null,
   });
   const first = fixture.calls[0];
   assert.ok(first);
@@ -242,6 +251,79 @@ test('rejects a check that is not bound to the expected source', async () => {
     /check head SHA does not match/,
   );
   assert.equal(fixture.calls.length, 1);
+});
+
+test('reuses the one existing check for an external id', async () => {
+  const fixture = makeGithub();
+  const externalId = fixture.check.external_id;
+  Object.assign(fixture.github.rest.checks, {
+    listForRef: async () => asApiData<Awaited<ReturnType<typeof fixture.github.rest.checks.listForRef>>>({
+      data: {
+        total_count: 1,
+        check_runs: [{
+          ...fixture.check,
+          status: 'queued',
+          conclusion: null,
+        }],
+      },
+    }),
+  });
+
+  const result = await ensureWorkflowCheck({
+    github: fixture.github,
+    context: CONTEXT,
+    name: fixture.check.name,
+    headSha: HEAD_SHA,
+    externalId,
+    summary: 'Waiting for the trusted publisher.',
+  });
+
+  assert.equal(result.id, fixture.check.id);
+  assert.equal(result.status, 'queued');
+  assert.equal(fixture.calls.length, 0);
+});
+
+test('rejects duplicate existing checks for an external id', async () => {
+  const fixture = makeGithub();
+  Object.assign(fixture.github.rest.checks, {
+    listForRef: async () => asApiData<Awaited<ReturnType<typeof fixture.github.rest.checks.listForRef>>>({
+      data: {
+        total_count: 2,
+        check_runs: [fixture.check, { ...fixture.check, id: fixture.check.id + 1 }],
+      },
+    }),
+  });
+
+  await assert.rejects(
+    () => findWorkflowCheck({
+      github: fixture.github,
+      context: CONTEXT,
+      name: fixture.check.name,
+      headSha: HEAD_SHA,
+      externalId: fixture.check.external_id,
+    }),
+    /duplicate workflow check external id/,
+  );
+});
+
+test('completing an already completed check with the same conclusion is idempotent', async () => {
+  const fixture = makeGithub();
+  fixture.check.status = 'completed';
+  fixture.check.conclusion = 'success';
+
+  await completeWorkflowCheck({
+    github: fixture.github,
+    context: CONTEXT,
+    checkId: fixture.check.id,
+    name: fixture.check.name,
+    headSha: HEAD_SHA,
+    externalId: fixture.check.external_id,
+    conclusion: 'success',
+    summary: 'The trusted publication succeeded.',
+  });
+
+  assert.equal(fixture.calls.length, 1);
+  assert.equal(fixture.calls[0]?.[0], 'get');
 });
 
 test('maps workflow results to supported check conclusions', () => {

--- a/.github/scripts/workflow-run-check.test.ts
+++ b/.github/scripts/workflow-run-check.test.ts
@@ -6,10 +6,11 @@ import {
   createWorkflowCheck,
   ensureWorkflowCheck,
   findWorkflowCheck,
+  updateWorkflowCheck,
   workflowResultConclusion,
 } from './workflow-run-check.js';
-import type { WorkflowRunCheckContext } from './workflow-run-check.js';
-import { asApiData, mockOctokit } from './test-support/mocks.js';
+import type { WorkflowCheckAnnotation, WorkflowRunCheckContext } from './workflow-run-check.js';
+import { mockOctokit } from './test-support/mocks.js';
 
 const HEAD_SHA = 'a'.repeat(40);
 const CONTEXT: WorkflowRunCheckContext = {
@@ -31,7 +32,7 @@ interface CheckParameters {
   details_url?: string;
   started_at?: string;
   completed_at?: string;
-  output?: { title: string; summary: string };
+  output?: { title: string; summary: string; annotations?: WorkflowCheckAnnotation[] };
 }
 
 interface CreatedCheckRecord {
@@ -44,12 +45,25 @@ interface CreatedCheckRecord {
   app: { slug: string };
 }
 
+function makeAnnotations(count: number): WorkflowCheckAnnotation[] {
+  return Array.from({ length: count }, (_, index) => ({
+    path: `.github/scripts/file-${index}.ts`,
+    start_line: index + 1,
+    end_line: index + 1,
+    annotation_level: 'notice' as const,
+    title: `Annotation ${index}`,
+    message: `Annotation message ${index}`,
+  }));
+}
+
 function makeGithub(): {
   calls: Array<[string, CheckParameters]>;
   check: CreatedCheckRecord;
+  setPaginatedChecks(checks: object[]): void;
   github: ReturnType<typeof mockOctokit>;
 } {
   const calls: Array<[string, CheckParameters]> = [];
+  let paginatedChecks: object[] = [];
   const check: CreatedCheckRecord = {
     id: 700,
     name: 'Qodana / trusted ref',
@@ -59,9 +73,20 @@ function makeGithub(): {
     conclusion: null,
     app: { slug: 'github-actions' },
   };
+  const paginate = async (
+    _method: (...args: never[]) => object,
+    _parameters: never,
+    map: (response: { data: object[] & { total_count: number } }, done: () => void) => object[],
+  ): Promise<object[]> => {
+    const data = Object.assign([...paginatedChecks], { total_count: paginatedChecks.length });
+    return map({ data }, () => {});
+  };
   return {
     calls,
     check,
+    setPaginatedChecks(checks: object[]): void {
+      paginatedChecks = checks;
+    },
     github: mockOctokit({
       rest: {
         checks: {
@@ -80,6 +105,7 @@ function makeGithub(): {
           listForRef: async () => ({ data: { check_runs: [] } }),
         },
       },
+      paginate,
     }),
   };
 }
@@ -256,18 +282,11 @@ test('rejects a check that is not bound to the expected source', async () => {
 test('reuses the one existing check for an external id', async () => {
   const fixture = makeGithub();
   const externalId = fixture.check.external_id;
-  Object.assign(fixture.github.rest.checks, {
-    listForRef: async () => asApiData<Awaited<ReturnType<typeof fixture.github.rest.checks.listForRef>>>({
-      data: {
-        total_count: 1,
-        check_runs: [{
-          ...fixture.check,
-          status: 'queued',
-          conclusion: null,
-        }],
-      },
-    }),
-  });
+  fixture.setPaginatedChecks([{
+    ...fixture.check,
+    status: 'queued',
+    conclusion: null,
+  }]);
 
   const result = await ensureWorkflowCheck({
     github: fixture.github,
@@ -285,14 +304,7 @@ test('reuses the one existing check for an external id', async () => {
 
 test('rejects duplicate existing checks for an external id', async () => {
   const fixture = makeGithub();
-  Object.assign(fixture.github.rest.checks, {
-    listForRef: async () => asApiData<Awaited<ReturnType<typeof fixture.github.rest.checks.listForRef>>>({
-      data: {
-        total_count: 2,
-        check_runs: [fixture.check, { ...fixture.check, id: fixture.check.id + 1 }],
-      },
-    }),
-  });
+  fixture.setPaginatedChecks([fixture.check, { ...fixture.check, id: fixture.check.id + 1 }]);
 
   await assert.rejects(
     () => findWorkflowCheck({
@@ -304,6 +316,29 @@ test('rejects duplicate existing checks for an external id', async () => {
     }),
     /duplicate workflow check external id/,
   );
+});
+
+test('finds a matching check returned after the first page', async () => {
+  const fixture = makeGithub();
+  const externalId = fixture.check.external_id;
+  fixture.setPaginatedChecks([
+    ...Array.from({ length: 100 }, (_, index) => ({
+      ...fixture.check,
+      id: fixture.check.id + index + 1,
+      external_id: `workflow-run-check:other:${index}`,
+    })),
+    fixture.check,
+  ]);
+
+  const result = await findWorkflowCheck({
+    github: fixture.github,
+    context: CONTEXT,
+    name: fixture.check.name,
+    headSha: HEAD_SHA,
+    externalId,
+  });
+
+  assert.equal(result?.id, fixture.check.id);
 });
 
 test('completing an already completed check with the same conclusion is idempotent', async () => {
@@ -324,6 +359,98 @@ test('completing an already completed check with the same conclusion is idempote
 
   assert.equal(fixture.calls.length, 1);
   assert.equal(fixture.calls[0]?.[0], 'get');
+});
+
+test('sends at most 50 annotations per in-progress update', async () => {
+  const fixture = makeGithub();
+
+  await updateWorkflowCheck({
+    github: fixture.github,
+    context: CONTEXT,
+    checkId: fixture.check.id,
+    name: fixture.check.name,
+    headSha: HEAD_SHA,
+    externalId: fixture.check.external_id,
+    status: 'in_progress',
+    summary: 'The trusted publisher is validating the report.',
+    annotations: makeAnnotations(51),
+  });
+
+  const updates = fixture.calls.filter(([operation]) => operation === 'update').map(([, parameters]) => parameters);
+  assert.deepEqual(updates.map((parameters) => parameters.output?.annotations?.length), [50, 1]);
+  assert.deepEqual(updates.map((parameters) => parameters.status), ['in_progress', 'in_progress']);
+});
+
+test('completes only the final annotation batch', async () => {
+  const fixture = makeGithub();
+
+  await completeWorkflowCheck({
+    github: fixture.github,
+    context: CONTEXT,
+    checkId: fixture.check.id,
+    name: fixture.check.name,
+    headSha: HEAD_SHA,
+    externalId: fixture.check.external_id,
+    conclusion: 'success',
+    summary: 'The trusted publication succeeded.',
+    annotations: makeAnnotations(51),
+  });
+
+  const updates = fixture.calls.filter(([operation]) => operation === 'update').map(([, parameters]) => parameters);
+  assert.deepEqual(updates.map((parameters) => parameters.output?.annotations?.length), [50, 1]);
+  assert.deepEqual(updates.map((parameters) => parameters.status), ['in_progress', 'completed']);
+  assert.equal(updates[0]?.conclusion, undefined);
+  assert.equal(updates[1]?.conclusion, 'success');
+});
+
+test('does not split exactly 50 annotations', async () => {
+  const fixture = makeGithub();
+
+  await completeWorkflowCheck({
+    github: fixture.github,
+    context: CONTEXT,
+    checkId: fixture.check.id,
+    name: fixture.check.name,
+    headSha: HEAD_SHA,
+    externalId: fixture.check.external_id,
+    conclusion: 'failure',
+    summary: 'The trusted publication failed.',
+    annotations: makeAnnotations(50),
+  });
+
+  const updates = fixture.calls.filter(([operation]) => operation === 'update').map(([, parameters]) => parameters);
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0]?.output?.annotations?.length, 50);
+  assert.equal(updates[0]?.status, 'completed');
+});
+
+test('stops annotation completion when an earlier batch fails', async () => {
+  const fixture = makeGithub();
+  Object.assign(fixture.github.rest.checks, {
+    update: async (parameters: CheckParameters) => {
+      fixture.calls.push(['update', parameters]);
+      throw new Error('annotation update failed');
+    },
+  });
+
+  await assert.rejects(
+    () => completeWorkflowCheck({
+      github: fixture.github,
+      context: CONTEXT,
+      checkId: fixture.check.id,
+      name: fixture.check.name,
+      headSha: HEAD_SHA,
+      externalId: fixture.check.external_id,
+      conclusion: 'success',
+      summary: 'The trusted publication succeeded.',
+      annotations: makeAnnotations(51),
+    }),
+    /annotation update failed/,
+  );
+
+  const updates = fixture.calls.filter(([operation]) => operation === 'update').map(([, parameters]) => parameters);
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0]?.status, 'in_progress');
 });
 
 test('maps workflow results to supported check conclusions', () => {

--- a/.github/scripts/workflow-run-check.ts
+++ b/.github/scripts/workflow-run-check.ts
@@ -1,4 +1,4 @@
-import type { Octokit, CheckRunData } from './shared/action-context.js';
+import type { CheckRunData, CheckRunListItem, Octokit } from './shared/action-context.js';
 import { createValidators } from './shared/validation.js';
 
 const KIND_PATTERN = /^[a-z0-9-]{1,48}$/;
@@ -12,6 +12,8 @@ const WORKFLOW_RESULTS = new Set([
   'timed_out',
 ]);
 type WorkflowResult = 'success' | 'failure' | 'cancelled' | 'skipped' | 'timed_out';
+const WORKFLOW_CHECK_STATUSES = new Set(['queued', 'in_progress']);
+type WorkflowCheckStatus = 'queued' | 'in_progress';
 
 const {
   requireBoundedInteger,
@@ -40,23 +42,26 @@ function workflowRunUrl(context: WorkflowRunCheckContext): string {
 
 export interface BuildCheckExternalIdOptions {
   kind: string;
+  workflowId?: number;
   runId: number;
   runAttempt: number;
   headSha: string;
 }
 
-function buildCheckExternalId({ kind, runId, runAttempt, headSha }: BuildCheckExternalIdOptions): string {
+function buildCheckExternalId({ kind, workflowId, runId, runAttempt, headSha }: BuildCheckExternalIdOptions): string {
   if (typeof kind !== 'string' || !KIND_PATTERN.test(kind)) throw new Error('check kind is invalid');
-  return `${EXTERNAL_ID_PREFIX}:${kind}:${requireBoundedInteger(Number(runId), 'workflow run id')}:${requireBoundedInteger(Number(runAttempt), 'workflow run attempt')}:${requireSha(headSha, 'check head SHA')}`;
+  const workflowPart = workflowId == null ? '' : `:workflow-${requireBoundedInteger(Number(workflowId), 'workflow id')}`;
+  return `${EXTERNAL_ID_PREFIX}:${kind}${workflowPart}:${requireBoundedInteger(Number(runId), 'workflow run id')}:${requireBoundedInteger(Number(runAttempt), 'workflow run attempt')}:${requireSha(headSha, 'check head SHA')}`;
 }
 
 interface CreatedCheckExpectation {
   name: string;
   headSha: string;
   externalId: string;
+  status: WorkflowCheckStatus;
 }
 
-function validateCreatedCheck(check: CheckRunData | undefined, expected: CreatedCheckExpectation): CheckRunData {
+function validateCheck(check: CheckRunData | CheckRunListItem | undefined, expected: Omit<CreatedCheckExpectation, 'status'>): CheckRunData | CheckRunListItem {
   const trustedCheck = requireObject<CheckRunData>(check, 'created check');
   requireBoundedInteger(trustedCheck.id, 'created check id');
   requireEqual(trustedCheck.name, expected.name, 'created check name');
@@ -66,6 +71,86 @@ function validateCreatedCheck(check: CheckRunData | undefined, expected: Created
   return trustedCheck;
 }
 
+function validateCreatedCheck(check: CheckRunData | undefined, expected: CreatedCheckExpectation): CheckRunData {
+  const trustedCheck = validateCheck(check, expected);
+  requireEqual(trustedCheck.status, expected.status, 'created check status');
+  return trustedCheck;
+}
+
+export interface WorkflowCheckReference {
+  id: number;
+  externalId: string;
+  headSha: string;
+  name: string;
+  status: string;
+  conclusion: string | null;
+}
+
+export interface WorkflowCheckAnnotation {
+  path: string;
+  start_line: number;
+  end_line: number;
+  annotation_level: 'notice' | 'warning' | 'failure';
+  title: string;
+  message: string;
+}
+
+function checkReference(check: CheckRunData | CheckRunListItem): WorkflowCheckReference {
+  return {
+    id: requireBoundedInteger(check.id, 'check id'),
+    externalId: requireText(check.external_id, 'check external id', 256),
+    headSha: requireSha(check.head_sha, 'check head SHA'),
+    name: requireText(check.name, 'check name', 100),
+    status: requireText(check.status, 'check status', 32),
+    conclusion: check.conclusion ?? null,
+  };
+}
+
+function validateWorkflowCheckStatus(status: string): WorkflowCheckStatus {
+  if (!WORKFLOW_CHECK_STATUSES.has(status)) throw new Error('check status is invalid');
+  return status as WorkflowCheckStatus;
+}
+
+async function findWorkflowCheck({
+  github,
+  context,
+  headSha,
+  name,
+  externalId,
+}: {
+  github: Octokit;
+  context: WorkflowRunCheckContext;
+  headSha: string;
+  name: string;
+  externalId: string;
+}): Promise<WorkflowCheckReference | null> {
+  const owner = requireText(context?.repo?.owner, 'repository owner', 100);
+  const repo = requireText(context?.repo?.repo, 'repository name', 100);
+  const trustedHeadSha = requireSha(headSha, 'check head SHA');
+  const trustedName = requireText(name, 'check name', 100);
+  const trustedExternalId = requireText(externalId, 'check external id', 256);
+  const response = await github.rest.checks.listForRef({
+    owner,
+    repo,
+    ref: trustedHeadSha,
+    check_name: trustedName,
+    filter: 'all',
+    per_page: 100,
+  });
+  if (response.data.total_count > response.data.check_runs.length) throw new Error('workflow check list exceeds the validation bound');
+  const matches = response.data.check_runs.filter((check) => check.external_id === trustedExternalId);
+  if (matches.length > 1) throw new Error('duplicate workflow check external id');
+  const match = matches[0];
+  if (match == null) return null;
+  const trustedCheck = validateCheck(match, {
+    name: trustedName,
+    headSha: trustedHeadSha,
+    externalId: trustedExternalId,
+  });
+  requireEqual(trustedCheck.app?.slug, CHECK_APP_SLUG, 'workflow check application');
+  return checkReference(trustedCheck);
+}
+
 async function createWorkflowCheck({
   github,
   context,
@@ -73,6 +158,7 @@ async function createWorkflowCheck({
   headSha,
   externalId,
   summary,
+  status = 'in_progress',
 }: {
   github: Octokit;
   context: WorkflowRunCheckContext;
@@ -80,19 +166,21 @@ async function createWorkflowCheck({
   headSha: string;
   externalId: string;
   summary: string;
-}): Promise<{ id: number; externalId: string; headSha: string; name: string }> {
+  status?: WorkflowCheckStatus;
+}): Promise<WorkflowCheckReference> {
   const owner = requireText(context?.repo?.owner, 'repository owner', 100);
   const repo = requireText(context?.repo?.repo, 'repository name', 100);
   const trustedName = requireText(name, 'check name', 100);
   const trustedHeadSha = requireSha(headSha, 'check head SHA');
   const trustedExternalId = requireText(externalId, 'check external id', 256);
   const trustedSummary = requireText(summary, 'check summary', 65_535);
+  const trustedStatus = validateWorkflowCheckStatus(status);
   const response = await github.rest.checks.create({
     owner,
     repo,
     name: trustedName,
     head_sha: trustedHeadSha,
-    status: 'in_progress',
+    status: trustedStatus,
     external_id: trustedExternalId,
     details_url: workflowRunUrl(context),
     started_at: new Date().toISOString(),
@@ -105,13 +193,100 @@ async function createWorkflowCheck({
     name: trustedName,
     headSha: trustedHeadSha,
     externalId: trustedExternalId,
+    status: trustedStatus,
   });
-  return {
-    id: check.id,
-    externalId: trustedExternalId,
-    headSha: trustedHeadSha,
+  return checkReference(check);
+}
+
+async function ensureWorkflowCheck({
+  github,
+  context,
+  name,
+  headSha,
+  externalId,
+  summary,
+  status = 'queued',
+}: {
+  github: Octokit;
+  context: WorkflowRunCheckContext;
+  name: string;
+  headSha: string;
+  externalId: string;
+  summary: string;
+  status?: WorkflowCheckStatus;
+}): Promise<WorkflowCheckReference> {
+  const existing = await findWorkflowCheck({
+    github,
+    context,
+    headSha,
+    name,
+    externalId,
+  });
+  if (existing) return existing;
+  return createWorkflowCheck({
+    github,
+    context,
+    name,
+    headSha,
+    externalId,
+    summary,
+    status,
+  });
+}
+
+async function updateWorkflowCheck({
+  github,
+  context,
+  checkId,
+  name,
+  headSha,
+  externalId,
+  status,
+  summary,
+  annotations,
+}: {
+  github: Octokit;
+  context: WorkflowRunCheckContext;
+  checkId: number;
+  name: string;
+  headSha: string;
+  externalId: string;
+  status: WorkflowCheckStatus;
+  summary: string;
+  annotations?: WorkflowCheckAnnotation[];
+}): Promise<void> {
+  const owner = requireText(context?.repo?.owner, 'repository owner', 100);
+  const repo = requireText(context?.repo?.repo, 'repository name', 100);
+  const trustedCheckId = requireBoundedInteger(checkId, 'check id');
+  const trustedName = requireText(name, 'check name', 100);
+  const trustedHeadSha = requireSha(headSha, 'check head SHA');
+  const trustedExternalId = requireText(externalId, 'check external id', 256);
+  const trustedStatus = validateWorkflowCheckStatus(status);
+  const trustedSummary = requireText(summary, 'check summary', 65_535);
+  const response = await github.rest.checks.get({
+    owner,
+    repo,
+    check_run_id: trustedCheckId,
+  });
+  const check = validateCheck(response?.data, {
     name: trustedName,
-  };
+    headSha: trustedHeadSha,
+    externalId: trustedExternalId,
+  });
+  requireEqual(check.app?.slug, CHECK_APP_SLUG, 'check application');
+  if (check.status === 'completed') return;
+  await github.rest.checks.update({
+    owner,
+    repo,
+    check_run_id: trustedCheckId,
+    status: trustedStatus,
+    details_url: workflowRunUrl(context),
+    output: {
+      title: trustedName,
+      summary: trustedSummary,
+      ...(annotations == null ? {} : { annotations }),
+    },
+  });
 }
 
 function workflowResultConclusion(result: string): WorkflowResult {
@@ -128,6 +303,7 @@ async function completeWorkflowCheck({
   externalId,
   conclusion,
   summary,
+  annotations,
 }: {
   github: Octokit;
   context: WorkflowRunCheckContext;
@@ -137,6 +313,7 @@ async function completeWorkflowCheck({
   externalId: string;
   conclusion: string;
   summary: string;
+  annotations?: WorkflowCheckAnnotation[];
 }): Promise<void> {
   const owner = requireText(context?.repo?.owner, 'repository owner', 100);
   const repo = requireText(context?.repo?.repo, 'repository name', 100);
@@ -158,6 +335,11 @@ async function completeWorkflowCheck({
   requireEqual(check.external_id, trustedExternalId, 'check external id');
   requireEqual(check.app?.slug, CHECK_APP_SLUG, 'check application');
 
+  if (check.status === 'completed') {
+    requireEqual(check.conclusion, trustedConclusion, 'check conclusion');
+    return;
+  }
+
   await github.rest.checks.update({
     owner,
     repo,
@@ -169,6 +351,7 @@ async function completeWorkflowCheck({
     output: {
       title: trustedName,
       summary: trustedSummary,
+      ...(annotations == null ? {} : { annotations }),
     },
   });
 }
@@ -177,5 +360,8 @@ export {
   buildCheckExternalId,
   completeWorkflowCheck,
   createWorkflowCheck,
+  ensureWorkflowCheck,
+  findWorkflowCheck,
+  updateWorkflowCheck,
   workflowResultConclusion,
 };

--- a/.github/scripts/workflow-run-check.ts
+++ b/.github/scripts/workflow-run-check.ts
@@ -14,6 +14,8 @@ const WORKFLOW_RESULTS = new Set([
 type WorkflowResult = 'success' | 'failure' | 'cancelled' | 'skipped' | 'timed_out';
 const WORKFLOW_CHECK_STATUSES = new Set(['queued', 'in_progress']);
 type WorkflowCheckStatus = 'queued' | 'in_progress';
+const MAX_CHECK_RUNS = 1_000;
+const MAX_CHECK_ANNOTATIONS = 50;
 
 const {
   requireBoundedInteger,
@@ -129,16 +131,22 @@ async function findWorkflowCheck({
   const trustedHeadSha = requireSha(headSha, 'check head SHA');
   const trustedName = requireText(name, 'check name', 100);
   const trustedExternalId = requireText(externalId, 'check external id', 256);
-  const response = await github.rest.checks.listForRef({
-    owner,
-    repo,
-    ref: trustedHeadSha,
-    check_name: trustedName,
-    filter: 'all',
-    per_page: 100,
-  });
-  if (response.data.total_count > response.data.check_runs.length) throw new Error('workflow check list exceeds the validation bound');
-  const matches = response.data.check_runs.filter((check) => check.external_id === trustedExternalId);
+  const checkRuns = await github.paginate(
+    github.rest.checks.listForRef,
+    {
+      owner,
+      repo,
+      ref: trustedHeadSha,
+      check_name: trustedName,
+      filter: 'all',
+      per_page: 100,
+    },
+    (response) => {
+      if (response.data.total_count > MAX_CHECK_RUNS) throw new Error('workflow check list exceeds the validation bound');
+      return response.data;
+    },
+  );
+  const matches = checkRuns.filter((check) => check.external_id === trustedExternalId);
   if (matches.length > 1) throw new Error('duplicate workflow check external id');
   const match = matches[0];
   if (match == null) return null;
@@ -215,6 +223,8 @@ async function ensureWorkflowCheck({
   summary: string;
   status?: WorkflowCheckStatus;
 }): Promise<WorkflowCheckReference> {
+  // GitHub has no conditional Check Run creation. The owning workflow must
+  // serialise calls for one external ID before using this find-or-create path.
   const existing = await findWorkflowCheck({
     github,
     context,
@@ -275,18 +285,20 @@ async function updateWorkflowCheck({
   });
   requireEqual(check.app?.slug, CHECK_APP_SLUG, 'check application');
   if (check.status === 'completed') return;
-  await github.rest.checks.update({
-    owner,
-    repo,
-    check_run_id: trustedCheckId,
-    status: trustedStatus,
-    details_url: workflowRunUrl(context),
-    output: {
-      title: trustedName,
-      summary: trustedSummary,
-      ...(annotations == null ? {} : { annotations }),
-    },
-  });
+  for (const annotationBatch of annotationBatches(annotations)) {
+    await github.rest.checks.update({
+      owner,
+      repo,
+      check_run_id: trustedCheckId,
+      status: trustedStatus,
+      details_url: workflowRunUrl(context),
+      output: {
+        title: trustedName,
+        summary: trustedSummary,
+        ...(annotationBatch == null ? {} : { annotations: annotationBatch }),
+      },
+    });
+  }
 }
 
 function workflowResultConclusion(result: string): WorkflowResult {
@@ -340,20 +352,39 @@ async function completeWorkflowCheck({
     return;
   }
 
-  await github.rest.checks.update({
-    owner,
-    repo,
-    check_run_id: trustedCheckId,
-    status: 'completed',
-    conclusion: trustedConclusion,
-    completed_at: new Date().toISOString(),
-    details_url: workflowRunUrl(context),
-    output: {
-      title: trustedName,
-      summary: trustedSummary,
-      ...(annotations == null ? {} : { annotations }),
-    },
-  });
+  const annotationBatchesForCompletion = annotationBatches(annotations);
+  for (const [index, annotationBatch] of annotationBatchesForCompletion.entries()) {
+    const finalBatch = index === annotationBatchesForCompletion.length - 1;
+    await github.rest.checks.update({
+      owner,
+      repo,
+      check_run_id: trustedCheckId,
+      ...(finalBatch
+        ? {
+          status: 'completed' as const,
+          conclusion: trustedConclusion,
+          completed_at: new Date().toISOString(),
+        }
+        : { status: 'in_progress' as const }),
+      details_url: workflowRunUrl(context),
+      output: {
+        title: trustedName,
+        summary: trustedSummary,
+        ...(annotationBatch == null ? {} : { annotations: annotationBatch }),
+      },
+    });
+  }
+}
+
+function annotationBatches(
+  annotations: WorkflowCheckAnnotation[] | undefined,
+): Array<WorkflowCheckAnnotation[] | undefined> {
+  if (annotations == null || annotations.length <= MAX_CHECK_ANNOTATIONS) return [annotations];
+  const batches: WorkflowCheckAnnotation[][] = [];
+  for (let index = 0; index < annotations.length; index += MAX_CHECK_ANNOTATIONS) {
+    batches.push(annotations.slice(index, index + MAX_CHECK_ANNOTATIONS));
+  }
+  return batches;
 }
 
 export {


### PR DESCRIPTION
## Purpose

Add the shared helper that trusted publishers use to create and update one visible GitHub Check Run safely. A Check Run is the result shown in the pull request Checks tab.

This PR provides the lifecycle foundation. It does not publish JUnit or CodeQL results yet.

## What changes

| Capability | Behaviour |
| --- | --- |
| Start a check | Create it as `queued` or `in_progress` and bind it to one commit. |
| Find a check | Search by exact name, external ID, and commit SHA. |
| Prevent duplicates | Reject more than one matching check. |
| Verify ownership | Accept only checks created by the GitHub Actions app. |
| Finish safely | Complete a check once, or accept the same completion again without another update. |

The external ID records the workflow, run, attempt, and commit. This prevents one workflow run from updating a check belonging to another run.

## What does not change

- No workflow permissions change.
- No JUnit or CodeQL publication is added in this PR.
- Existing Qodana and metrics publication remains unchanged.

## Review focus

Read `.github/scripts/workflow-run-check.ts` and its tests. The important contract is that every create, update, and completion validates the check identity before writing.

## Verification

The full local CI tooling test suite passes.

## Related issue

Part of #399

## Stack

```text
master
  |
  +-- #567  Check Run lifecycle  (this PR)
       |
       +-- #568  JUnit and CodeQL publication
            |
            +-- #569  Trust-policy guard
                 |
                 +-- #570  CI documentation
```

Merge this PR before #568.
