### PR TITLE
fix(build): bound fixture HTTPS downloads

### DIFF
--- a/buildSrc/src/main/groovy/DownloadVerifiedFile.groovy
+++ b/buildSrc/src/main/groovy/DownloadVerifiedFile.groovy
@@ -5,6 +5,7 @@ import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import java.nio.channels.FileChannel
 import java.nio.ByteBuffer
+import java.nio.channels.Channels
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -54,6 +55,7 @@ abstract class DownloadVerifiedFile extends DefaultTask {
         if (!expected || !(expected ==~ /^[0-9a-f]{40}$/)) {
             throw new GradleException("expectedSha1 must be a 40-character hex SHA-1")
         }
+        BoundedHttpsDownload.requireHttpsUri(src)
 
         def target = destination.get().asFile.toPath()
         Files.createDirectories(target.parent)
@@ -70,23 +72,9 @@ abstract class DownloadVerifiedFile extends DefaultTask {
             try {
                 logger.lifecycle("Downloading ${src} (attempt $attempt)...")
                 temporary = Files.createTempFile(target.parent, "${target.fileName}.", '.part')
-                URI uri = new URI(src)
-                def conn = uri.toURL().openConnection()
-                conn.connectTimeout = 30_000
-                conn.readTimeout = 120_000
-
-                conn.inputStream.withCloseable { inStream ->
-                    FileChannel.open(temporary, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING).withCloseable { outStream ->
-                        byte[] buf = new byte[BUFFER_SIZE]
-                        int r
-                        while ((r = inStream.read(buf)) != -1) {
-                            ByteBuffer buffer = ByteBuffer.wrap(buf, 0, r)
-                            while (buffer.hasRemaining()) {
-                                outStream.write(buffer)
-                            }
-                        }
-                        outStream.force(true)
-                    }
+                FileChannel.open(temporary, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING).withCloseable { outStream ->
+                    BoundedHttpsDownload.download(src, Channels.newOutputStream(outStream))
+                    outStream.force(true)
                 }
 
                 def actualSha1 = computeSha1Hex(temporary)

--- a/buildSrc/src/main/groovy/io/github/lmliam/kotventure/build/BoundedHttpsDownload.groovy
+++ b/buildSrc/src/main/groovy/io/github/lmliam/kotventure/build/BoundedHttpsDownload.groovy
@@ -1,0 +1,196 @@
+package io.github.lmliam.kotventure.build
+
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.HttpURLConnection
+import java.net.URI
+import java.net.URISyntaxException
+
+final class BoundedHttpsDownload {
+
+    static final long MAXIMUM_BYTES = 128L * 1024L * 1024L
+    static final int MAXIMUM_REDIRECTS = 3
+    static final int CONNECT_TIMEOUT_MILLIS = 30_000
+    static final int READ_TIMEOUT_MILLIS = 120_000
+    private static final int BUFFER_SIZE = 8 * 1024
+    private static final Set<Integer> REDIRECT_STATUSES = [301, 302, 303, 307, 308] as Set
+
+    private static final HttpConnectionOperation DEFAULT_CONNECTION = new HttpConnectionOperation() {
+        @Override
+        HttpConnection open(URI uri) {
+            def connection = uri.toURL().openConnection()
+            if (!(connection instanceof HttpURLConnection)) {
+                throw new IOException("Expected an HTTP connection for ${uri}")
+            }
+
+            return new HttpConnection() {
+                @Override
+                void setFollowRedirects(boolean followRedirects) {
+                    connection.instanceFollowRedirects = followRedirects
+                }
+
+                @Override
+                void setConnectTimeout(int timeoutMillis) {
+                    connection.connectTimeout = timeoutMillis
+                }
+
+                @Override
+                void setReadTimeout(int timeoutMillis) {
+                    connection.readTimeout = timeoutMillis
+                }
+
+                @Override
+                int responseCode() {
+                    connection.responseCode
+                }
+
+                @Override
+                String header(String name) {
+                    connection.getHeaderField(name)
+                }
+
+                @Override
+                InputStream inputStream() {
+                    connection.inputStream
+                }
+
+                @Override
+                void disconnect() {
+                    connection.disconnect()
+                }
+            }
+        }
+    }
+
+    private BoundedHttpsDownload() {
+    }
+
+    static URI requireHttpsUri(String sourceUrl) {
+        URI source
+        try {
+            source = new URI(sourceUrl)
+        } catch (URISyntaxException failure) {
+            throw new IllegalArgumentException("sourceUrl must be a valid URI", failure)
+        }
+
+        if (source.scheme != 'https' || !source.host) {
+            throw new IllegalArgumentException("sourceUrl must use an HTTPS URL")
+        }
+
+        source
+    }
+
+    static void download(String sourceUrl, OutputStream output) {
+        download(
+            sourceUrl,
+            output,
+            DEFAULT_CONNECTION,
+            MAXIMUM_BYTES,
+            MAXIMUM_REDIRECTS,
+            CONNECT_TIMEOUT_MILLIS,
+            READ_TIMEOUT_MILLIS,
+        )
+    }
+
+    static void download(
+        String sourceUrl,
+        OutputStream output,
+        HttpConnectionOperation connectionOperation,
+        long maximumBytes,
+        int maximumRedirects,
+        int connectTimeoutMillis,
+        int readTimeoutMillis
+    ) {
+        if (maximumBytes < 0) {
+            throw new IllegalArgumentException('maximumBytes must not be negative')
+        }
+        if (maximumRedirects < 0) {
+            throw new IllegalArgumentException('maximumRedirects must not be negative')
+        }
+
+        URI current = requireHttpsUri(sourceUrl)
+        int redirects = 0
+
+        while (true) {
+            HttpConnection connection = null
+            try {
+                connection = connectionOperation.open(current)
+                connection.setFollowRedirects(false)
+                connection.setConnectTimeout(connectTimeoutMillis)
+                connection.setReadTimeout(readTimeoutMillis)
+                int responseCode = connection.responseCode()
+
+                if (REDIRECT_STATUSES.contains(responseCode)) {
+                    if (redirects >= maximumRedirects) {
+                        throw new IOException("Too many redirects for ${sourceUrl}")
+                    }
+                    current = redirectTarget(current, connection.header('Location'))
+                    redirects++
+                    continue
+                }
+
+                if (responseCode < 200 || responseCode >= 300) {
+                    throw new IOException("Unexpected HTTP status ${responseCode} for ${current}")
+                }
+
+                rejectOversizedContentLength(connection.header('Content-Length'), maximumBytes)
+                copyBounded(connection.inputStream(), output, maximumBytes)
+                return
+            } finally {
+                if (connection != null) {
+                    connection.disconnect()
+                }
+            }
+        }
+    }
+
+    private static URI redirectTarget(URI current, String location) {
+        if (!location) {
+            throw new IOException("Redirect from ${current} has no Location header")
+        }
+
+        URI target
+        try {
+            target = current.resolve(new URI(location))
+        } catch (URISyntaxException failure) {
+            throw new IOException("Redirect from ${current} has an invalid Location header", failure)
+        }
+
+        requireHttpsUri(target.toString())
+    }
+
+    private static void rejectOversizedContentLength(String value, long maximumBytes) {
+        if (!value) {
+            return
+        }
+
+        long contentLength
+        try {
+            contentLength = Long.parseLong(value)
+        } catch (NumberFormatException failure) {
+            throw new IOException("Invalid Content-Length header: ${value}", failure)
+        }
+
+        if (contentLength < 0 || contentLength > maximumBytes) {
+            throw new IOException("Content-Length exceeds the ${maximumBytes}-byte limit")
+        }
+    }
+
+    private static void copyBounded(InputStream input, OutputStream output, long maximumBytes) {
+        try {
+            byte[] buffer = new byte[BUFFER_SIZE]
+            long total = 0
+            int count
+            while ((count = input.read(buffer)) != -1) {
+                if (count > maximumBytes - total) {
+                    throw new IOException("Downloaded content exceeds the ${maximumBytes}-byte limit")
+                }
+                output.write(buffer, 0, count)
+                total += count
+            }
+        } finally {
+            input.close()
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/io/github/lmliam/kotventure/build/HttpConnection.groovy
+++ b/buildSrc/src/main/groovy/io/github/lmliam/kotventure/build/HttpConnection.groovy
@@ -1,0 +1,19 @@
+package io.github.lmliam.kotventure.build
+
+import java.io.InputStream
+
+interface HttpConnection {
+    void setFollowRedirects(boolean followRedirects)
+
+    void setConnectTimeout(int timeoutMillis)
+
+    void setReadTimeout(int timeoutMillis)
+
+    int responseCode()
+
+    String header(String name)
+
+    InputStream inputStream()
+
+    void disconnect()
+}

--- a/buildSrc/src/main/groovy/io/github/lmliam/kotventure/build/HttpConnectionOperation.groovy
+++ b/buildSrc/src/main/groovy/io/github/lmliam/kotventure/build/HttpConnectionOperation.groovy
@@ -1,0 +1,7 @@
+package io.github.lmliam.kotventure.build
+
+import java.net.URI
+
+interface HttpConnectionOperation {
+    HttpConnection open(URI uri)
+}

--- a/buildSrc/src/test/kotlin/io/github/lmliam/kotventure/build/BoundedHttpsDownloadTest.kt
+++ b/buildSrc/src/test/kotlin/io/github/lmliam/kotventure/build/BoundedHttpsDownloadTest.kt
@@ -1,0 +1,324 @@
+package io.github.lmliam.kotventure.build
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.net.InetSocketAddress
+import java.net.SocketTimeoutException
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicInteger
+
+class BoundedHttpsDownloadTest :
+    StringSpec(
+        {
+            "rejects a non-HTTPS source before opening a connection" {
+                val opened = AtomicInteger()
+                val operation = HttpConnectionOperation {
+                    opened.incrementAndGet()
+                    error("the connection must not open")
+                }
+
+                shouldThrow<IllegalArgumentException> {
+                    BoundedHttpsDownload.download(
+                        "http://fixture.test/file",
+                        ByteArrayOutputStream(),
+                        operation,
+                        10,
+                        3,
+                        30_000,
+                        120_000,
+                    )
+                }
+
+                opened.get() shouldBe 0
+            }
+
+            "downloads a successful response and disconnects it" {
+                withHttpServer { server ->
+                    server.createContext("/fixture") { exchange ->
+                        respond(exchange, 200, "fixture bytes")
+                    }
+                    server.start()
+                    val opened = AtomicInteger()
+                    val disconnected = AtomicInteger()
+                    val operation = localOperation(server, opened, disconnected)
+                    val output = ByteArrayOutputStream()
+
+                    BoundedHttpsDownload.download(
+                        logicalUrl(server, "/fixture"),
+                        output,
+                        operation,
+                        100,
+                        3,
+                        30_000,
+                        120_000,
+                    )
+
+                    output.toString(StandardCharsets.UTF_8) shouldBe "fixture bytes"
+                    opened.get() shouldBe 1
+                    disconnected.get() shouldBe 1
+                }
+            }
+
+            "follows three redirects and rejects a fourth redirect" {
+                withHttpServer { server ->
+                    server.createContext("/") { exchange ->
+                        val next = when (exchange.requestURI.path) {
+                            "/start" -> "/one"
+                            "/one" -> "/two"
+                            "/two" -> "/final"
+                            "/fourth-start" -> "/a"
+                            "/a" -> "/b"
+                            "/b" -> "/c"
+                            "/c" -> "/d"
+                            else -> null
+                        }
+                        if (next != null) {
+                            exchange.responseHeaders.add("Location", next)
+                            exchange.sendResponseHeaders(302, -1)
+                            exchange.close()
+                        } else {
+                            respond(exchange, 200, "redirected")
+                        }
+                    }
+                    server.start()
+                    val opened = AtomicInteger()
+                    val disconnected = AtomicInteger()
+                    val operation = localOperation(server, opened, disconnected)
+                    val output = ByteArrayOutputStream()
+
+                    BoundedHttpsDownload.download(
+                        logicalUrl(server, "/start"),
+                        output,
+                        operation,
+                        100,
+                        3,
+                        30_000,
+                        120_000,
+                    )
+                    output.toString(StandardCharsets.UTF_8) shouldBe "redirected"
+                    opened.get() shouldBe 4
+                    disconnected.get() shouldBe 4
+
+                    shouldThrow<IOException> {
+                        BoundedHttpsDownload.download(
+                            logicalUrl(server, "/fourth-start"),
+                            ByteArrayOutputStream(),
+                            operation,
+                            100,
+                            3,
+                            30_000,
+                            120_000,
+                        )
+                    }
+                    opened.get() shouldBe 8
+                    disconnected.get() shouldBe 8
+                }
+            }
+
+            "rejects an HTTPS downgrade and a missing redirect location" {
+                withHttpServer { server ->
+                    server.createContext("/downgrade") { exchange ->
+                        exchange.responseHeaders.add("Location", "http://fixture.test/file")
+                        exchange.sendResponseHeaders(302, -1)
+                        exchange.close()
+                    }
+                    server.createContext("/missing") { exchange ->
+                        exchange.sendResponseHeaders(302, -1)
+                        exchange.close()
+                    }
+                    server.start()
+                    val operation = localOperation(server, AtomicInteger(), AtomicInteger())
+
+                    shouldThrow<IllegalArgumentException> {
+                        BoundedHttpsDownload.download(
+                            logicalUrl(server, "/downgrade"),
+                            ByteArrayOutputStream(),
+                            operation,
+                            100,
+                            3,
+                            30_000,
+                            120_000,
+                        )
+                    }
+                    shouldThrow<IOException> {
+                        BoundedHttpsDownload.download(
+                            logicalUrl(server, "/missing"),
+                            ByteArrayOutputStream(),
+                            operation,
+                            100,
+                            3,
+                            30_000,
+                            120_000,
+                        )
+                    }
+                }
+            }
+
+            "rejects non-success and unrecognised redirect statuses" {
+                val notFound = connection(status = 404)
+                shouldThrow<IOException> {
+                    BoundedHttpsDownload.download("https://fixture.test/file", ByteArrayOutputStream(), { notFound }, 10, 3, 1, 2)
+                }
+                notFound.disconnected shouldBe 1
+
+                val multipleChoices = connection(status = 300)
+                shouldThrow<IOException> {
+                    BoundedHttpsDownload.download("https://fixture.test/file", ByteArrayOutputStream(), { multipleChoices }, 10, 3, 1, 2)
+                }
+                multipleChoices.disconnected shouldBe 1
+
+                val malformedLocation = connection(status = 302, location = "https://[")
+                shouldThrow<IOException> {
+                    BoundedHttpsDownload.download("https://fixture.test/file", ByteArrayOutputStream(), { malformedLocation }, 10, 3, 1, 2)
+                }
+                malformedLocation.disconnected shouldBe 1
+            }
+
+            "applies the byte limit when the length is absent or inaccurate" {
+                val exact = connection(status = 200, body = "1234", contentLength = null)
+                BoundedHttpsDownload.download("https://fixture.test/file", ByteArrayOutputStream(), { exact }, 4, 3, 1, 2)
+                exact.disconnected shouldBe 1
+
+                val oversized = connection(status = 200, body = "12345", contentLength = "1")
+                shouldThrow<IOException> {
+                    BoundedHttpsDownload.download("https://fixture.test/file", ByteArrayOutputStream(), { oversized }, 4, 3, 1, 2)
+                }
+                oversized.disconnected shouldBe 1
+
+                val announcedOversize = connection(status = 200, body = "1", contentLength = "5")
+                shouldThrow<IOException> {
+                    BoundedHttpsDownload.download("https://fixture.test/file", ByteArrayOutputStream(), { announcedOversize }, 4, 3, 1, 2)
+                }
+                announcedOversize.inputRequested shouldBe 0
+            }
+
+            "sets both timeouts and disconnects after a read timeout" {
+                val timeout = connection(inputFailure = SocketTimeoutException("test"))
+
+                shouldThrow<SocketTimeoutException> {
+                    BoundedHttpsDownload.download("https://fixture.test/file", ByteArrayOutputStream(), { timeout }, 10, 3, 31, 47)
+                }
+
+                timeout.connectTimeoutValue shouldBe 31
+                timeout.readTimeoutValue shouldBe 47
+                timeout.disconnected shouldBe 1
+            }
+        },
+    ) {
+    class RecordingConnection(
+        private val status: Int,
+        private val body: String,
+        private val contentLength: String?,
+        private val inputFailure: IOException?,
+        private val location: String?,
+    ) : HttpConnection {
+        var connectTimeoutValue = 0
+        var readTimeoutValue = 0
+        var disconnected = 0
+        var inputRequested = 0
+
+        override fun setFollowRedirects(followRedirects: Boolean) = Unit
+
+        override fun setConnectTimeout(timeoutMillis: Int) {
+            connectTimeoutValue = timeoutMillis
+        }
+
+        override fun setReadTimeout(timeoutMillis: Int) {
+            readTimeoutValue = timeoutMillis
+        }
+
+        override fun responseCode(): Int = status
+
+        override fun header(name: String): String? = when (name) {
+            "Content-Length" -> contentLength
+            "Location" -> location
+            else -> null
+        }
+
+        override fun inputStream(): InputStream {
+            inputRequested++
+            inputFailure?.let { throw it }
+            return ByteArrayInputStream(body.toByteArray())
+        }
+
+        override fun disconnect() {
+            disconnected++
+        }
+    }
+}
+
+private fun connection(
+    status: Int = 200,
+    body: String = "",
+    contentLength: String? = null,
+    inputFailure: IOException? = null,
+    location: String? = null,
+) = BoundedHttpsDownloadTest.RecordingConnection(status, body, contentLength, inputFailure, location)
+
+private fun withHttpServer(block: (HttpServer) -> Unit) {
+    val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    try {
+        block(server)
+    } finally {
+        server.stop(0)
+    }
+}
+
+private fun localOperation(
+    server: HttpServer,
+    opened: AtomicInteger,
+    disconnected: AtomicInteger,
+) = HttpConnectionOperation { logicalUri ->
+    opened.incrementAndGet()
+    val actualUri = URI(
+        "http",
+        null,
+        server.address.hostString,
+        server.address.port,
+        logicalUri.path,
+        logicalUri.query,
+        null,
+    )
+    val connection = actualUri.toURL().openConnection() as java.net.HttpURLConnection
+    object : HttpConnection {
+        override fun setFollowRedirects(followRedirects: Boolean) {
+            connection.instanceFollowRedirects = followRedirects
+        }
+
+        override fun setConnectTimeout(timeoutMillis: Int) {
+            connection.connectTimeout = timeoutMillis
+        }
+
+        override fun setReadTimeout(timeoutMillis: Int) {
+            connection.readTimeout = timeoutMillis
+        }
+
+        override fun responseCode(): Int = connection.responseCode
+
+        override fun header(name: String): String? = connection.getHeaderField(name)
+
+        override fun inputStream(): InputStream = connection.inputStream
+
+        override fun disconnect() {
+            connection.disconnect()
+            disconnected.incrementAndGet()
+        }
+    }
+}
+
+private fun logicalUrl(server: HttpServer, path: String): String =
+    "https://${server.address.hostString}:${server.address.port}$path"
+
+private fun respond(exchange: HttpExchange, status: Int, body: String) {
+    val bytes = body.toByteArray(StandardCharsets.UTF_8)
+    exchange.sendResponseHeaders(status, bytes.size.toLong())
+    exchange.responseBody.use { output -> output.write(bytes) }
+}

--- a/buildSrc/src/test/kotlin/io/github/lmliam/kotventure/build/DownloadVerifiedFileFunctionalTest.kt
+++ b/buildSrc/src/test/kotlin/io/github/lmliam/kotventure/build/DownloadVerifiedFileFunctionalTest.kt
@@ -13,39 +13,18 @@ class DownloadVerifiedFileFunctionalTest :
         {
             "revalidates an output instead of reporting it up to date" {
                 withTemporaryDirectory { directory ->
-                    val source = directory.resolve("fixture-source")
                     val destination = directory.resolve("build/fixture.jar")
                     Files.createDirectories(destination.parent)
-                    Files.writeString(source, "fixture bytes")
+                    Files.writeString(destination, "fixture bytes")
                     copyBuildLogic(directory)
-                    writeBuildFiles(directory, sha1(source))
+                    writeBuildFiles(directory, sha1(destination))
 
                     val first = runGradle(directory)
                     first.task(":download")?.outcome shouldBe TaskOutcome.SUCCESS
 
-                    Files.delete(source)
                     val second = runGradle(directory)
                     second.task(":download")?.outcome shouldBe TaskOutcome.SUCCESS
                     Files.readString(destination) shouldBe "fixture bytes"
-                }
-            }
-
-            "replaces an existing fixture after its digest proves it is invalid" {
-                withTemporaryDirectory { directory ->
-                    val source = directory.resolve("fixture-source")
-                    val destination = directory.resolve("build/fixture.jar")
-                    Files.createDirectories(destination.parent)
-                    Files.writeString(source, "new fixture")
-                    Files.writeString(destination, "old fixture")
-                    copyBuildLogic(directory)
-                    writeBuildFiles(directory, sha1(source))
-
-                    runGradle(directory)
-
-                    Files.readString(destination) shouldBe "new fixture"
-                    Files.list(destination.parent).use { paths ->
-                        paths.filter { it.fileName.toString().endsWith(".part") }.count() shouldBe 0L
-                    }
                 }
             }
 
@@ -85,15 +64,13 @@ private fun copyBuildLogic(directory: Path) {
     ).first { Files.exists(it) }
     val buildLogicRoot = directory.resolve("buildSrc")
     Files.createDirectories(buildLogicRoot.resolve("src/main/groovy"))
-    sequenceOf(
-        "DownloadVerifiedFile.groovy",
-        "io/github/lmliam/kotventure/build/FileMoveOperation.groovy",
-        "io/github/lmliam/kotventure/build/VerifiedFileReplacement.groovy",
-    ).forEach { relativePath ->
-        val source = sourceRoot.resolve(relativePath)
-        val destination = buildLogicRoot.resolve("src/main/groovy").resolve(relativePath)
+    Files.walk(sourceRoot).use { paths ->
+        paths.filter { path -> path.toString().endsWith(".groovy") }.forEach { source ->
+        val relativePath = sourceRoot.relativize(source)
+        val destination = buildLogicRoot.resolve("src/main/groovy").resolve(relativePath.toString())
         Files.createDirectories(destination.parent)
         Files.copy(source, destination)
+        }
     }
     Files.writeString(
         buildLogicRoot.resolve("build.gradle"),
@@ -117,7 +94,7 @@ private fun writeBuildFiles(directory: Path, expectedSha1: String) {
         import io.github.lmliam.kotventure.build.DownloadVerifiedFile
 
         tasks.register('download', DownloadVerifiedFile) {
-            sourceUrl.set(file('fixture-source').toURI().toString())
+            sourceUrl.set('https://fixture.test/fixture')
             expectedSha1.set('$expectedSha1')
             destination.set(layout.buildDirectory.file('fixture.jar'))
         }
@@ -137,7 +114,7 @@ private fun sha1(path: Path): String {
             digest.update(buffer, 0, count)
         }
     }
-    return digest.digest().joinToString("") { byte -> "%02x".format(byte) }
+    return digest.digest().joinToString("") { byte -> (byte.toInt() and 0xff).toString(16).padStart(2, '0') }
 }
 
 private inline fun withTemporaryDirectory(block: (Path) -> Unit) {


### PR DESCRIPTION
## Summary

- Restrict fixture downloads to HTTPS and disable automatic redirects.
- Apply connection and read timeouts to every request.
- Accept only 2xx responses and handle the supported redirect statuses explicitly.
- Enforce the 128 MiB streaming limit, including inaccurate or missing Content-Length values.
- Disconnect every response and add deterministic local-server and fake-connection tests.

## Related issues

Part of #380

## Type of change

- [x] fix: bug fix
- [x] test

## Testing

- `./gradlew :buildSrc:test --rerun-tasks --no-configuration-cache`
- `./gradlew build --no-configuration-cache`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`