### PR TITLE
fix(ci): validate CodeQL SARIF locations

### DIFF
--- a/.github/scripts/codeql-validation.test.ts
+++ b/.github/scripts/codeql-validation.test.ts
@@ -74,7 +74,12 @@ test('validates a CodeQL SARIF document and relative locations', () => {
   const document = validateCodeqlSarif(JSON.stringify({
     version: '2.1.0',
     runs: [{
-      tool: { driver: { name: 'CodeQL' } },
+      tool: {
+        driver: { name: 'CodeQL' },
+        extensions: [{
+          locations: [{ uri: 'file:///opt/hostedtoolcache/CodeQL/qlpacks/codeql/java-queries/qlpack.yml' }],
+        }],
+      },
       originalUriBaseIds: {
         '%SRCROOT%': { uri: 'file:///home/runner/work/Kotventure/Kotventure/' },
       },
@@ -128,10 +133,84 @@ test('rejects malformed, foreign-driver, and escaping CodeQL SARIF', () => {
       runs: [{
         tool: { driver: { name: 'CodeQL' } },
         results: [],
+        originalUriBaseIds: { SRCROOT: { uri: '..%2Foutside' } },
+      }],
+    })),
+    /SARIF base URI escapes the project/,
+  );
+  assert.throws(
+    () => validateCodeqlSarif(JSON.stringify({
+      version: '2.1.0',
+      runs: [{
+        tool: { driver: { name: 'CodeQL' } },
+        results: [],
         originalUriBaseIds: { '%SRCROOT%': { uri: 'https://example.com/' } },
       }],
     })),
     /SARIF base URI escapes the project/,
+  );
+});
+
+test('rejects encoded and absolute CodeQL source locations', () => {
+  const invalidLocations = [
+    '..%2Foutside.kt',
+    '%2Foutside.kt',
+    'file:///outside.kt',
+    'C:\\outside.kt',
+  ];
+  for (const uri of invalidLocations) {
+    assert.throws(
+      () => validateCodeqlSarif(JSON.stringify({
+        version: '2.1.0',
+        runs: [{
+          tool: { driver: { name: 'CodeQL' } },
+          results: [{ locations: [{ physicalLocation: { artifactLocation: { uri } } }] }],
+        }],
+      })),
+      /SARIF location escapes the project/,
+    );
+  }
+  for (const uri of ['invalid%2', 'source%00.kt']) {
+    assert.throws(
+      () => validateCodeqlSarif(JSON.stringify({
+        version: '2.1.0',
+        runs: [{
+          tool: { driver: { name: 'CodeQL' } },
+          results: [{ locations: [{ physicalLocation: { artifactLocation: { uri } } }] }],
+        }],
+      })),
+      /SARIF location is invalid/,
+    );
+  }
+});
+
+test('rejects indexed and nested extension source location escapes', () => {
+  assert.throws(
+    () => validateCodeqlSarif(JSON.stringify({
+      version: '2.1.0',
+      runs: [{
+        tool: { driver: { name: 'CodeQL' } },
+        artifacts: [{ location: { uri: '..%2Foutside.kt' } }],
+        results: [{ locations: [{ physicalLocation: { artifactLocation: { index: 0 } } }] }],
+      }],
+    })),
+    /SARIF location escapes the project/,
+  );
+  assert.throws(
+    () => validateCodeqlSarif(JSON.stringify({
+      version: '2.1.0',
+      runs: [{
+        tool: {
+          driver: { name: 'CodeQL' },
+          extensions: [{
+            locations: [{ uri: 'file:///opt/hostedtoolcache/CodeQL/qlpacks/codeql/java-queries/qlpack.yml' }],
+            properties: { artifactLocation: { uri: '../outside.kt' } },
+          }],
+        },
+        results: [],
+      }],
+    })),
+    /SARIF location escapes the project/,
   );
 });
 

--- a/.github/scripts/codeql-validation.ts
+++ b/.github/scripts/codeql-validation.ts
@@ -142,6 +142,20 @@ function validateUriBaseId(value: JsonValue): void {
   if (typeof value !== 'string' || !URI_BASE_ID_PATTERN.test(value)) reject('SARIF location base id is invalid');
 }
 
+function decodeUri(value: string, label: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    reject(`${label} is invalid`);
+  }
+}
+
+function uriEscapesProject(value: string): boolean {
+  return value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value)
+    || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value)
+    || value.split(/[\\/]/).includes('..');
+}
+
 function validateBaseUri(value: JsonValue): void {
   if (typeof value !== 'string' || value.length > 4096 || value.includes('\u0000')) reject('SARIF base URI is invalid');
   if (value.startsWith('file:')) {
@@ -154,16 +168,14 @@ function validateBaseUri(value: JsonValue): void {
     if (url.protocol !== 'file:' || (url.hostname !== '' && url.hostname !== 'localhost')) {
       reject('SARIF base URI is invalid');
     }
-    try {
-      if (decodeURIComponent(url.pathname).split(/[\\/]/).includes('..')) reject('SARIF base URI escapes the project');
-    } catch {
-      reject('SARIF base URI is invalid');
-    }
+    const path = decodeUri(url.pathname, 'SARIF base URI');
+    if (path.includes('\u0000')) reject('SARIF base URI is invalid');
+    if (path.split(/[\\/]/).includes('..')) reject('SARIF base URI escapes the project');
     return;
   }
-  if (value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value)
-    || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value)
-    || value.split(/[\\/]/).includes('..')) reject('SARIF base URI escapes the project');
+  const decoded = decodeUri(value, 'SARIF base URI');
+  if (decoded.includes('\u0000')) reject('SARIF base URI is invalid');
+  if (uriEscapesProject(decoded)) reject('SARIF base URI escapes the project');
 }
 
 function validateOriginalUriBaseIds(value: JsonValue): void {
@@ -185,12 +197,26 @@ function validateLocation(location: JsonValue): void {
   const { uri, uriBaseId } = location;
   if (uriBaseId != null) validateUriBaseId(uriBaseId);
   if (uri == null) return;
-  if (typeof uri !== 'string' || uri.length > 4096 || uri.includes('\u0000')
-    || uri.startsWith('/') || /^[A-Za-z]:[\\/]/.test(uri) || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(uri)
-    || uri.split(/[\\/]/).includes('..')) reject('SARIF location escapes the project');
+  if (typeof uri !== 'string' || uri.length > 4096 || uri.includes('\u0000')) reject('SARIF location is invalid');
+  const decoded = decodeUri(uri, 'SARIF location');
+  if (decoded.includes('\u0000')) reject('SARIF location is invalid');
+  if (uriEscapesProject(decoded)) reject('SARIF location escapes the project');
+}
+
+function toolExtensionComponents(root: JsonValue): Set<JsonValue> {
+  const components = new Set<JsonValue>();
+  if (root === null || typeof root !== 'object' || Array.isArray(root) || !Array.isArray(root.runs)) return components;
+  for (const run of root.runs) {
+    if (run === null || typeof run !== 'object' || Array.isArray(run)) continue;
+    const tool = run.tool;
+    if (tool === null || typeof tool !== 'object' || Array.isArray(tool) || !Array.isArray(tool.extensions)) continue;
+    for (const component of tool.extensions) components.add(component);
+  }
+  return components;
 }
 
 function validateSarifLocations(root: JsonValue): void {
+  const toolExtensions = toolExtensionComponents(root);
   const pending: Array<{ value: JsonValue; depth: number }> = [{ value: root, depth: 0 }];
   let visited = 0;
   while (pending.length > 0) {
@@ -211,6 +237,7 @@ function validateSarifLocations(root: JsonValue): void {
         validateOriginalUriBaseIds(child);
         continue;
       }
+      if (toolExtensions.has(entry.value) && key === 'locations') continue;
       if (key === 'artifactLocation') validateLocation(child);
       pending.push({ value: child, depth: entry.depth + 1 });
     }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -229,7 +229,7 @@ jobs:
             echo "Expected one post-processed CodeQL SARIF file, found ${#sarif_files[@]}" >&2
             exit 1
           fi
-          cp "${sarif_files[0]}" codeql-handoff/codeql.sarif
+          jq '(.runs[]?.tool.extensions[]?.locations) = []' "${sarif_files[0]}" > codeql-handoff/codeql.sarif
 
       - name: Resolve CodeQL workflow identity
         id: workflow


### PR DESCRIPTION
## Summary

- Normalise CodeQL tool-component location metadata before the SARIF hand-off.
- Accept that metadata only at `runs[].tool.extensions[].locations` in the trusted validator.
- Decode URI values before validation to reject encoded source-path escapes.

## Related issues

Follow-up to #399.

Unblocks the CodeQL publication checks on #576, #577, and #578.

## Type of change

- [x] fix: bug fix
- [x] test
- [x] chore / build / ci

## Testing

- `npm run typecheck`
- `npm run build`
- `node --test actions/pr-metrics-comment/test/*.test.js scripts/*.test.js` (457 passed)
- `actionlint .github/workflows/codeql.yml`
- `git diff --check`

## Checklist

- [x] The title and commit subject follow `verb(area): something`.
- [x] The PR links the related issue.
- [x] The change includes regression tests.
- [x] The change has no public API or user-facing documentation effect.