### PR TITLE
fix(build): make fixture replacement durable

### DIFF
--- a/.github/scripts/codeql-validation.test.ts
+++ b/.github/scripts/codeql-validation.test.ts
@@ -74,7 +74,12 @@ test('validates a CodeQL SARIF document and relative locations', () => {
   const document = validateCodeqlSarif(JSON.stringify({
     version: '2.1.0',
     runs: [{
-      tool: { driver: { name: 'CodeQL' } },
+      tool: {
+        driver: { name: 'CodeQL' },
+        extensions: [{
+          locations: [{ uri: 'file:///opt/hostedtoolcache/CodeQL/qlpacks/codeql/java-queries/qlpack.yml' }],
+        }],
+      },
       originalUriBaseIds: {
         '%SRCROOT%': { uri: 'file:///home/runner/work/Kotventure/Kotventure/' },
       },

--- a/.github/scripts/codeql-validation.ts
+++ b/.github/scripts/codeql-validation.ts
@@ -211,6 +211,8 @@ function validateSarifLocations(root: JsonValue): void {
         validateOriginalUriBaseIds(child);
         continue;
       }
+      // CodeQL records absolute qlpack paths in tool extensions. They are metadata, not source locations.
+      if (key === 'extensions' && Object.hasOwn(entry.value, 'driver')) continue;
       if (key === 'artifactLocation') validateLocation(child);
       pending.push({ value: child, depth: entry.depth + 1 });
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       matrix:
         include:
           - shard: core
-            tasks: :core:koverBinaryReport :core:jar
+            tasks: :buildSrc:test :core:koverBinaryReport :core:jar
           - shard: text
             tasks: :minimessage:koverBinaryReport :serializer:koverBinaryReport :minimessage:jar :serializer:jar
           - shard: runtime
@@ -319,6 +319,7 @@ jobs:
         with:
           name: gradle-test-results-${{ matrix.shard }}
           path: |
+            buildSrc/build/test-results/test
             modules/*/build/test-results/test
             modules/*/build/reports/tests/test
           if-no-files-found: ignore

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -229,7 +229,7 @@ jobs:
             echo "Expected one post-processed CodeQL SARIF file, found ${#sarif_files[@]}" >&2
             exit 1
           fi
-          cp "${sarif_files[0]}" codeql-handoff/codeql.sarif
+          jq '(.runs[]?.tool.extensions[]?.locations) = []' "${sarif_files[0]}" > codeql-handoff/codeql.sarif
 
       - name: Resolve CodeQL workflow identity
         id: workflow

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'groovy'
+    alias(libs.plugins.kotlin.jvm)
+}
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    jvmToolchain(25)
+}
+
+dependencies {
+    implementation gradleApi()
+    testImplementation libs.kotest.assertions.core
+    testImplementation libs.kotest.runner.junit5
+    testImplementation gradleTestKit()
+    testRuntimeOnly libs.junit.platform.launcher
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+}

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,20 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+
+    versionCatalogs {
+        libs {
+            from(files('../gradle/libs.versions.toml'))
+        }
+    }
+}
+
+rootProject.name = 'buildSrc'

--- a/buildSrc/src/main/groovy/DownloadVerifiedFile.groovy
+++ b/buildSrc/src/main/groovy/DownloadVerifiedFile.groovy
@@ -1,7 +1,10 @@
+package io.github.lmliam.kotventure.build
+
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
+import java.nio.channels.FileChannel
+import java.nio.ByteBuffer
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -25,6 +28,10 @@ import java.security.MessageDigest
 @DisableCachingByDefault(because = "Downloads a checksum-pinned external fixture")
 abstract class DownloadVerifiedFile extends DefaultTask {
 
+    DownloadVerifiedFile() {
+        outputs.upToDateWhen { false }
+    }
+
     @Input
     abstract Property<String> getSourceUrl()
 
@@ -39,7 +46,6 @@ abstract class DownloadVerifiedFile extends DefaultTask {
 
     @TaskAction
     void download() {
-        // Validate early
         def src = sourceUrl.get()
         def expected = expectedSha1.get()?.toLowerCase()?.trim()
         if (!src) {
@@ -52,65 +58,77 @@ abstract class DownloadVerifiedFile extends DefaultTask {
         def target = destination.get().asFile.toPath()
         Files.createDirectories(target.parent)
 
-        def temporary = target.resolveSibling("${target.fileName}.part")
+        if (verifyExistingTarget(target, expected)) {
+            logger.lifecycle("Verified existing ${target}")
+            return
+        }
 
         Exception lastFailure = null
         for (int attempt = 1; attempt <= ATTEMPTS; attempt++) {
-            // ensure clean temporary file
-            try {
-                Files.deleteIfExists(temporary)
-            } catch (Exception ignored) {
-            }
+            Path temporary = null
 
             try {
                 logger.lifecycle("Downloading ${src} (attempt $attempt)...")
+                temporary = Files.createTempFile(target.parent, "${target.fileName}.", '.part')
                 URI uri = new URI(src)
                 def conn = uri.toURL().openConnection()
                 conn.connectTimeout = 30_000
                 conn.readTimeout = 120_000
 
-                // Stream download to temporary file
                 conn.inputStream.withCloseable { inStream ->
-                    // Open temporary for writing (replace if exists)
-                    Files.newOutputStream(temporary, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING).withCloseable { outStream ->
+                    FileChannel.open(temporary, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING).withCloseable { outStream ->
                         byte[] buf = new byte[BUFFER_SIZE]
                         int r
                         while ((r = inStream.read(buf)) != -1) {
-                            outStream.write(buf, 0, r)
+                            ByteBuffer buffer = ByteBuffer.wrap(buf, 0, r)
+                            while (buffer.hasRemaining()) {
+                                outStream.write(buffer)
+                            }
                         }
+                        outStream.force(true)
                     }
                 }
 
-                // Compute SHA-1 from temporary file (streaming)
                 def actualSha1 = computeSha1Hex(temporary)
                 if (actualSha1 != expected) {
                     throw new GradleException("Checksum mismatch for ${src}: expected ${expected}, got ${actualSha1}")
                 }
 
-                // Move into place (attempt atomic move, fall back to replace)
-                try {
-                    Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
-                } catch (UnsupportedOperationException ignored) {
-                    Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING)
-                }
+                VerifiedFileReplacement.replace(temporary, target)
 
                 logger.lifecycle("Downloaded and verified ${target}")
                 return
             } catch (Exception e) {
                 lastFailure = e
                 logger.warn("Download attempt $attempt failed: ${e.class.simpleName}: ${e.message}")
-                try {
-                    Files.deleteIfExists(temporary)
-                } catch (Exception ignored) {
-                }
                 if (attempt < ATTEMPTS) {
-                    // simple backoff
                     sleep(attempt * 1000L)
+                }
+            } finally {
+                if (temporary != null) {
+                    Files.deleteIfExists(temporary)
                 }
             }
         }
 
         throw new GradleException("Failed to download ${src} after ${ATTEMPTS} attempts.", lastFailure)
+    }
+
+    private static boolean verifyExistingTarget(Path target, String expected) {
+        if (!Files.exists(target)) {
+            return false
+        }
+
+        try {
+            if (computeSha1Hex(target) == expected) {
+                return true
+            }
+        } catch (Exception failure) {
+            throw new GradleException("Could not verify existing fixture ${target}.", failure)
+        }
+
+        Files.delete(target)
+        return false
     }
 
     private static String computeSha1Hex(Path path) {
@@ -124,7 +142,6 @@ abstract class DownloadVerifiedFile extends DefaultTask {
             }
         }
         byte[] digest = md.digest()
-        // convert to lower-case hex
         StringBuilder sb = new StringBuilder(digest.length * 2)
         for (byte b : digest) {
             sb.append(String.format("%02x", b & 0xff))

--- a/buildSrc/src/main/groovy/io/github/lmliam/kotventure/build/FileMoveOperation.groovy
+++ b/buildSrc/src/main/groovy/io/github/lmliam/kotventure/build/FileMoveOperation.groovy
@@ -1,0 +1,8 @@
+package io.github.lmliam.kotventure.build
+
+import java.nio.file.CopyOption
+import java.nio.file.Path
+
+interface FileMoveOperation {
+    Path move(Path source, Path target, CopyOption... options)
+}

--- a/buildSrc/src/main/groovy/io/github/lmliam/kotventure/build/VerifiedFileReplacement.groovy
+++ b/buildSrc/src/main/groovy/io/github/lmliam/kotventure/build/VerifiedFileReplacement.groovy
@@ -1,0 +1,37 @@
+package io.github.lmliam.kotventure.build
+
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.CopyOption
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+final class VerifiedFileReplacement {
+
+    private static final FileMoveOperation FILES_MOVE = new FileMoveOperation() {
+        @Override
+        Path move(Path source, Path target, CopyOption... options) {
+            Files.move(source, target, options)
+        }
+    }
+
+    private VerifiedFileReplacement() {
+    }
+
+    static void replace(Path temporary, Path destination) {
+        replace(temporary, destination, FILES_MOVE)
+    }
+
+    static void replace(Path temporary, Path destination, FileMoveOperation moveOperation) {
+        try {
+            moveOperation.move(
+                temporary,
+                destination,
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        } catch (AtomicMoveNotSupportedException ignored) {
+            moveOperation.move(temporary, destination, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+}

--- a/buildSrc/src/test/kotlin/io/github/lmliam/kotventure/build/DownloadVerifiedFileFunctionalTest.kt
+++ b/buildSrc/src/test/kotlin/io/github/lmliam/kotventure/build/DownloadVerifiedFileFunctionalTest.kt
@@ -1,0 +1,150 @@
+package io.github.lmliam.kotventure.build
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+
+class DownloadVerifiedFileFunctionalTest :
+    StringSpec(
+        {
+            "revalidates an output instead of reporting it up to date" {
+                withTemporaryDirectory { directory ->
+                    val source = directory.resolve("fixture-source")
+                    val destination = directory.resolve("build/fixture.jar")
+                    Files.createDirectories(destination.parent)
+                    Files.writeString(source, "fixture bytes")
+                    copyBuildLogic(directory)
+                    writeBuildFiles(directory, sha1(source))
+
+                    val first = runGradle(directory)
+                    first.task(":download")?.outcome shouldBe TaskOutcome.SUCCESS
+
+                    Files.delete(source)
+                    val second = runGradle(directory)
+                    second.task(":download")?.outcome shouldBe TaskOutcome.SUCCESS
+                    Files.readString(destination) shouldBe "fixture bytes"
+                }
+            }
+
+            "replaces an existing fixture after its digest proves it is invalid" {
+                withTemporaryDirectory { directory ->
+                    val source = directory.resolve("fixture-source")
+                    val destination = directory.resolve("build/fixture.jar")
+                    Files.createDirectories(destination.parent)
+                    Files.writeString(source, "new fixture")
+                    Files.writeString(destination, "old fixture")
+                    copyBuildLogic(directory)
+                    writeBuildFiles(directory, sha1(source))
+
+                    runGradle(directory)
+
+                    Files.readString(destination) shouldBe "new fixture"
+                    Files.list(destination.parent).use { paths ->
+                        paths.filter { it.fileName.toString().endsWith(".part") }.count() shouldBe 0L
+                    }
+                }
+            }
+
+            "preserves a destination that cannot be read" {
+                withTemporaryDirectory { directory ->
+                    val destination = directory.resolve("build/fixture.jar")
+                    Files.createDirectories(destination)
+                    copyBuildLogic(directory)
+                    writeBuildFiles(directory, "0".repeat(40))
+
+                    runGradleAndExpectFailure(directory)
+
+                    Files.isDirectory(destination) shouldBe true
+                }
+            }
+        },
+    )
+
+private fun runGradle(directory: Path) =
+    GradleRunner.create()
+        .withProjectDir(directory.toFile())
+        .withArguments("download")
+        .forwardOutput()
+        .build()
+
+private fun runGradleAndExpectFailure(directory: Path) =
+    GradleRunner.create()
+        .withProjectDir(directory.toFile())
+        .withArguments("download")
+        .forwardOutput()
+        .buildAndFail()
+
+private fun copyBuildLogic(directory: Path) {
+    val sourceRoot = sequenceOf(
+        Path.of("src/main/groovy"),
+        Path.of("buildSrc/src/main/groovy"),
+    ).first { Files.exists(it) }
+    val buildLogicRoot = directory.resolve("buildSrc")
+    Files.createDirectories(buildLogicRoot.resolve("src/main/groovy"))
+    sequenceOf(
+        "DownloadVerifiedFile.groovy",
+        "io/github/lmliam/kotventure/build/FileMoveOperation.groovy",
+        "io/github/lmliam/kotventure/build/VerifiedFileReplacement.groovy",
+    ).forEach { relativePath ->
+        val source = sourceRoot.resolve(relativePath)
+        val destination = buildLogicRoot.resolve("src/main/groovy").resolve(relativePath)
+        Files.createDirectories(destination.parent)
+        Files.copy(source, destination)
+    }
+    Files.writeString(
+        buildLogicRoot.resolve("build.gradle"),
+        """
+        plugins {
+            id 'groovy'
+        }
+
+        dependencies {
+            implementation gradleApi()
+        }
+        """.trimIndent(),
+    )
+}
+
+private fun writeBuildFiles(directory: Path, expectedSha1: String) {
+    Files.writeString(directory.resolve("settings.gradle"), "rootProject.name = 'fixture-test'\n")
+    Files.writeString(
+        directory.resolve("build.gradle"),
+        """
+        import io.github.lmliam.kotventure.build.DownloadVerifiedFile
+
+        tasks.register('download', DownloadVerifiedFile) {
+            sourceUrl.set(file('fixture-source').toURI().toString())
+            expectedSha1.set('$expectedSha1')
+            destination.set(layout.buildDirectory.file('fixture.jar'))
+        }
+        """.trimIndent(),
+    )
+}
+
+private fun sha1(path: Path): String {
+    val digest = MessageDigest.getInstance("SHA-1")
+    Files.newInputStream(path).use { input ->
+        val buffer = ByteArray(8 * 1024)
+        while (true) {
+            val count = input.read(buffer)
+            if (count < 0) {
+                break
+            }
+            digest.update(buffer, 0, count)
+        }
+    }
+    return digest.digest().joinToString("") { byte -> "%02x".format(byte) }
+}
+
+private inline fun withTemporaryDirectory(block: (Path) -> Unit) {
+    val directory = Files.createTempDirectory("kotventure-verified-file-functional-")
+    try {
+        block(directory)
+    } finally {
+        directory.toFile().deleteRecursively()
+    }
+}

--- a/buildSrc/src/test/kotlin/io/github/lmliam/kotventure/build/VerifiedFileReplacementTest.kt
+++ b/buildSrc/src/test/kotlin/io/github/lmliam/kotventure/build/VerifiedFileReplacementTest.kt
@@ -1,0 +1,118 @@
+package io.github.lmliam.kotventure.build
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.io.IOException
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.CopyOption
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+class VerifiedFileReplacementTest :
+    StringSpec(
+        {
+            "uses an atomic replacement when the file system supports it" {
+                withTemporaryDirectory { directory ->
+                    val temporary = directory.resolve("download.part")
+                    val destination = directory.resolve("fixture.jar")
+                    Files.writeString(temporary, "new fixture")
+                    Files.writeString(destination, "old fixture")
+                    val calls = mutableListOf<List<CopyOption>>()
+                    val moveOperation = recordingMove(calls)
+
+                    VerifiedFileReplacement.replace(temporary, destination, moveOperation)
+
+                    calls shouldBe listOf(
+                        listOf(StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING),
+                    )
+                    Files.readString(destination) shouldBe "new fixture"
+                }
+            }
+
+            "falls back only when atomic replacement is unsupported" {
+                withTemporaryDirectory { directory ->
+                    val temporary = directory.resolve("download.part")
+                    val destination = directory.resolve("fixture.jar")
+                    Files.writeString(temporary, "new fixture")
+                    Files.writeString(destination, "old fixture")
+                    val calls = mutableListOf<List<CopyOption>>()
+                    val moveOperation = object : FileMoveOperation {
+                        override fun move(source: Path, target: Path, vararg options: CopyOption): Path {
+                            calls += options.toList()
+                            if (options.contains(StandardCopyOption.ATOMIC_MOVE)) {
+                                throw AtomicMoveNotSupportedException(source.toString(), target.toString(), "test")
+                            }
+                            return Files.move(source, target, *options)
+                        }
+                    }
+
+                    VerifiedFileReplacement.replace(temporary, destination, moveOperation)
+
+                    calls shouldBe listOf(
+                        listOf(StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING),
+                        listOf(StandardCopyOption.REPLACE_EXISTING),
+                    )
+                    Files.readString(destination) shouldBe "new fixture"
+                }
+            }
+
+            "does not treat an unsupported operation as an atomic move limitation" {
+                withTemporaryDirectory { directory ->
+                    val temporary = directory.resolve("download.part")
+                    val destination = directory.resolve("fixture.jar")
+                    Files.writeString(temporary, "new fixture")
+                    Files.writeString(destination, "old fixture")
+                    val moveOperation = object : FileMoveOperation {
+                        override fun move(source: Path, target: Path, vararg options: CopyOption): Path {
+                            throw UnsupportedOperationException("test")
+                        }
+                    }
+
+                    shouldThrow<UnsupportedOperationException> {
+                        VerifiedFileReplacement.replace(temporary, destination, moveOperation)
+                    }
+
+                    Files.readString(destination) shouldBe "old fixture"
+                }
+            }
+
+            "does not treat an I/O failure as an atomic move limitation" {
+                withTemporaryDirectory { directory ->
+                    val temporary = directory.resolve("download.part")
+                    val destination = directory.resolve("fixture.jar")
+                    Files.writeString(temporary, "new fixture")
+                    Files.writeString(destination, "old fixture")
+                    val moveOperation = object : FileMoveOperation {
+                        override fun move(source: Path, target: Path, vararg options: CopyOption): Path {
+                            throw IOException("test")
+                        }
+                    }
+
+                    shouldThrow<IOException> {
+                        VerifiedFileReplacement.replace(temporary, destination, moveOperation)
+                    }
+
+                    Files.readString(destination) shouldBe "old fixture"
+                }
+            }
+        },
+    )
+
+private fun recordingMove(calls: MutableList<List<CopyOption>>): FileMoveOperation =
+    object : FileMoveOperation {
+        override fun move(source: Path, target: Path, vararg options: CopyOption): Path {
+            calls += options.toList()
+            return Files.move(source, target, *options)
+        }
+    }
+
+private inline fun withTemporaryDirectory(block: (Path) -> Unit) {
+    val directory = Files.createTempDirectory("kotventure-fixture-replacement-")
+    try {
+        block(directory)
+    } finally {
+        directory.toFile().deleteRecursively()
+    }
+}

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -10,7 +10,7 @@ For local development commands, see [CONTRIBUTING.md](../.github/CONTRIBUTING.md
 
 | Workflow | File | Triggers | Purpose |
 |----------|------|----------|---------|
-| **CI** | `ci.yml` | PR, push, `merge_group`, weekly schedule, `workflow_dispatch` | Gate, path filter, parallel lint (Kotlin + Actions), sharded build (`core | text | runtime` → Aggregate), Vanilla. Always reports the required status check |
+| **CI** | `ci.yml` | PR, push, `merge_group`, weekly schedule, `workflow_dispatch` | Gate, path filter, parallel lint (Kotlin + Actions), sharded build (`core (including buildSrc tests) | text | runtime` → Aggregate), Vanilla. Always reports the required status check |
 | **JUnit publication** | `junit-publish.yml` | `workflow_run` for CI (`in_progress`, `completed`) | Uses default-branch code to publish the Build and Vanilla JUnit checks from bounded XML artefacts |
 | **CodeQL** | `codeql.yml` | PR, push, `merge_group`, weekly schedule | CodeQL analysis (`actions` + `java-kotlin` matrix), parallel with CI |
 | **CodeQL publication** | `codeql-publish.yml` | `workflow_run` for CodeQL (`in_progress`, `completed`) | Uses default-branch code to validate and upload PR and merge-group SARIF artefacts |
@@ -34,7 +34,7 @@ CI
 ├─ Tier 1: Core (parallel, fast feedback — all gated on Triage) ──
 │   ├─ Lint (Kotlin)     (spotlessCheck + ktlintCheck)
 │   ├─ Lint (Actions)    (declaration check + CI tooling tests)
-│   ├─ Build             (sharded: core | text (`minimessage` + `serializer`) | runtime (`coroutines` + `paper` + `test` + `test-snapshot` + `bom`) — each `koverBinaryReport` + test results)
+│   ├─ Build             (sharded: core (`buildSrc:test` + `core`) | text (`minimessage` + `serializer`) | runtime (`coroutines` + `paper` + `test` + `test-snapshot` + `bom`) — each `koverBinaryReport` + test results)
 │   ├─ Vanilla           (MC-backed selector tests, path-filtered)
 │   └─ Dokka             (dokkaGenerate, parallel with Build)
 │
@@ -308,7 +308,7 @@ reports zero alerts. This lets GitHub treat the tool as configured.
 ### Full builds
 
 Pull requests, pushes, merge groups, schedules, and manual dispatches run the complete pipeline. The Build matrix shards
-the work: `core` (`:core:koverBinaryReport` + `:core:jar`), `text` (`minimessage` + `serializer`), and `runtime`
+the work: `core` (`:buildSrc:test` + `:core:koverBinaryReport` + `:core:jar`), `text` (`minimessage` + `serializer`), and `runtime`
 (`coroutines` + `paper` + `test` + `test-snapshot` + `bom`). Dokka runs in its own parallel job. Aggregate consumes the
 shard coverage hand-off and enforces the 85% `koverVerify` gate. Path filters control whether the full CI pipeline
 starts. They do not control which modules compile. Thus, each code pull request includes the coverage gate, BOM checks,

--- a/gradle/vanilla-conformance.gradle
+++ b/gradle/vanilla-conformance.gradle
@@ -1,3 +1,5 @@
+import io.github.lmliam.kotventure.build.DownloadVerifiedFile
+
 final String targetMinecraftVersion = '26.2'
 final String serverBundleSha1 = '823e2250d24b3ddac457a60c92a6a941943fcd6a'
 final String serverBundleUrl = "https://piston-data.mojang.com/v1/objects/${serverBundleSha1}/server.jar"


### PR DESCRIPTION
## Summary

- Add build-logic Gradle and Kotest test setup.
- Revalidate the fixture output on every task execution.
- Stream verified bytes to a same-directory temporary file, force the file channel, and use an atomic replacement with the required narrow fallback.
- Preserve unreadable destinations and clean temporary files on failure.
- Add build-logic and Gradle TestKit coverage.
- Accept the absolute `file://` qlpack locations that CodeQL emits in tool-extension metadata without relaxing result-location path checks.

## Related issues

Part of #380

## Type of change

- [x] fix: bug fix
- [x] test
- [x] chore / build / ci

## Testing

- `./gradlew build --no-configuration-cache`
- `./gradlew :buildSrc:test --rerun-tasks --no-configuration-cache`
- `cd .github && npm run typecheck && npm run build && node --test scripts/codeql-validation.test.js scripts/codeql-publisher.test.js`
- `cd .github && node --test actions/pr-metrics-comment/test/*.test.js scripts/*.test.js`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

The fix accepts the real failed CodeQL SARIF artifact locally. The trusted publisher will use it after this change reaches `master`.